### PR TITLE
Lint and format with `ruff`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: Lint, format and tests
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  ruff-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - run: pip install ruff==0.9.*
+    - run: ruff check src/
+
+  ruff-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - run: pip install ruff==0.9.*
+    - run: ruff format --check src/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ where = ["src"]
 [tool.setuptools.package-data]
 "vortex.data" = ["geometries.ini"]
 "vortex.algo" = ["mpitools_templates/*.tpl"]
+
+[tool.ruff]
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ where = ["src"]
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+ignore = ["E741"]

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -20,14 +20,19 @@ of the very high level interface defined in the :mod:`vortex.toolbox` module is
 strongly advised.
 """
 
-__version__ = '2.0.0b1'
-__prompt__ = 'Vortex v-' + __version__ + ':'
+__version__ = "2.0.0b1"
+__prompt__ = "Vortex v-" + __version__ + ":"
 
-__nextversion__ = '2.0.0b2'
-__tocinfoline__ = 'VORTEX core package'
+__nextversion__ = "2.0.0b2"
+__tocinfoline__ = "VORTEX core package"
 
 __all__ = [
-    "input", "output", "executable", "task", "promise", "diff",
+    "input",
+    "output",
+    "executable",
+    "task",
+    "promise",
+    "diff",
 ]
 
 # Set vortex specific priorities for footprints usage
@@ -35,16 +40,18 @@ __all__ = [
 from bronx.fancies import loggers as bloggers
 
 import footprints
-footprints.priorities.set_before('debug', 'olive', 'oper')
+
+footprints.priorities.set_before("debug", "olive", "oper")
 
 # Set a root logging mechanism for vortex
 
 #: Shortcut to Vortex's root logger
-logger = bloggers.getLogger('vortex')
+logger = bloggers.getLogger("vortex")
 
 # Populate a fake proxy module with footprints shortcuts
 
 from . import proxy
+
 setup = footprints.config.get()
 setup.add_proxy(proxy)
 proxy.cat = footprints.proxy.cat
@@ -58,7 +65,9 @@ from . import config
 
 rootenv = tools.env.Environment(active=True)
 
-rs = sessions.get(active=True, topenv=rootenv, glove=sessions.getglove(), prompt=__prompt__)
+rs = sessions.get(
+    active=True, topenv=rootenv, glove=sessions.getglove(), prompt=__prompt__
+)
 if rs.system().systems_reload():
     rs.system(refill=True)
 del rs
@@ -70,8 +79,7 @@ def vortexfpdefaults():
     """Return actual glove, according to current environment."""
     cur_session = sessions.current()
     return dict(
-        glove=cur_session.glove,
-        systemtarget=cur_session.sh.default_target
+        glove=cur_session.glove, systemtarget=cur_session.sh.default_target
     )
 
 
@@ -87,7 +95,9 @@ sh = sessions.system
 
 class VortexForceComplete(Exception):
     """Exception for handling fast exit mecanisms."""
+
     pass
+
 
 # If a config file can be found in current dir, load it
 config.load_config()
@@ -110,26 +120,45 @@ from . import nwp
 # and 'vortex.nwp', these must be imported /before/
 # loading plugins.
 from importlib.metadata import entry_points
-for plugin in entry_points(group='vtx'):
+
+for plugin in entry_points(group="vtx"):
     plugin.load()
     print(f"Loaded plugin {plugin.name}")
 
 # Register proper vortex exit before the end of interpreter session
 
 import bronx.stdtypes.date
+
+
 def complete():
     sessions.exit()
     import multiprocessing
+
     for kid in multiprocessing.active_children():
-        logger.warning('Terminate active kid %s', str(kid))
+        logger.warning("Terminate active kid %s", str(kid))
         kid.terminate()
-    print('Vortex', __version__, 'completed', '(', bronx.stdtypes.date.at_second().reallynice(), ')')
+    print(
+        "Vortex",
+        __version__,
+        "completed",
+        "(",
+        bronx.stdtypes.date.at_second().reallynice(),
+        ")",
+    )
 
 
 import atexit
+
 atexit.register(complete)
 del atexit, complete
 
-print('Vortex', __version__, 'loaded', '(', bronx.stdtypes.date.at_second().reallynice(), ')')
+print(
+    "Vortex",
+    __version__,
+    "loaded",
+    "(",
+    bronx.stdtypes.date.at_second().reallynice(),
+    ")",
+)
 
 del footprints

--- a/src/vortex/algo/__init__.py
+++ b/src/vortex/algo/__init__.py
@@ -9,4 +9,4 @@ from . import components, serversynctools
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'Generic AlgoComponent classes (and their utility classes)'
+__tocinfoline__ = "Generic AlgoComponent classes (and their utility classes)"

--- a/src/vortex/algo/__init__.py
+++ b/src/vortex/algo/__init__.py
@@ -4,7 +4,8 @@ Generic AlgoComponent classes (and related utility classes).
 Application specific AlgoComponent classes should be defined in dedicated packages.
 """
 
-from . import components, serversynctools
+from . import components as components
+from . import serversynctools as serversynctools
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/algo/components.py
+++ b/src/vortex/algo/components.py
@@ -63,11 +63,13 @@ logger = loggers.getLogger(__name__)
 
 class AlgoComponentError(Exception):
     """Generic exception class for Algo Components."""
+
     pass
 
 
 class AlgoComponentAssertionError(AlgoComponentError):
     """Assertion exception class for Algo Components."""
+
     pass
 
 
@@ -83,8 +85,12 @@ class DelayedAlgoComponentError(AlgoComponentError):
 
     def __str__(self):
         outstr = "One or several errors occurred during the run. In order of appearance:\n"
-        outstr += "\n".join(['{:3d}. {!s} (type: {!s})'.format(i + 1, exc, type(exc))
-                             for i, exc in enumerate(self)])
+        outstr += "\n".join(
+            [
+                "{:3d}. {!s} (type: {!s})".format(i + 1, exc, type(exc))
+                for i, exc in enumerate(self)
+            ]
+        )
         return outstr
 
 
@@ -102,10 +108,14 @@ def _clsmtd_mixin_locked(f):
     This is a utility decorator (for class methods) : it ensures that the method can only
     be called on a bare :class:`AlgoComponentDecoMixin` class.
     """
+
     def wrapped_clsmethod(cls, *kargs, **kwargs):
         if issubclass(cls, AlgoComponent):
-            raise RuntimeError("This class method should not be called once the mixin is in use.")
+            raise RuntimeError(
+                "This class method should not be called once the mixin is in use."
+            )
         return f(cls, *kargs, **kwargs)
+
     return wrapped_clsmethod
 
 
@@ -114,45 +124,69 @@ def algo_component_deco_mixin_autodoc(cls):
     Decorator that adds an automatic documentation on any :class:`AlgoComponentDecoMixin`
     class.
     """
-    extradoc = ''
+    extradoc = ""
 
     # Document extra footprints
     if cls.MIXIN_AUTO_FPTWEAK and cls._MIXIN_EXTRA_FOOTPRINTS:
-        extradoc += '\nThe following footprints will be applied to the target classes:\n\n'
+        extradoc += "\nThe following footprints will be applied to the target classes:\n\n"
         for fp in cls._MIXIN_EXTRA_FOOTPRINTS:
             if isinstance(fp, footprints.Footprint):
-                extradoc += footprints.doc.format_docstring(fp,
-                                                            footprints.setup.docstrings,
-                                                            abstractfpobj=True)
-                extradoc += '\n'
+                extradoc += footprints.doc.format_docstring(
+                    fp, footprints.setup.docstrings, abstractfpobj=True
+                )
+                extradoc += "\n"
 
     # Document decorating classes
     if cls.MIXIN_AUTO_DECO:
-        for what, desc in (('PREPARE_PREHOOKS', 'before the original ``prepare`` method'),
-                           ('PREPARE_HOOKS', 'after the original ``prepare`` method'),
-                           ('POSTFIX_PREHOOKS', 'before the original ``postfix`` method'),
-                           ('POSTFIX_HOOKS', 'after the original ``postfix`` method'),
-                           ('SPAWN_HOOKS', 'after the original ``spawn_hook`` method'),
-                           ('CLI_OPTS_EXTEND', 'to alter the result of the ``spawn_command_options`` method'),
-                           ('STDIN_OPTS_EXTEND', 'to alter the result of the ``spawn_stdin_options`` method'),
-                           ('_MIXIN_EXECUTE_OVERWRITE', 'instead of the original ``execute`` method'),
-                           ('MPIBINS_HOOKS', 'to alter the result of the ``_bootstrap_mpibins_hack`` method'),
-                           ('MPIENVELOPE_HOOKS', 'to alter the result of the ``_bootstrap_mpienvelope_hack`` method')):
-            what = '_MIXIN_{:s}'.format(what)
+        for what, desc in (
+            ("PREPARE_PREHOOKS", "before the original ``prepare`` method"),
+            ("PREPARE_HOOKS", "after the original ``prepare`` method"),
+            ("POSTFIX_PREHOOKS", "before the original ``postfix`` method"),
+            ("POSTFIX_HOOKS", "after the original ``postfix`` method"),
+            ("SPAWN_HOOKS", "after the original ``spawn_hook`` method"),
+            (
+                "CLI_OPTS_EXTEND",
+                "to alter the result of the ``spawn_command_options`` method",
+            ),
+            (
+                "STDIN_OPTS_EXTEND",
+                "to alter the result of the ``spawn_stdin_options`` method",
+            ),
+            (
+                "_MIXIN_EXECUTE_OVERWRITE",
+                "instead of the original ``execute`` method",
+            ),
+            (
+                "MPIBINS_HOOKS",
+                "to alter the result of the ``_bootstrap_mpibins_hack`` method",
+            ),
+            (
+                "MPIENVELOPE_HOOKS",
+                "to alter the result of the ``_bootstrap_mpienvelope_hack`` method",
+            ),
+        ):
+            what = "_MIXIN_{:s}".format(what)
             if getattr(cls, what, ()):
-                extradoc += '\nThe following method(s) will be called {:s}:\n\n'.format(desc)
-                extradoc += '\n'.join('    * {!r}'.format(cb) for cb in getattr(cls, what))
-                extradoc += '\n'
+                extradoc += "\nThe following method(s) will be called {:s}:\n\n".format(
+                    desc
+                )
+                extradoc += "\n".join(
+                    "    * {!r}".format(cb) for cb in getattr(cls, what)
+                )
+                extradoc += "\n"
 
     if extradoc:
-        extradoc = ('\n    .. note:: The following documentation is automatically generated. ' +
-                    'From a developer point of view, using the present mixin class ' +
-                    'will result in the following actions:\n' +
-                    ' \n'.join(['        ' + t if t else ''
-                                for t in extradoc.split('\n')]))
+        extradoc = (
+            "\n    .. note:: The following documentation is automatically generated. "
+            + "From a developer point of view, using the present mixin class "
+            + "will result in the following actions:\n"
+            + " \n".join(
+                ["        " + t if t else "" for t in extradoc.split("\n")]
+            )
+        )
 
-        if isinstance(getattr(cls, '__doc__', None), str):
-            cls.__doc__ += '\n' + extradoc
+        if isinstance(getattr(cls, "__doc__", None), str):
+            cls.__doc__ += "\n" + extradoc
         else:
             cls.__doc__ = extradoc
 
@@ -253,8 +287,11 @@ class AlgoComponentDecoMixin:
     def __new__(cls, *args, **kwargs):
         if not issubclass(cls, AlgoComponent):
             # This class cannot be instanciated by itself !
-            raise RuntimeError('< {0.__name__:s} > is a mixin class: it cannot be instantiated.'
-                               .format(cls))
+            raise RuntimeError(
+                "< {0.__name__:s} > is a mixin class: it cannot be instantiated.".format(
+                    cls
+                )
+            )
         else:
             return super().__new__(cls)
 
@@ -268,18 +305,24 @@ class AlgoComponentDecoMixin:
 
     @classmethod
     @_clsmtd_mixin_locked
-    def _get_algo_wrapped(cls, targetcls, targetmtd, hooks, prehooks=(), reentering=False):
+    def _get_algo_wrapped(
+        cls, targetcls, targetmtd, hooks, prehooks=(), reentering=False
+    ):
         """Wraps **targetcls**'s **targetmtd** method."""
         orig_mtd = getattr(targetcls, targetmtd)
         if prehooks and reentering:
-            raise ValueError('Conflicting values between prehooks and reenterin.')
+            raise ValueError(
+                "Conflicting values between prehooks and reenterin."
+            )
 
         def wrapped_method(self, *kargs, **kwargs):
             for phook in prehooks:
                 phook(self, *kargs, **kwargs)
             rv = orig_mtd(self, *kargs, **kwargs)
             if reentering:
-                kargs = [rv, ] + list(kargs)
+                kargs = [
+                    rv,
+                ] + list(kargs)
             for phook in hooks:
                 rv = phook(self, *kargs, **kwargs)
                 if reentering:
@@ -288,9 +331,11 @@ class AlgoComponentDecoMixin:
                 return rv
 
         wrapped_method.__name__ = orig_mtd.__name__
-        wrapped_method.__doc__ = ((orig_mtd.__doc__ or '').rstrip('\n') +
-                                  "\n\nDecorated by :class:`{0.__module__:s}{0.__name__:s}`."
-                                  .format(cls))
+        wrapped_method.__doc__ = (orig_mtd.__doc__ or "").rstrip(
+            "\n"
+        ) + "\n\nDecorated by :class:`{0.__module__:s}{0.__name__:s}`.".format(
+            cls
+        )
         wrapped_method.__dict__.update(orig_mtd.__dict__)
         return wrapped_method
 
@@ -302,33 +347,36 @@ class AlgoComponentDecoMixin:
         :class:`AlgoComponent` class.
         """
         if not issubclass(targetcls, AlgoComponent):
-            raise RuntimeError('This class can only be mixed in AlgoComponent classes.')
-        for targetmtd, hooks, prehooks, reenter in [('prepare',
-                                                     cls._MIXIN_PREPARE_HOOKS,
-                                                     cls._MIXIN_PREPARE_PREHOOKS,
-                                                     False),
-                                                    ('fail_execute',
-                                                     cls._MIXIN_FAIL_EXECUTE_HOOKS, (),
-                                                     False),
-                                                    ('execute_finalise',
-                                                     cls._MIXIN_EXECUTE_FINALISE_HOOKS, (),
-                                                     False),
-                                                    ('postfix',
-                                                     cls._MIXIN_POSTFIX_HOOKS,
-                                                     cls._MIXIN_POSTFIX_PREHOOKS,
-                                                     False),
-                                                    ('spawn_hook',
-                                                     cls._MIXIN_SPAWN_HOOKS, (),
-                                                     False),
-                                                    ('spawn_command_options',
-                                                     cls._MIXIN_CLI_OPTS_EXTEND, (),
-                                                     True),
-                                                    ('spawn_stdin_options',
-                                                     cls._MIXIN_STDIN_OPTS_EXTEND, (),
-                                                     True), ]:
+            raise RuntimeError(
+                "This class can only be mixed in AlgoComponent classes."
+            )
+        for targetmtd, hooks, prehooks, reenter in [
+            (
+                "prepare",
+                cls._MIXIN_PREPARE_HOOKS,
+                cls._MIXIN_PREPARE_PREHOOKS,
+                False,
+            ),
+            ("fail_execute", cls._MIXIN_FAIL_EXECUTE_HOOKS, (), False),
+            ("execute_finalise", cls._MIXIN_EXECUTE_FINALISE_HOOKS, (), False),
+            (
+                "postfix",
+                cls._MIXIN_POSTFIX_HOOKS,
+                cls._MIXIN_POSTFIX_PREHOOKS,
+                False,
+            ),
+            ("spawn_hook", cls._MIXIN_SPAWN_HOOKS, (), False),
+            ("spawn_command_options", cls._MIXIN_CLI_OPTS_EXTEND, (), True),
+            ("spawn_stdin_options", cls._MIXIN_STDIN_OPTS_EXTEND, (), True),
+        ]:
             if hooks or prehooks:
-                setattr(targetcls, targetmtd,
-                        cls._get_algo_wrapped(targetcls, targetmtd, hooks, prehooks, reenter))
+                setattr(
+                    targetcls,
+                    targetmtd,
+                    cls._get_algo_wrapped(
+                        targetcls, targetmtd, hooks, prehooks, reenter
+                    ),
+                )
         return targetcls
 
     @classmethod
@@ -339,7 +387,7 @@ class AlgoComponentDecoMixin:
     @classmethod
     def mixin_execute_companion(cls):
         """Find on which class "super" should be called (if_MIXIN_EXECUTE_OVERWRITE is used)."""
-        comp = getattr(cls, '_algo_meta_execute_companion', ())
+        comp = getattr(cls, "_algo_meta_execute_companion", ())
         if not comp:
             raise RuntimeError("unable to find a suitable companion class")
         return comp
@@ -396,19 +444,32 @@ class AlgoComponentMpiDecoMixin(AlgoComponentDecoMixin):
         """
         targetcls = AlgoComponentDecoMixin.mixin_algo_deco(targetcls)
         if not issubclass(targetcls, Parallel):
-            raise RuntimeError('This class can only be mixed in Parallel classes.')
-        for targetmtd, hooks, prehooks, reenter in [('_bootstrap_mpibins_hack',
-                                                     cls._MIXIN_MPIBINS_HOOKS, (),
-                                                     True),
-                                                    ('_bootstrap_mpienvelope_hack',
-                                                     cls._MIXIN_MPIENVELOPE_HOOKS, (),
-                                                     True),
-                                                    ('_bootstrap_mpienvelope_posthack',
-                                                     cls._MIXIN_MPIENVELOPE_POSTHOOKS, (),
-                                                     True), ]:
+            raise RuntimeError(
+                "This class can only be mixed in Parallel classes."
+            )
+        for targetmtd, hooks, prehooks, reenter in [
+            ("_bootstrap_mpibins_hack", cls._MIXIN_MPIBINS_HOOKS, (), True),
+            (
+                "_bootstrap_mpienvelope_hack",
+                cls._MIXIN_MPIENVELOPE_HOOKS,
+                (),
+                True,
+            ),
+            (
+                "_bootstrap_mpienvelope_posthack",
+                cls._MIXIN_MPIENVELOPE_POSTHOOKS,
+                (),
+                True,
+            ),
+        ]:
             if hooks or prehooks:
-                setattr(targetcls, targetmtd,
-                        cls._get_algo_wrapped(targetcls, targetmtd, hooks, prehooks, reenter))
+                setattr(
+                    targetcls,
+                    targetmtd,
+                    cls._get_algo_wrapped(
+                        targetcls, targetmtd, hooks, prehooks, reenter
+                    ),
+                )
         return targetcls
 
 
@@ -423,31 +484,47 @@ class AlgoComponentMeta(footprints.FootprintBaseMeta):
     def __new__(cls, n, b, d):
         # Mixin candidates: a mixin must only be dealt with once hence the
         # condition on issubclass(base, AlgoComponent)
-        candidates = [base for base in b
-                      if (issubclass(base, AlgoComponentDecoMixin) and
-                          not issubclass(base, AlgoComponent))]
+        candidates = [
+            base
+            for base in b
+            if (
+                issubclass(base, AlgoComponentDecoMixin)
+                and not issubclass(base, AlgoComponent)
+            )
+        ]
         # Tweak footprints
         todobases = [base for base in candidates if base.MIXIN_AUTO_FPTWEAK]
         if todobases:
-            fplocal = d.get('_footprint', list())
+            fplocal = d.get("_footprint", list())
             if not isinstance(fplocal, list):
-                fplocal = [fplocal, ]
+                fplocal = [
+                    fplocal,
+                ]
             for base in todobases:
                 base.mixin_tweak_footprint(fplocal)
-            d['_footprint'] = fplocal
+            d["_footprint"] = fplocal
         # Overwrite the execute method...
-        todobases_exc = [base for base in candidates if base.mixin_execute_overwrite() is not None]
+        todobases_exc = [
+            base
+            for base in candidates
+            if base.mixin_execute_overwrite() is not None
+        ]
         if len(todobases_exc) > 1:
-            raise RuntimeError('Cannot overwrite < execute > multiple times: {:s}'
-                               .format(','.join([base.__name__ for base in todobases_exc])))
+            raise RuntimeError(
+                "Cannot overwrite < execute > multiple times: {:s}".format(
+                    ",".join([base.__name__ for base in todobases_exc])
+                )
+            )
         if todobases_exc:
-            if 'execute' in d:
-                raise RuntimeError('< execute > is already defined in the target class: cannot proceed')
-            d['execute'] = todobases_exc[0].mixin_execute_overwrite()
+            if "execute" in d:
+                raise RuntimeError(
+                    "< execute > is already defined in the target class: cannot proceed"
+                )
+            d["execute"] = todobases_exc[0].mixin_execute_overwrite()
         # Create the class as usual
         fpcls = super().__new__(cls, n, b, d)
         if todobases_exc:
-            setattr(fpcls, '_algo_meta_execute_companion', fpcls)
+            setattr(fpcls, "_algo_meta_execute_companion", fpcls)
         # Apply decorators
         todobases = [base for base in candidates if base.MIXIN_AUTO_DECO]
         for base in reversed(todobases):
@@ -463,84 +540,86 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
     _SERVERSYNC_STOPONEXIT = True
 
     _abstract = True
-    _collector = ('component',)
+    _collector = ("component",)
     _footprint = dict(
-        info = 'Abstract algo component',
-        attr = dict(
-            engine = dict(
-                info     = 'The way the executable should be run.',
-                values   = ['algo', ]
+        info="Abstract algo component",
+        attr=dict(
+            engine=dict(
+                info="The way the executable should be run.",
+                values=[
+                    "algo",
+                ],
             ),
-            flyput = dict(
-                info            = 'Activate a background job in charge off on the fly processing.',
-                type            = bool,
-                optional        = True,
-                default         = False,
-                access          = 'rwx',
-                doc_visibility  = footprints.doc.visibility.GURU,
-                doc_zorder      = -99,
+            flyput=dict(
+                info="Activate a background job in charge off on the fly processing.",
+                type=bool,
+                optional=True,
+                default=False,
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.GURU,
+                doc_zorder=-99,
             ),
-            flypoll = dict(
-                info            = 'The system method called by the flyput background job.',
-                optional        = True,
-                default         = 'io_poll',
-                access          = 'rwx',
-                doc_visibility  = footprints.doc.visibility.GURU,
-                doc_zorder      = -99,
+            flypoll=dict(
+                info="The system method called by the flyput background job.",
+                optional=True,
+                default="io_poll",
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.GURU,
+                doc_zorder=-99,
             ),
-            flyargs = dict(
-                info            = 'Arguments for the *flypoll* method.',
-                type            = footprints.FPTuple,
-                optional        = True,
-                default         = footprints.FPTuple(),
-                doc_visibility  = footprints.doc.visibility.GURU,
-                doc_zorder      = -99,
+            flyargs=dict(
+                info="Arguments for the *flypoll* method.",
+                type=footprints.FPTuple,
+                optional=True,
+                default=footprints.FPTuple(),
+                doc_visibility=footprints.doc.visibility.GURU,
+                doc_zorder=-99,
             ),
-            flymapping = dict(
-                info            = 'Allow renaming of output files during on the fly processing.',
-                optional        = True,
-                default         = False,
-                access          = 'rwx',
-                doc_visibility  = footprints.doc.visibility.GURU,
-                doc_zorder      = -99,
+            flymapping=dict(
+                info="Allow renaming of output files during on the fly processing.",
+                optional=True,
+                default=False,
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.GURU,
+                doc_zorder=-99,
             ),
-            timeout = dict(
-                info            = 'Default timeout (in sec.) used  when waiting for an expected resource.',
-                type            = int,
-                optional        = True,
-                default         = 180,
-                doc_zorder      = -50,
+            timeout=dict(
+                info="Default timeout (in sec.) used  when waiting for an expected resource.",
+                type=int,
+                optional=True,
+                default=180,
+                doc_zorder=-50,
             ),
-            server_run = dict(
-                info            = 'Run the executable as a server.',
-                type            = bool,
-                optional        = True,
-                values          = [False],
-                default         = False,
-                access          = 'rwx',
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            server_run=dict(
+                info="Run the executable as a server.",
+                type=bool,
+                optional=True,
+                values=[False],
+                default=False,
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            serversync_method = dict(
-                info                    = 'The method that is used to synchronise with the server.',
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            serversync_method=dict(
+                info="The method that is used to synchronise with the server.",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            serversync_medium = dict(
-                info            = 'The medium that is used to synchronise with the server.',
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            serversync_medium=dict(
+                info="The medium that is used to synchronise with the server.",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            extendpypath = dict(
-                info     = "The list of things to be prepended in the python's path.",
-                type     = footprints.FPList,
-                default  = footprints.FPList([]),
-                optional = True
+            extendpypath=dict(
+                info="The list of things to be prepended in the python's path.",
+                type=footprints.FPList,
+                default=footprints.FPList([]),
+                optional=True,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Algo component init %s', self.__class__)
+        logger.debug("Algo component init %s", self.__class__)
         self._fslog = list()
         self._promises = None
         self._expected = None
@@ -552,7 +631,7 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
     @property
     def realkind(self):
         """Default kind is ``algo``."""
-        return 'algo'
+        return "algo"
 
     @property
     def fslog(self):
@@ -561,7 +640,7 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
 
     def fstag(self):
         """Defines a tag specific to the current algo component."""
-        return '-'.join((self.realkind, self.engine))
+        return "-".join((self.realkind, self.engine))
 
     def fsstamp(self, opts):
         """Ask the current context to put a stamp on file system."""
@@ -576,7 +655,8 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         """Build and return list of actual promises of the current component."""
         if self._promises is None:
             self._promises = [
-                x for x in self.context.sequence.outputs()
+                x
+                for x in self.context.sequence.outputs()
                 if x.rh.provider.expected
             ]
         return self._promises
@@ -586,7 +666,8 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         """Return the list of really expected inputs."""
         if self._expected is None:
             self._expected = [
-                x for x in self.context.sequence.effective_inputs()
+                x
+                for x in self.context.sequence.effective_inputs()
                 if x.rh.is_expected()
             ]
         return self._expected
@@ -596,42 +677,42 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         logger.error("An exception is delayed")
         if traceback:
             (exc_type, exc_value, exc_traceback) = sys.exc_info()
-            print('Exception type: {!s}'.format(exc_type))
-            print('Exception info: {!s}'.format(exc_value))
-            print('Traceback:')
+            print("Exception type: {!s}".format(exc_type))
+            print("Exception info: {!s}".format(exc_value))
+            print("Traceback:")
             print("\n".join(py_traceback.format_tb(exc_traceback)))
         self._delayed_excs.append(exc)
 
-    def algoassert(self, assertion, msg=''):
+    def algoassert(self, assertion, msg=""):
         if not assertion:
             raise AlgoComponentAssertionError(msg)
 
-    def grab(self, sec, comment='resource', sleep=10, timeout=None):
+    def grab(self, sec, comment="resource", sleep=10, timeout=None):
         """Wait for a given resource and get it if expected."""
         local = sec.rh.container.localpath()
-        self.system.header('Wait for ' + comment + ' ... [' + local + ']')
+        self.system.header("Wait for " + comment + " ... [" + local + "]")
         if timeout is None:
             timeout = self.timeout
         if sec.rh.wait(timeout=timeout, sleep=sleep):
             if sec.rh.is_expected():
                 sec.get(incache=True)
         elif sec.fatal:
-            logger.critical('Missing expected resource <%s>', local)
-            raise ValueError('Could not get ' + local)
+            logger.critical("Missing expected resource <%s>", local)
+            raise ValueError("Could not get " + local)
         else:
-            logger.error('Missing expected resource <%s>', local)
+            logger.error("Missing expected resource <%s>", local)
 
     def export(self, packenv):
         """Export environment variables in given pack."""
         for k, v in from_config(section=packenv).items():
             if k not in self.env:
-                logger.info('Setting %s env %s = %s', packenv.upper(), k, v)
+                logger.info("Setting %s env %s = %s", packenv.upper(), k, v)
                 self.env[k] = v
 
     def prepare(self, rh, opts):
         """Set some defaults env values."""
-        if opts.get('fortran', True):
-            self.export('fortran')
+        if opts.get("fortran", True):
+            self.export("fortran")
 
     def absexcutable(self, xfile):
         """Retuns the absolute pathname of the ``xfile`` executable."""
@@ -640,15 +721,17 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
 
     def flyput_method(self):
         """Check out what could be a valid io_poll command."""
-        return getattr(self, 'io_poll_method', getattr(self.system, self.flypoll, None))
+        return getattr(
+            self, "io_poll_method", getattr(self.system, self.flypoll, None)
+        )
 
     def flyput_args(self):
         """Return actual io_poll prefixes."""
-        return getattr(self, 'io_poll_args', tuple(self.flyargs))
+        return getattr(self, "io_poll_args", tuple(self.flyargs))
 
     def flyput_kwargs(self):
         """Return actual io_poll prefixes."""
-        return getattr(self, 'io_poll_kwargs', dict())
+        return getattr(self, "io_poll_kwargs", dict())
 
     def flyput_check(self):
         """Check default args for io_poll command."""
@@ -658,38 +741,54 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             return self.flyput_args()
         else:
             for arg in self.flyput_args():
-                logger.info('Check arg <%s>', arg)
-                if any([x.rh.container.basename.startswith(arg) for x in self.promises]):
+                logger.info("Check arg <%s>", arg)
+                if any(
+                    [
+                        x.rh.container.basename.startswith(arg)
+                        for x in self.promises
+                    ]
+                ):
                     logger.info(
-                        'Match some promise %s',
-                        str([x.rh.container.basename for x in self.promises
-                             if x.rh.container.basename.startswith(arg)])
+                        "Match some promise %s",
+                        str(
+                            [
+                                x.rh.container.basename
+                                for x in self.promises
+                                if x.rh.container.basename.startswith(arg)
+                            ]
+                        ),
                     )
                     actual_args.append(arg)
                 else:
-                    logger.info('Do not match any promise %s',
-                                str([x.rh.container.basename for x in self.promises]))
+                    logger.info(
+                        "Do not match any promise %s",
+                        str([x.rh.container.basename for x in self.promises]),
+                    )
             return actual_args
 
     def flyput_sleep(self):
         """Return a sleeping time in seconds between io_poll commands."""
-        return getattr(self, 'io_poll_sleep', self.env.get('IO_POLL_SLEEP', 20))
+        return getattr(
+            self, "io_poll_sleep", self.env.get("IO_POLL_SLEEP", 20)
+        )
 
     def flyput_outputmapping(self, item):
         """Map output to another filename."""
-        return item, 'unknown'
+        return item, "unknown"
 
-    def _flyput_job_internal_search(self, io_poll_method, io_poll_args, io_poll_kwargs):
+    def _flyput_job_internal_search(
+        self, io_poll_method, io_poll_args, io_poll_kwargs
+    ):
         data = list()
         for arg in io_poll_args:
-            logger.info('Polling check arg %s', arg)
+            logger.info("Polling check arg %s", arg)
             rc = io_poll_method(arg, **io_poll_kwargs)
             try:
                 data.extend(rc.result)
             except AttributeError:
                 data.extend(rc)
             data = [x for x in data if x]
-            logger.info('Polling retrieved data %s', str(data))
+            logger.info("Polling retrieved data %s", str(data))
         return data
 
     def _flyput_job_internal_put(self, data):
@@ -697,27 +796,46 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             if self.flymapping:
                 mappeddata, mappedfmt = self.flyput_outputmapping(thisdata)
                 if not mappeddata:
-                    raise AlgoComponentError('The mapping method failed for {:s}.'.format(thisdata))
+                    raise AlgoComponentError(
+                        "The mapping method failed for {:s}.".format(thisdata)
+                    )
                 if thisdata != mappeddata:
-                    logger.info('Linking <%s> to <%s> (fmt=%s) before put',
-                                thisdata, mappeddata, mappedfmt)
-                    self.system.cp(thisdata, mappeddata, intent='in', fmt=mappedfmt)
+                    logger.info(
+                        "Linking <%s> to <%s> (fmt=%s) before put",
+                        thisdata,
+                        mappeddata,
+                        mappedfmt,
+                    )
+                    self.system.cp(
+                        thisdata, mappeddata, intent="in", fmt=mappedfmt
+                    )
             else:
                 mappeddata = thisdata
-            candidates = [x for x in self.promises
-                          if x.rh.container.abspath == self.system.path.abspath(mappeddata)]
+            candidates = [
+                x
+                for x in self.promises
+                if x.rh.container.abspath
+                == self.system.path.abspath(mappeddata)
+            ]
             if candidates:
-                logger.info('Polled data is promised <%s>', mappeddata)
+                logger.info("Polled data is promised <%s>", mappeddata)
                 bingo = candidates.pop()
                 bingo.put(incache=True)
             else:
-                logger.warning('Polled data not promised <%s>', mappeddata)
+                logger.warning("Polled data not promised <%s>", mappeddata)
 
-    def flyput_job(self, io_poll_method, io_poll_args, io_poll_kwargs,
-                   event_complete, event_free, queue_context):
+    def flyput_job(
+        self,
+        io_poll_method,
+        io_poll_args,
+        io_poll_kwargs,
+        event_complete,
+        event_free,
+        queue_context,
+    ):
         """Poll new data resources."""
-        logger.info('Polling with method %s', str(io_poll_method))
-        logger.info('Polling with args %s', str(io_poll_args))
+        logger.info("Polling with method %s", str(io_poll_method))
+        logger.info("Polling with args %s", str(io_poll_args))
 
         time_sleep = self.flyput_sleep()
         redo = True
@@ -728,29 +846,33 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         while redo and not event_complete.is_set():
             event_free.clear()
             try:
-                data = self._flyput_job_internal_search(io_poll_method,
-                                                        io_poll_args, io_poll_kwargs)
+                data = self._flyput_job_internal_search(
+                    io_poll_method, io_poll_args, io_poll_kwargs
+                )
                 self._flyput_job_internal_put(data)
             except Exception as trouble:
-                logger.error('Polling trouble: %s. %s',
-                             str(trouble), py_traceback.format_exc())
+                logger.error(
+                    "Polling trouble: %s. %s",
+                    str(trouble),
+                    py_traceback.format_exc(),
+                )
                 redo = False
             finally:
                 event_free.set()
             if redo and not data and not event_complete.is_set():
-                logger.info('Get asleep for %d seconds...', time_sleep)
+                logger.info("Get asleep for %d seconds...", time_sleep)
                 self.system.sleep(time_sleep)
 
         # Stop recording and send back the results
         ctxrec.unregister()
-        logger.info('Sending the Context recorder to the master process.')
+        logger.info("Sending the Context recorder to the master process.")
         queue_context.put(ctxrec)
         queue_context.close()
 
         if redo:
-            logger.info('Polling exit on complete event')
+            logger.info("Polling exit on complete event")
         else:
-            logger.warning('Polling exit on abort')
+            logger.warning("Polling exit on abort")
 
     def flyput_begin(self):
         """Launch a co-process to handle promises."""
@@ -760,22 +882,24 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             return nope
 
         sh = self.system
-        sh.subtitle('On the fly - Begin')
+        sh.subtitle("On the fly - Begin")
 
         if not self.promises:
-            logger.info('No promise, no co-process')
+            logger.info("No promise, no co-process")
             return nope
 
         # Find out a polling method
         io_poll_method = self.flyput_method()
         if not io_poll_method:
-            logger.error('No method or shell function defined for polling data')
+            logger.error(
+                "No method or shell function defined for polling data"
+            )
             return nope
 
         # Be sure that some default args could match local promises names
         io_poll_args = self.flyput_check()
         if not io_poll_args:
-            logger.error('Could not check default arguments for polling data')
+            logger.error("Could not check default arguments for polling data")
             return nope
 
         # Additional named attributes
@@ -789,7 +913,14 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         p_io = multiprocessing.Process(
             name=self.footprint_clsname(),
             target=self.flyput_job,
-            args=(io_poll_method, io_poll_args, io_poll_kwargs, event_stop, event_free, queue_ctx),
+            args=(
+                io_poll_method,
+                io_poll_args,
+                io_poll_kwargs,
+                event_stop,
+                event_free,
+                queue_ctx,
+            ),
         )
 
         # The co-process is started
@@ -802,16 +933,17 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         # Find out a polling method
         io_poll_method = self.flyput_method()
         if not io_poll_method:
-            raise AlgoComponentError('Unable to find an io_poll_method')
+            raise AlgoComponentError("Unable to find an io_poll_method")
         # Find out some polling prefixes
         io_poll_args = self.flyput_check()
         if not io_poll_args:
-            raise AlgoComponentError('Unable to find an io_poll_args')
+            raise AlgoComponentError("Unable to find an io_poll_args")
         # Additional named attributes
         io_poll_kwargs = self.flyput_kwargs()
         # Starting polling each of the prefixes
-        return self._flyput_job_internal_search(io_poll_method,
-                                                io_poll_args, io_poll_kwargs)
+        return self._flyput_job_internal_search(
+            io_poll_method, io_poll_args, io_poll_kwargs
+        )
 
     def manual_flypolling_job(self):
         """Call the flyput method and deal with promised files."""
@@ -821,7 +953,7 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
     def flyput_end(self, p_io, e_complete, e_free, queue_ctx):
         """Wait for the co-process in charge of promises."""
         e_complete.set()
-        logger.info('Waiting for polling process... <%s>', p_io.pid)
+        logger.info("Waiting for polling process... <%s>", p_io.pid)
         t0 = date.now()
         e_free.wait(60)
         # Get the Queue and update the context
@@ -839,11 +971,14 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         p_io.join(30)
         t1 = date.now()
         waiting = t1 - t0
-        logger.info('Waiting for polling process took %f seconds', waiting.total_seconds())
+        logger.info(
+            "Waiting for polling process took %f seconds",
+            waiting.total_seconds(),
+        )
         if p_io.is_alive():
-            logger.warning('Force termination of polling process')
+            logger.warning("Force termination of polling process")
             p_io.terminate()
-        logger.info('Polling still alive ? %s', str(p_io.is_alive()))
+        logger.info("Polling still alive ? %s", str(p_io.is_alive()))
         return not p_io.is_alive()
 
     def server_begin(self, rh, opts):
@@ -852,7 +987,7 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         self._server_process = multiprocessing.Process(
             name=self.footprint_clsname(),
             target=self.server_job,
-            args=(rh, opts)
+            args=(rh, opts),
         )
         self._server_process.start()
 
@@ -867,17 +1002,19 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             self.execute_single(rh, opts)
         except Exception:
             (exc_type, exc_value, exc_traceback) = sys.exc_info()
-            print('Exception type: {!s}'.format(exc_type))
-            print('Exception info: {!s}'.format(exc_value))
-            print('Traceback:')
+            print("Exception type: {!s}".format(exc_type))
+            print("Exception info: {!s}".format(exc_value))
+            print("Traceback:")
             print("\n".join(py_traceback.format_tb(exc_traceback)))
             # Alert the main process of the error
             self._server_event.set()
 
     def server_alive(self):
         """Is the server still running ?"""
-        return (self._server_process is not None and
-                self._server_process.is_alive())
+        return (
+            self._server_process is not None
+            and self._server_process.is_alive()
+        )
 
     def server_end(self):
         """End the server.
@@ -887,39 +1024,55 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         """
         rc = False
         # This test should always succeed...
-        if self._server_synctool is not None and self._server_process is not None:
+        if (
+            self._server_synctool is not None
+            and self._server_process is not None
+        ):
             # Is the process still running ?
             if self._server_process.is_alive():
                 # Try to stop it nicely
-                if self._SERVERSYNC_STOPONEXIT and self._server_synctool.trigger_stop():
+                if (
+                    self._SERVERSYNC_STOPONEXIT
+                    and self._server_synctool.trigger_stop()
+                ):
                     t0 = date.now()
                     self._server_process.join(30)
                     waiting = date.now() - t0
-                    logger.info('Waiting for the server to stop took %f seconds',
-                                waiting.total_seconds())
+                    logger.info(
+                        "Waiting for the server to stop took %f seconds",
+                        waiting.total_seconds(),
+                    )
                 rc = not self._server_event.is_set()
                 # Be less nice if needed...
-                if (not self._SERVERSYNC_STOPONEXIT) or self._server_process.is_alive():
-                    logger.warning('Force termination of the server process')
+                if (
+                    not self._SERVERSYNC_STOPONEXIT
+                ) or self._server_process.is_alive():
+                    logger.warning("Force termination of the server process")
                     self._server_process.terminate()
-                    self.system.sleep(1)  # Allow some time for the process to terminate
+                    self.system.sleep(
+                        1
+                    )  # Allow some time for the process to terminate
                     if not self._SERVERSYNC_STOPONEXIT:
                         rc = False
             else:
                 rc = not self._server_event.is_set()
-            logger.info('Server still alive ? %s', str(self._server_process.is_alive()))
+            logger.info(
+                "Server still alive ? %s", str(self._server_process.is_alive())
+            )
             # We are done with the server
             self._server_synctool = None
             self._server_process = None
             del self._server_event
             # Check the rc
             if not rc:
-                raise AlgoComponentError('The server process ended badly.')
+                raise AlgoComponentError("The server process ended badly.")
         return rc
 
     def spawn_pre_dirlisting(self):
         """Print a directory listing just before run."""
-        self.system.subtitle('{:s} : directory listing (pre-execution)'.format(self.realkind))
+        self.system.subtitle(
+            "{:s} : directory listing (pre-execution)".format(self.realkind)
+        )
         self.system.dir(output=False, fatal=False)
 
     def spawn_hook(self):
@@ -936,24 +1089,27 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         """
         sh = self.system
 
-        if self.env.true('vortex_debug_env'):
-            sh.subtitle('{:s} : dump environment (os bound: {!s})'.format(
-                self.realkind,
-                self.env.osbound()
-            ))
+        if self.env.true("vortex_debug_env"):
+            sh.subtitle(
+                "{:s} : dump environment (os bound: {!s})".format(
+                    self.realkind, self.env.osbound()
+                )
+            )
             self.env.osdump()
 
         # On-the-fly coprocessing initialisation
         p_io, e_complete, e_free, q_ctx = self.flyput_begin()
 
-        sh.remove('core')
-        sh.softlink('/dev/null', 'core')
+        sh.remove("core")
+        sh.softlink("/dev/null", "core")
         self.spawn_hook()
         self.target.spawn_hook(sh)
         self.spawn_pre_dirlisting()
-        sh.subtitle('{:s} : start execution'.format(self.realkind))
+        sh.subtitle("{:s} : start execution".format(self.realkind))
         try:
-            sh.spawn(args, output=False, stdin=stdin, fatal=opts.get('fatal', True))
+            sh.spawn(
+                args, output=False, stdin=stdin, fatal=opts.get("fatal", True)
+            )
         finally:
             # On-the-fly coprocessing cleaning
             if p_io:
@@ -977,8 +1133,8 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         opts = self.spawn_stdin_options()
         stdin_text = rh.resource.stdin_text(**opts)
         if stdin_text is not None:
-            plocale = locale.getlocale()[1] or 'ascii'
-            tmpfh = tempfile.TemporaryFile(dir=self.system.pwd(), mode='w+b')
+            plocale = locale.getlocale()[1] or "ascii"
+            tmpfh = tempfile.TemporaryFile(dir=self.system.pwd(), mode="w+b")
             if isinstance(stdin_text, str):
                 tmpfh.write(stdin_text.encode(plocale))
             else:
@@ -1002,13 +1158,15 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             # First time here ?
             if self._server_synctool is None:
                 if self.serversync_method is None:
-                    raise ValueError('The serversync_method must be provided.')
+                    raise ValueError("The serversync_method must be provided.")
                 self._server_synctool = footprints.proxy.serversynctool(
                     method=self.serversync_method,
                     medium=self.serversync_medium,
                     raiseonexit=self._SERVERSYNC_RAISEONEXIT,
                 )
-                self._server_synctool.set_servercheck_callback(self.server_alive)
+                self._server_synctool.set_servercheck_callback(
+                    self.server_alive
+                )
                 self.server_begin(rh, opts)
                 # Wait for the first request
                 self._server_synctool.trigger_wait()
@@ -1034,7 +1192,9 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
             self.server_end()
 
     def postfix_post_dirlisting(self):
-        self.system.subtitle('{:s} : directory listing (post-run)'.format(self.realkind))
+        self.system.subtitle(
+            "{:s} : directory listing (post-run)".format(self.realkind)
+        )
         self.system.dir(output=False, fatal=False)
 
     def postfix(self, rh, opts):
@@ -1043,7 +1203,7 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
 
     def dumplog(self, opts):
         """Dump to local file the internal log of the current algo component."""
-        self.system.pickle_dump(self.fslog, 'log.' + self.fstag())
+        self.system.pickle_dump(self.fslog, "log." + self.fstag())
 
     def delayed_exceptions(self, opts):
         """Gather all the delayed exceptions and raises one if necessary."""
@@ -1063,13 +1223,15 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         """A shortcut to avoid next steps of the run."""
 
         def fastexit(self, *args, **kw):
-            logger.warning('Run <%s> skipped because abort occurred [%s]', step, msg)
+            logger.warning(
+                "Run <%s> skipped because abort occurred [%s]", step, msg
+            )
 
         return fastexit
 
-    def abort(self, msg='Not documented'):
+    def abort(self, msg="Not documented"):
         """A shortcut to avoid next steps of the run."""
-        for step in ('prepare', 'execute', 'postfix'):
+        for step in ("prepare", "execute", "postfix"):
             setattr(self, step, self.abortfabrik(step, msg))
 
     def run(self, rh=None, **kw):
@@ -1080,33 +1242,34 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
         self.ticket = vortex.sessions.current()
         self.context = self.ticket.context
         self.system = self.context.system
-        self.target = kw.pop('target', None)
+        self.target = kw.pop("target", None)
         if self.target is None:
             self.target = self.system.default_target
 
         # Before trying to do anything, check the executable
         if not self.valid_executable(rh):
-            logger.warning('Resource %s is not a valid executable', rh.resource)
+            logger.warning(
+                "Resource %s is not a valid executable", rh.resource
+            )
             return False
 
         # A cloned environment will be bound to the OS
         self.env = self.context.env.clone()
         with self.env:
-
             # The actual "run" recipe
-            self.prepare(rh, kw)            # 1
-            self.fsstamp(kw)                # 2
+            self.prepare(rh, kw)  # 1
+            self.fsstamp(kw)  # 2
             try:
-                self.execute(rh, kw)        # 3
+                self.execute(rh, kw)  # 3
             except Exception as e:
                 self.fail_execute(e, rh, kw)  # 3.1
                 raise
             finally:
-                self.execute_finalise(kw)   # 3.2
-            self.fscheck(kw)                # 4
-            self.postfix(rh, kw)            # 5
-            self.dumplog(kw)                # 6
-            self.delayed_exceptions(kw)     # 7
+                self.execute_finalise(kw)  # 3.2
+            self.fscheck(kw)  # 4
+            self.postfix(rh, kw)  # 5
+            self.dumplog(kw)  # 6
+            self.delayed_exceptions(kw)  # 7
 
         # Free local references
         self.env = None
@@ -1116,30 +1279,41 @@ class AlgoComponent(footprints.FootprintBase, metaclass=AlgoComponentMeta):
 
     def quickview(self, nb=0, indent=0):
         """Standard glance to objects."""
-        tab = '  ' * indent
-        print('{}{:02d}. {:s}'.format(tab, nb, repr(self)))
-        for subobj in ('kind', 'engine', 'interpreter'):
+        tab = "  " * indent
+        print("{}{:02d}. {:s}".format(tab, nb, repr(self)))
+        for subobj in ("kind", "engine", "interpreter"):
             obj = getattr(self, subobj, None)
             if obj:
-                print('{}  {:s}: {!s}'.format(tab, subobj, obj))
+                print("{}  {:s}: {!s}".format(tab, subobj, obj))
         print()
 
-    def setlink(self, initrole=None, initkind=None, initname=None, inittest=lambda x: True):
+    def setlink(
+        self,
+        initrole=None,
+        initkind=None,
+        initname=None,
+        inittest=lambda x: True,
+    ):
         """Set a symbolic link for actual resource playing defined role."""
         initsec = [
-            x for x in self.context.sequence.effective_inputs(role=initrole, kind=initkind)
+            x
+            for x in self.context.sequence.effective_inputs(
+                role=initrole, kind=initkind
+            )
             if inittest(x.rh)
         ]
 
         if not initsec:
             logger.warning(
-                'Could not find logical role %s with kind %s - assuming already renamed',
-                initrole, initkind
+                "Could not find logical role %s with kind %s - assuming already renamed",
+                initrole,
+                initkind,
             )
 
         if len(initsec) > 1:
-            logger.warning('More than one role %s with kind %s',
-                           initrole, initkind)
+            logger.warning(
+                "More than one role %s with kind %s", initrole, initkind
+            )
 
         if initname is not None:
             for l in [x.rh.container.localpath() for x in initsec]:
@@ -1186,25 +1360,19 @@ class PythonFunction(AlgoComponent):
     """
 
     _footprint = dict(
-        info = "Execute a Python function in a given module",
-
-        attr = dict(
-            engine = dict(
-                values = ["function"]
-            ),
-            func_name = dict(
-                info="The function's name"
-            ),
-            func_kwargs = dict(
+        info="Execute a Python function in a given module",
+        attr=dict(
+            engine=dict(values=["function"]),
+            func_name=dict(info="The function's name"),
+            func_kwargs=dict(
                 info=(
-                    "A dictionary containing the function's "
-                    "keyword arguments"
+                    "A dictionary containing the function's keyword arguments"
                 ),
                 type=footprints.FPDict,
                 default=footprints.FPDict({}),
                 optional=True,
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
@@ -1221,7 +1389,8 @@ class PythonFunction(AlgoComponent):
 
     def execute(self, rh, opts):
         self.func(
-            self.context.sequence, **self.func_kwargs,
+            self.context.sequence,
+            **self.func_kwargs,
         )
 
     def execute_finalise(self, opts):
@@ -1255,7 +1424,13 @@ class xExecutableAlgoComponent(ExecutableAlgoComponent):
         rc = super().valid_executable(rh)
         if rc:
             # Ensure that the input file is executable
-            xrh = rh if isinstance(rh, (list, tuple)) else [rh, ]
+            xrh = (
+                rh
+                if isinstance(rh, (list, tuple))
+                else [
+                    rh,
+                ]
+            )
             for arh in xrh:
                 self.system.xperm(arh.container.localpath(), force=True)
         return rc
@@ -1273,23 +1448,23 @@ class TaylorRun(AlgoComponent):
 
     _abstract = True
     _footprint = dict(
-        info = 'Abstract algo component based on the taylorism package.',
-        attr = dict(
-            kind = dict(),
-            verbose = dict(
-                info        = 'Run in verbose mode',
-                type        = bool,
-                default     = False,
-                optional    = True,
-                doc_zorder  = -50,
+        info="Abstract algo component based on the taylorism package.",
+        attr=dict(
+            kind=dict(),
+            verbose=dict(
+                info="Run in verbose mode",
+                type=bool,
+                default=False,
+                optional=True,
+                doc_zorder=-50,
             ),
-            ntasks = dict(
-                info        = 'The maximum number of parallel tasks',
-                type        = int,
-                default     = DelayedEnvValue('VORTEX_SUBMIT_TASKS', 1),
-                optional    = True
+            ntasks=dict(
+                info="The maximum number of parallel tasks",
+                type=int,
+                default=DelayedEnvValue("VORTEX_SUBMIT_TASKS", 1),
+                optional=True,
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -1303,8 +1478,12 @@ class TaylorRun(AlgoComponent):
     def _default_pre_execute(self, rh, opts):
         """Various initialisations. In particular it creates the task scheduler (Boss)."""
         # Start the task scheduler
-        self._boss = Boss(verbose=self.verbose,
-                          scheduler=footprints.proxy.scheduler(limit='threads', max_threads=self.ntasks))
+        self._boss = Boss(
+            verbose=self.verbose,
+            scheduler=footprints.proxy.scheduler(
+                limit="threads", max_threads=self.ntasks
+            ),
+        )
         self._boss.make_them_work()
 
     def _add_instructions(self, common_i, individual_i):
@@ -1313,12 +1492,16 @@ class TaylorRun(AlgoComponent):
 
     def _default_post_execute(self, rh, opts):
         """Summarise the results of the various tasks that were run."""
-        logger.info("All the input files were dealt with: now waiting for the parallel processing to finish")
+        logger.info(
+            "All the input files were dealt with: now waiting for the parallel processing to finish"
+        )
         self._boss.wait_till_finished()
-        logger.info("The parallel processing has finished. here are the results:")
+        logger.info(
+            "The parallel processing has finished. here are the results:"
+        )
         report = self._boss.get_report()
         prp = ParallelResultParser(self.context)
-        for r in report['workers_report']:
+        for r in report["workers_report"]:
             rc = prp(r)
             if isinstance(rc, Exception):
                 self.delayed_exception_add(rc, traceback=False)
@@ -1328,8 +1511,10 @@ class TaylorRun(AlgoComponent):
     def _default_rc_action(self, rh, opts, report, rc):
         """How should we process the return code ?"""
         if not rc:
-            logger.warning("Apparently something went sideways with this task (rc=%s).",
-                           str(rc))
+            logger.warning(
+                "Apparently something went sideways with this task (rc=%s).",
+                str(rc),
+            )
 
     def execute(self, rh, opts):
         """
@@ -1359,28 +1544,28 @@ class Expresso(ExecutableAlgoComponent):
     """Run a script resource in the good environment."""
 
     _footprint = dict(
-        info = 'AlgoComponent that simply runs a script',
-        attr = dict(
-            interpreter = dict(
-                info     = 'The interpreter needed to run the script.',
-                values   = ['current', 'awk', 'ksh', 'bash', 'perl', 'python']
+        info="AlgoComponent that simply runs a script",
+        attr=dict(
+            interpreter=dict(
+                info="The interpreter needed to run the script.",
+                values=["current", "awk", "ksh", "bash", "perl", "python"],
             ),
-            interpreter_path = dict(
-                info     = 'The interpreter command.',
-                optional = True,
+            interpreter_path=dict(
+                info="The interpreter command.",
+                optional=True,
             ),
-            engine = dict(
-                values = ['exec', 'launch']
-            ),
-        )
+            engine=dict(values=["exec", "launch"]),
+        ),
     )
 
     @property
     def _actual_interpreter(self):
         """Return the interpreter command."""
-        if self.interpreter == 'current':
+        if self.interpreter == "current":
             if self.interpreter_path is not None:
-                raise ValueError("*interpreter=current* and *interpreter_path* attributes are incompatible")
+                raise ValueError(
+                    "*interpreter=current* and *interpreter_path* attributes are incompatible"
+                )
             return sys.executable
         else:
             if self.interpreter_path is None:
@@ -1389,15 +1574,20 @@ class Expresso(ExecutableAlgoComponent):
                 if self.system.xperm(self.interpreter_path):
                     return self.interpreter_path
                 else:
-                    raise AlgoComponentError("The '{:s}' interpreter is not executable"
-                                             .format(self.interpreter_path))
+                    raise AlgoComponentError(
+                        "The '{:s}' interpreter is not executable".format(
+                            self.interpreter_path
+                        )
+                    )
 
     def _interpreter_args_fix(self, rh, opts):
         absexec = self.absexcutable(rh.container.localpath())
-        if self.interpreter == 'awk':
-            return ['-f', absexec]
+        if self.interpreter == "awk":
+            return ["-f", absexec]
         else:
-            return [absexec, ]
+            return [
+                absexec,
+            ]
 
     def execute_single(self, rh, opts):
         """
@@ -1405,19 +1595,23 @@ class Expresso(ExecutableAlgoComponent):
         using the resource command_line method as args.
         """
         # Generic config
-        args = [self._actual_interpreter, ]
+        args = [
+            self._actual_interpreter,
+        ]
         args.extend(self._interpreter_args_fix(rh, opts))
         args.extend(self.spawn_command_line(rh))
-        logger.info('Run script %s', args)
+        logger.info("Run script %s", args)
         rh_stdin = self.spawn_stdin(rh)
         if rh_stdin is not None:
-            plocale = locale.getlocale()[1] or 'ascii'
-            logger.info('Script stdin:\n%s', rh_stdin.read().decode(plocale, 'replace'))
+            plocale = locale.getlocale()[1] or "ascii"
+            logger.info(
+                "Script stdin:\n%s", rh_stdin.read().decode(plocale, "replace")
+            )
             rh_stdin.seek(0)
         # Python path stuff
-        newpypath = ':'.join(self.extendpypath)
-        if 'pythonpath' in self.env:
-            newpypath += ':{:s}'.format(self.env.pythonpath)
+        newpypath = ":".join(self.extendpypath)
+        if "pythonpath" in self.env:
+            newpypath += ":{:s}".format(self.env.pythonpath)
         # launching the program...
         with self.env.delta_context(pythonpath=newpypath):
             self.spawn(args, opts, stdin=rh_stdin)
@@ -1435,26 +1629,24 @@ class ParaExpresso(TaylorRun):
 
     _abstract = True
     _footprint = dict(
-        info = 'AlgoComponent that simply runs a script using the taylorism package.',
-        attr = dict(
-            interpreter = dict(
-                info   = 'The interpreter needed to run the script.',
-                values = ['current', 'awk', 'ksh', 'bash', 'perl', 'python']
+        info="AlgoComponent that simply runs a script using the taylorism package.",
+        attr=dict(
+            interpreter=dict(
+                info="The interpreter needed to run the script.",
+                values=["current", "awk", "ksh", "bash", "perl", "python"],
             ),
-            engine = dict(
-                values   = ['exec', 'launch']
+            engine=dict(values=["exec", "launch"]),
+            interpreter_path=dict(
+                info="The full path to the interpreter.",
+                optional=True,
             ),
-            interpreter_path = dict(
-                info     = 'The full path to the interpreter.',
-                optional = True,
+            extendpypath=dict(
+                info="The list of things to be prepended in the python's path.",
+                type=footprints.FPList,
+                default=footprints.FPList([]),
+                optional=True,
             ),
-            extendpypath = dict(
-                info     = "The list of things to be prepended in the python's path.",
-                type     = footprints.FPList,
-                default  = footprints.FPList([]),
-                optional = True
-            ),
-        )
+        ),
     )
 
     def valid_executable(self, rh):
@@ -1466,25 +1658,32 @@ class ParaExpresso(TaylorRun):
 
     def _interpreter_args_fix(self, rh, opts):
         absexec = self.absexcutable(rh.container.localpath())
-        if self.interpreter == 'awk':
-            return ['-f', absexec]
+        if self.interpreter == "awk":
+            return ["-f", absexec]
         else:
-            return [absexec, ]
+            return [
+                absexec,
+            ]
 
     def _default_common_instructions(self, rh, opts):
         """Create a common instruction dictionary that will be used by the workers."""
         ddict = super()._default_common_instructions(rh, opts)
-        actual_interpreter = sys.executable if self.interpreter == 'current' else self.interpreter
-        ddict['progname'] = actual_interpreter
-        ddict['progargs'] = footprints.FPList(self._interpreter_args_fix(rh, opts) +
-                                              self.spawn_command_line(rh))
-        ddict['progenvdelta'] = footprints.FPDict()
+        actual_interpreter = (
+            sys.executable
+            if self.interpreter == "current"
+            else self.interpreter
+        )
+        ddict["progname"] = actual_interpreter
+        ddict["progargs"] = footprints.FPList(
+            self._interpreter_args_fix(rh, opts) + self.spawn_command_line(rh)
+        )
+        ddict["progenvdelta"] = footprints.FPDict()
         # Deal with the python path
-        newpypath = ':'.join(self.extendpypath)
-        if 'pythonpath' in self.env:
-            self.env.pythonpath += ':{:s}'.format(newpypath)
+        newpypath = ":".join(self.extendpypath)
+        if "pythonpath" in self.env:
+            self.env.pythonpath += ":{:s}".format(newpypath)
         if newpypath:
-            ddict['progenvdelta']['pythonpath'] = newpypath
+            ddict["progenvdelta"]["pythonpath"] = newpypath
         return ddict
 
 
@@ -1495,12 +1694,8 @@ class BlindRun(xExecutableAlgoComponent):
     """
 
     _footprint = dict(
-        info = 'AlgoComponent that simply runs a serial binary',
-        attr = dict(
-            engine = dict(
-                values = ['blind']
-            )
-        )
+        info="AlgoComponent that simply runs a serial binary",
+        attr=dict(engine=dict(values=["blind"])),
     )
 
     def execute_single(self, rh, opts):
@@ -1511,12 +1706,15 @@ class BlindRun(xExecutableAlgoComponent):
 
         args = [self.absexcutable(rh.container.localpath())]
         args.extend(self.spawn_command_line(rh))
-        logger.info('BlindRun executable resource %s', args)
+        logger.info("BlindRun executable resource %s", args)
         rh_stdin = self.spawn_stdin(rh)
         if rh_stdin is not None:
-            plocale = locale.getlocale()[1] or 'ascii'
-            logger.info('BlindRun executable stdin (fileno:%d):\n%s',
-                        rh_stdin.fileno(), rh_stdin.read().decode(plocale, 'replace'))
+            plocale = locale.getlocale()[1] or "ascii"
+            logger.info(
+                "BlindRun executable stdin (fileno:%d):\n%s",
+                rh_stdin.fileno(),
+                rh_stdin.read().decode(plocale, "replace"),
+            )
             rh_stdin.seek(0)
         self.spawn(args, opts, stdin=rh_stdin)
 
@@ -1533,26 +1731,26 @@ class ParaBlindRun(TaylorRun):
 
     _abstract = True
     _footprint = dict(
-        info = 'Abstract AlgoComponent that runs a serial binary using the taylorism package.',
-        attr = dict(
-            engine = dict(
-                values = ['blind']
+        info="Abstract AlgoComponent that runs a serial binary using the taylorism package.",
+        attr=dict(
+            engine=dict(values=["blind"]),
+            taskset=dict(
+                info="Topology/Method to set up the CPU affinity of the child task.",
+                default=None,
+                optional=True,
+                values=[
+                    "{:s}{:s}".format(t, m)
+                    for t in ("raw", "socketpacked", "numapacked")
+                    for m in ("", "_taskset", "_gomp", "_omp", "_ompverbose")
+                ],
             ),
-            taskset = dict(
-                info = "Topology/Method to set up the CPU affinity of the child task.",
-                default = None,
-                optional = True,
-                values = ['{:s}{:s}'.format(t, m)
-                          for t in ('raw', 'socketpacked', 'numapacked')
-                          for m in ('', '_taskset', '_gomp', '_omp', '_ompverbose')]
+            taskset_bsize=dict(
+                info="The number of threads used by one task",
+                type=int,
+                default=1,
+                optional=True,
             ),
-            taskset_bsize = dict(
-                info        = 'The number of threads used by one task',
-                type        = int,
-                default     = 1,
-                optional    = True
-            ),
-        )
+        ),
     )
 
     def valid_executable(self, rh):
@@ -1563,7 +1761,13 @@ class ParaBlindRun(TaylorRun):
         rc = rh is not None
         if rc:
             # Ensure that the input file is executable
-            xrh = rh if isinstance(rh, (list, tuple)) else [rh, ]
+            xrh = (
+                rh
+                if isinstance(rh, (list, tuple))
+                else [
+                    rh,
+                ]
+            )
             for arh in xrh:
                 self.system.xperm(arh.container.localpath(), force=True)
         return rc
@@ -1571,10 +1775,10 @@ class ParaBlindRun(TaylorRun):
     def _default_common_instructions(self, rh, opts):
         """Create a common instruction dictionary that will be used by the workers."""
         ddict = super()._default_common_instructions(rh, opts)
-        ddict['progname'] = self.absexcutable(rh.container.localpath())
-        ddict['progargs'] = footprints.FPList(self.spawn_command_line(rh))
-        ddict['progtaskset'] = self.taskset
-        ddict['progtaskset_bsize'] = self.taskset_bsize
+        ddict["progname"] = self.absexcutable(rh.container.localpath())
+        ddict["progargs"] = footprints.FPList(self.spawn_command_line(rh))
+        ddict["progtaskset"] = self.taskset
+        ddict["progtaskset_bsize"] = self.taskset_bsize
         return ddict
 
 
@@ -1584,50 +1788,54 @@ class Parallel(xExecutableAlgoComponent):
     """
 
     _footprint = dict(
-        info = 'AlgoComponent that simply runs an MPI binary',
-        attr = dict(
-            engine = dict(
-                values   = ['parallel']
+        info="AlgoComponent that simply runs an MPI binary",
+        attr=dict(
+            engine=dict(values=["parallel"]),
+            mpitool=dict(
+                info="The object used to launch the parallel program",
+                optional=True,
+                type=mpitools.MpiTool,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            mpitool = dict(
-                info            = 'The object used to launch the parallel program',
-                optional        = True,
-                type            = mpitools.MpiTool,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            mpiname=dict(
+                info=(
+                    "The mpiname of a class in the mpitool collector "
+                    + "(used only if *mpitool* is not provided)"
+                ),
+                optional=True,
+                alias=["mpi"],
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            mpiname = dict(
-                info            = ('The mpiname of a class in the mpitool collector ' +
-                                   '(used only if *mpitool* is not provided)'),
-                optional        = True,
-                alias           = ['mpi'],
-                doc_visibility  = footprints.doc.visibility.GURU,
+            mpiverbose=dict(
+                info="Boost logging verbosity in mpitools",
+                optional=True,
+                default=False,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            mpiverbose = dict(
-                info            = 'Boost logging verbosity in mpitools',
-                optional        = True,
-                default         = False,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            binaries=dict(
+                info="List of MpiBinaryDescription objects",
+                optional=True,
+                type=footprints.FPList,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            binaries = dict(
-                info            = 'List of MpiBinaryDescription objects',
-                optional        = True,
-                type            = footprints.FPList,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            binarysingle=dict(
+                info="If *binaries* is missing, the default binary role for single binaries",
+                optional=True,
+                default="basicsingle",
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            binarysingle = dict(
-                info            = 'If *binaries* is missing, the default binary role for single binaries',
-                optional        = True,
-                default         = 'basicsingle',
-                doc_visibility  = footprints.doc.visibility.GURU,
+            binarymulti=dict(
+                info="If *binaries* is missing, the default binary role for multiple binaries",
+                type=footprints.FPList,
+                optional=True,
+                default=footprints.FPList(
+                    [
+                        "basic",
+                    ]
+                ),
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            binarymulti = dict(
-                info            = 'If *binaries* is missing, the default binary role for multiple binaries',
-                type            = footprints.FPList,
-                optional        = True,
-                default         = footprints.FPList(['basic', ]),
-                doc_visibility  = footprints.doc.visibility.GURU,
-            ),
-        )
+        ),
     )
 
     def _mpitool_attributes(self, opts):
@@ -1650,7 +1858,7 @@ class Parallel(xExecutableAlgoComponent):
         if nonkeys:
             msg = (
                 "The following keywords are unknown configuration"
-                "keys for section \"mpitool\":\n"
+                'keys for section "mpitool":\n'
             )
 
             raise ValueError(msg + "\n".join(nonkeys))
@@ -1674,56 +1882,68 @@ class Parallel(xExecutableAlgoComponent):
 
         # Rh is a list binaries...
         if not isinstance(rh, collections.abc.Iterable):
-            rh = [rh, ]
+            rh = [
+                rh,
+            ]
 
         # Find the MPI launcher
         mpi = self.mpitool
         if not mpi:
             mpi = footprints.proxy.mpitool(
-                sysname=self.system.sysname,
-                ** self._mpitool_attributes(opts)
+                sysname=self.system.sysname, **self._mpitool_attributes(opts)
             )
         if not mpi:
-            logger.critical('Component %s could not find any mpitool', self.footprint_clsname())
-            raise AttributeError('No valid mpitool attr could be found.')
+            logger.critical(
+                "Component %s could not find any mpitool",
+                self.footprint_clsname(),
+            )
+            raise AttributeError("No valid mpitool attr could be found.")
 
         # Setup various useful things (env, system, ...)
         mpi.import_basics(self)
 
-        mpi_opts = opts.get('mpiopts', dict())
+        mpi_opts = opts.get("mpiopts", dict())
 
         envelope = []
-        use_envelope = 'envelope' in mpi_opts
+        use_envelope = "envelope" in mpi_opts
         if use_envelope:
-            envelope = mpi_opts.pop('envelope')
-            if envelope == 'auto':
-                blockspec = dict(nn=self.env.get('VORTEX_SUBMIT_NODES', 1), )
-                if 'VORTEX_SUBMIT_TASKS' in self.env:
-                    blockspec['nnp'] = self.env.get('VORTEX_SUBMIT_TASKS')
+            envelope = mpi_opts.pop("envelope")
+            if envelope == "auto":
+                blockspec = dict(
+                    nn=self.env.get("VORTEX_SUBMIT_NODES", 1),
+                )
+                if "VORTEX_SUBMIT_TASKS" in self.env:
+                    blockspec["nnp"] = self.env.get("VORTEX_SUBMIT_TASKS")
                 else:
-                    raise ValueError("when envelope='auto', VORTEX_SUBMIT_TASKS must be set up.")
-                envelope = [blockspec, ]
+                    raise ValueError(
+                        "when envelope='auto', VORTEX_SUBMIT_TASKS must be set up."
+                    )
+                envelope = [
+                    blockspec,
+                ]
             elif isinstance(envelope, dict):
-                envelope = [envelope, ]
+                envelope = [
+                    envelope,
+                ]
             elif isinstance(envelope, (list, tuple)):
                 pass
             else:
-                raise AttributeError('Invalid envelope specification')
+                raise AttributeError("Invalid envelope specification")
             if envelope:
-                envelope_ntasks = sum([d['nn'] * d['nnp'] for d in envelope])
+                envelope_ntasks = sum([d["nn"] * d["nnp"] for d in envelope])
             if not envelope:
                 use_envelope = False
 
         if not use_envelope:
             # Some MPI presets
             mpi_desc = dict()
-            for mpi_k in ('tasks', 'openmp'):
-                mpi_kenv = 'VORTEX_SUBMIT_' + mpi_k.upper()
+            for mpi_k in ("tasks", "openmp"):
+                mpi_kenv = "VORTEX_SUBMIT_" + mpi_k.upper()
                 if mpi_kenv in self.env:
                     mpi_desc[mpi_k] = self.env.get(mpi_kenv)
 
         # Binaries may be grouped together on the same nodes
-        bin_groups = mpi_opts.pop('groups', [])
+        bin_groups = mpi_opts.pop("groups", [])
 
         # Find out the command line
         bargs = self.spawn_command_line(rh)
@@ -1733,65 +1953,89 @@ class Parallel(xExecutableAlgoComponent):
 
         # The usual case: no indications, 1 binary + a potential ioserver
         if len(rh) == 1 and not self.binaries:
-
             # In such a case, defining group does not makes sense
-            self.algoassert(not bin_groups,
-                            "With only one binary, groups should not be defined")
+            self.algoassert(
+                not bin_groups,
+                "With only one binary, groups should not be defined",
+            )
 
             # The main program
-            allowbind = mpi_opts.pop('allowbind', True)
-            distribution = mpi_opts.pop('distribution',
-                                        self.env.get('VORTEX_MPIBIN_DEF_DISTRIBUTION', None))
+            allowbind = mpi_opts.pop("allowbind", True)
+            distribution = mpi_opts.pop(
+                "distribution",
+                self.env.get("VORTEX_MPIBIN_DEF_DISTRIBUTION", None),
+            )
             if use_envelope:
                 master = footprints.proxy.mpibinary(
                     kind=self.binarysingle,
                     ranks=envelope_ntasks,
-                    openmp=self.env.get('VORTEX_SUBMIT_OPENMP', None),
+                    openmp=self.env.get("VORTEX_SUBMIT_OPENMP", None),
                     allowbind=allowbind,
-                    distribution=distribution)
+                    distribution=distribution,
+                )
             else:
                 master = footprints.proxy.mpibinary(
                     kind=self.binarysingle,
-                    nodes=self.env.get('VORTEX_SUBMIT_NODES', 1),
+                    nodes=self.env.get("VORTEX_SUBMIT_NODES", 1),
                     allowbind=allowbind,
                     distribution=distribution,
-                    **mpi_desc)
+                    **mpi_desc,
+                )
             master.options = mpi_opts
             master.master = self.absexcutable(rh[0].container.localpath())
             master.arguments = bargs[0]
-            bins = [master, ]
+            bins = [
+                master,
+            ]
             # Source files ?
-            if hasattr(rh[0].resource, 'guess_binary_sources'):
-                sources.extend(rh[0].resource.guess_binary_sources(rh[0].provider))
+            if hasattr(rh[0].resource, "guess_binary_sources"):
+                sources.extend(
+                    rh[0].resource.guess_binary_sources(rh[0].provider)
+                )
 
         # Multiple binaries are to be launched: no IO server support here.
         elif len(rh) > 1 and not self.binaries:
-
             # Binary roles
             if len(self.binarymulti) == 1:
                 bnames = self.binarymulti * len(rh)
             else:
                 if len(self.binarymulti) != len(rh):
-                    raise ParallelInconsistencyAlgoComponentError("self.binarymulti")
+                    raise ParallelInconsistencyAlgoComponentError(
+                        "self.binarymulti"
+                    )
                 bnames = self.binarymulti
 
             # Check mpiopts shape
             for k, v in mpi_opts.items():
                 if not isinstance(v, collections.abc.Iterable):
-                    raise ValueError('In such a case, mpiopts must be Iterable')
+                    raise ValueError(
+                        "In such a case, mpiopts must be Iterable"
+                    )
                 if len(v) != len(rh):
-                    raise ParallelInconsistencyAlgoComponentError('mpiopts[{:s}]'.format(k))
+                    raise ParallelInconsistencyAlgoComponentError(
+                        "mpiopts[{:s}]".format(k)
+                    )
             # Check bin_group shape
             if bin_groups:
                 if len(bin_groups) != len(rh):
-                    raise ParallelInconsistencyAlgoComponentError('bin_group')
+                    raise ParallelInconsistencyAlgoComponentError("bin_group")
 
             # Create MpiBinaryDescription objects
             bins = list()
-            allowbinds = mpi_opts.pop('allowbind', [True, ] * len(rh))
-            distributions = mpi_opts.pop('distribution',
-                                         [self.env.get('VORTEX_MPIBIN_DEF_DISTRIBUTION', None), ]
-                                         * len(rh))
+            allowbinds = mpi_opts.pop(
+                "allowbind",
+                [
+                    True,
+                ]
+                * len(rh),
+            )
+            distributions = mpi_opts.pop(
+                "distribution",
+                [
+                    self.env.get("VORTEX_MPIBIN_DEF_DISTRIBUTION", None),
+                ]
+                * len(rh),
+            )
             for i, r in enumerate(rh):
                 if use_envelope:
                     bins.append(
@@ -1805,10 +2049,10 @@ class Parallel(xExecutableAlgoComponent):
                     bins.append(
                         footprints.proxy.mpibinary(
                             kind=bnames[i],
-                            nodes=self.env.get('VORTEX_SUBMIT_NODES', 1),
+                            nodes=self.env.get("VORTEX_SUBMIT_NODES", 1),
                             allowbind=allowbinds[i],
                             distribution=distributions[i],
-                            **mpi_desc
+                            **mpi_desc,
                         )
                     )
                 # Reshape mpiopts
@@ -1818,7 +2062,7 @@ class Parallel(xExecutableAlgoComponent):
                 bins[i].master = self.absexcutable(r.container.localpath())
                 bins[i].arguments = bargs[i]
                 # Source files ?
-                if hasattr(r.resource, 'guess_binary_sources'):
+                if hasattr(r.resource, "guess_binary_sources"):
                     sources.extend(r.resource.guess_binary_sources(r.provider))
 
         # Nothing to do: binary descriptions are provided by the user
@@ -1836,8 +2080,12 @@ class Parallel(xExecutableAlgoComponent):
             mpi.envelope = envelope
 
         # The binaries description
-        mpi.binaries = self._bootstrap_mpibins_hack(bins, rh, opts, use_envelope)
-        upd_envelope = self._bootstrap_mpienvelope_posthack(envelope, rh, opts, mpi)
+        mpi.binaries = self._bootstrap_mpibins_hack(
+            bins, rh, opts, use_envelope
+        )
+        upd_envelope = self._bootstrap_mpienvelope_posthack(
+            envelope, rh, opts, mpi
+        )
         if upd_envelope:
             mpi.envelope = upd_envelope
 
@@ -1850,14 +2098,20 @@ class Parallel(xExecutableAlgoComponent):
             mpibins_total = sum([m.nprocs for m in mpi.binaries])
             if not envelope_ntasks == mpibins_total:
                 raise AlgoComponentError(
-                    ("The number of requested ranks ({:d}) must be equal "
-                     "to the number of processes available in the envelope ({:d})").
-                    format(mpibins_total, envelope_ntasks))
+                    (
+                        "The number of requested ranks ({:d}) must be equal "
+                        "to the number of processes available in the envelope ({:d})"
+                    ).format(mpibins_total, envelope_ntasks)
+                )
 
         args = mpi.mkcmdline()
         for b in mpi.binaries:
-            logger.info('Run %s in parallel mode. Args: %s.', b.master, ' '.join(b.arguments))
-        logger.info('Full MPI command line: %s', ' '.join(args))
+            logger.info(
+                "Run %s in parallel mode. Args: %s.",
+                b.master,
+                " ".join(b.arguments),
+            )
+        logger.info("Full MPI command line: %s", " ".join(args))
 
         # Setup various useful things (env, system, ...)
         mpi.import_basics(self)
@@ -1868,7 +2122,9 @@ class Parallel(xExecutableAlgoComponent):
     def _tweak_mpitools_logging(self):
         if self.mpiverbose:
             m_loggers = dict()
-            for m_logger_name in [l for l in loggers.lognames if 'mpitools' in l]:
+            for m_logger_name in [
+                l for l in loggers.lognames if "mpitools" in l
+            ]:
                 m_logger = loggers.getLogger(m_logger_name)
                 m_loggers[m_logger] = m_logger.level
                 m_logger.setLevel(logging.DEBUG)
@@ -1887,10 +2143,9 @@ class Parallel(xExecutableAlgoComponent):
         contain indications on the number of nodes, tasks, ...
         """
 
-        self.system.subtitle('{:s} : parallel engine'.format(self.realkind))
+        self.system.subtitle("{:s} : parallel engine".format(self.realkind))
 
         with self._tweak_mpitools_logging():
-
             # Return a mpitool object and the mpicommand line
             mpi, args = self._bootstrap_mpitool(rh, opts)
 
@@ -1908,91 +2163,125 @@ class Parallel(xExecutableAlgoComponent):
 class ParallelIoServerMixin(AlgoComponentMpiDecoMixin):
     """Adds an IOServer capabilities (footprints attributes + MPI bianries alteration)."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = [footprints.Footprint(
-        info="Abstract IoServer footprints' attributes.",
-        attr=dict(
-            ioserver=dict(
-                info='The object used to launch the IOserver part of the binary.',
-                type=mpitools.MpiBinaryIOServer,
-                optional=True,
-                default=None,
-                doc_visibility=footprints.doc.visibility.GURU,
+    _MIXIN_EXTRA_FOOTPRINTS = [
+        footprints.Footprint(
+            info="Abstract IoServer footprints' attributes.",
+            attr=dict(
+                ioserver=dict(
+                    info="The object used to launch the IOserver part of the binary.",
+                    type=mpitools.MpiBinaryIOServer,
+                    optional=True,
+                    default=None,
+                    doc_visibility=footprints.doc.visibility.GURU,
+                ),
+                ioname=dict(
+                    info=(
+                        "The binary_kind of a class in the mpibinary collector "
+                        + "(used only if *ioserver* is not provided)"
+                    ),
+                    optional=True,
+                    default="ioserv",
+                    doc_visibility=footprints.doc.visibility.GURU,
+                ),
+                iolocation=dict(
+                    info="Location of the IO server within the binary list",
+                    type=int,
+                    default=-1,
+                    optional=True,
+                ),
             ),
-            ioname=dict(
-                info=('The binary_kind of a class in the mpibinary collector ' +
-                      '(used only if *ioserver* is not provided)'),
-                optional=True,
-                default='ioserv',
-                doc_visibility=footprints.doc.visibility.GURU,
-            ),
-            iolocation=dict(
-                info='Location of the IO server within the binary list',
-                type=int,
-                default=-1,
-                optional=True
-            )
-        )),
+        ),
     ]
 
-    def _bootstrap_mpibins_ioserver_hack(self, bins, bins0, rh, opts, use_envelope):
+    def _bootstrap_mpibins_ioserver_hack(
+        self, bins, bins0, rh, opts, use_envelope
+    ):
         """If requested, adds an extra binary that will act as an IOServer."""
         master = bins[-1]
         # A potential IO server
         io = self.ioserver
-        if not io and int(self.env.get('VORTEX_IOSERVER_NODES', -1)) >= 0:
+        if not io and int(self.env.get("VORTEX_IOSERVER_NODES", -1)) >= 0:
             io = footprints.proxy.mpibinary(
                 kind=self.ioname,
                 nodes=self.env.VORTEX_IOSERVER_NODES,
-                tasks=(self.env.VORTEX_IOSERVER_TASKS or
-                       master.options.get('nnp', master.tasks)),
-                openmp=(self.env.VORTEX_IOSERVER_OPENMP or
-                        master.options.get('openmp', master.openmp)),
-                iolocation=self.iolocation)
-            io.options = {x[3:]: opts[x]
-                          for x in opts.keys() if x.startswith('io_')}
+                tasks=(
+                    self.env.VORTEX_IOSERVER_TASKS
+                    or master.options.get("nnp", master.tasks)
+                ),
+                openmp=(
+                    self.env.VORTEX_IOSERVER_OPENMP
+                    or master.options.get("openmp", master.openmp)
+                ),
+                iolocation=self.iolocation,
+            )
+            io.options = {
+                x[3:]: opts[x] for x in opts.keys() if x.startswith("io_")
+            }
             io.master = master.master
             io.arguments = master.arguments
-        if not io and int(self.env.get('VORTEX_IOSERVER_COMPANION_TASKS', -1)) >= 0:
+        if (
+            not io
+            and int(self.env.get("VORTEX_IOSERVER_COMPANION_TASKS", -1)) >= 0
+        ):
             io = footprints.proxy.mpibinary(
                 kind=self.ioname,
-                nodes=master.options.get('nn', master.nodes),
+                nodes=master.options.get("nn", master.nodes),
                 tasks=self.env.VORTEX_IOSERVER_COMPANION_TASKS,
-                openmp=(self.env.VORTEX_IOSERVER_OPENMP or
-                        master.options.get('openmp', master.openmp)))
-            io.options = {x[3:]: opts[x]
-                          for x in opts.keys() if x.startswith('io_')}
+                openmp=(
+                    self.env.VORTEX_IOSERVER_OPENMP
+                    or master.options.get("openmp", master.openmp)
+                ),
+            )
+            io.options = {
+                x[3:]: opts[x] for x in opts.keys() if x.startswith("io_")
+            }
             io.master = master.master
             io.arguments = master.arguments
             if master.group is not None:
                 # The master binary is already in a group ! Use it.
                 io.group = master.group
             else:
-                io.group = 'auto_masterwithio'
-                master.group = 'auto_masterwithio'
-        if not io and self.env.get('VORTEX_IOSERVER_INCORE_TASKS', None) is not None:
-            if hasattr(master, 'incore_iotasks'):
+                io.group = "auto_masterwithio"
+                master.group = "auto_masterwithio"
+        if (
+            not io
+            and self.env.get("VORTEX_IOSERVER_INCORE_TASKS", None) is not None
+        ):
+            if hasattr(master, "incore_iotasks"):
                 master.incore_iotasks = self.env.VORTEX_IOSERVER_INCORE_TASKS
-        if not io and self.env.get('VORTEX_IOSERVER_INCORE_FIXER', None) is not None:
-            if hasattr(master, 'incore_iotasks_fixer'):
-                master.incore_iotasks_fixer = self.env.VORTEX_IOSERVER_INCORE_FIXER
-        if not io and self.env.get('VORTEX_IOSERVER_INCORE_DIST', None) is not None:
-            if hasattr(master, 'incore_iodist'):
+        if (
+            not io
+            and self.env.get("VORTEX_IOSERVER_INCORE_FIXER", None) is not None
+        ):
+            if hasattr(master, "incore_iotasks_fixer"):
+                master.incore_iotasks_fixer = (
+                    self.env.VORTEX_IOSERVER_INCORE_FIXER
+                )
+        if (
+            not io
+            and self.env.get("VORTEX_IOSERVER_INCORE_DIST", None) is not None
+        ):
+            if hasattr(master, "incore_iodist"):
                 master.incore_iodist = self.env.VORTEX_IOSERVER_INCORE_DIST
         if io:
             rh.append(rh[0])
             if master.group is None:
-                if 'nn' in master.options:
-                    master.options['nn'] = master.options['nn'] - io.options['nn']
+                if "nn" in master.options:
+                    master.options["nn"] = (
+                        master.options["nn"] - io.options["nn"]
+                    )
                 else:
-                    logger.warning('The "nn" option is not available in the master binary ' +
-                                   'mpi options. Consequently it can be fixed...')
+                    logger.warning(
+                        'The "nn" option is not available in the master binary '
+                        + "mpi options. Consequently it can be fixed..."
+                    )
             if self.iolocation >= 0:
                 bins.insert(self.iolocation, io)
             else:
                 bins.append(io)
         return bins
 
-    _MIXIN_MPIBINS_HOOKS = (_bootstrap_mpibins_ioserver_hack, )
+    _MIXIN_MPIBINS_HOOKS = (_bootstrap_mpibins_ioserver_hack,)
 
 
 @algo_component_deco_mixin_autodoc
@@ -2006,38 +2295,44 @@ class ParallelOpenPalmMixin(AlgoComponentMpiDecoMixin):
     provided using the **openpalm_driver** footprint's argument.
     """
 
-    _MIXIN_EXTRA_FOOTPRINTS = [footprints.Footprint(
-        info="Abstract OpenPALM footprints' attributes.",
-        attr=dict(
-            openpalm_driver=dict(
-                info=('The path to the OpenPALM driver binary. ' +
-                      'When omitted, the input sequence is looked up ' +
-                      'for section with ``role=OpenPALM Driver``.'),
-                optional=True,
-                doc_visibility=footprints.doc.visibility.ADVANCED,
+    _MIXIN_EXTRA_FOOTPRINTS = [
+        footprints.Footprint(
+            info="Abstract OpenPALM footprints' attributes.",
+            attr=dict(
+                openpalm_driver=dict(
+                    info=(
+                        "The path to the OpenPALM driver binary. "
+                        + "When omitted, the input sequence is looked up "
+                        + "for section with ``role=OpenPALM Driver``."
+                    ),
+                    optional=True,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
+                ),
+                openpalm_overcommit=dict(
+                    info=(
+                        "Run the OpenPALM driver on the first node in addition "
+                        + "to existing tasks. Otherwise dedicated tasks are used."
+                    ),
+                    type=bool,
+                    default=True,
+                    optional=True,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
+                ),
+                openpalm_binddriver=dict(
+                    info="Try to bind the OpenPALM driver binary.",
+                    type=bool,
+                    optional=True,
+                    default=False,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
+                ),
+                openpalm_binkind=dict(
+                    info="The binary kind for the OpenPALM driver.",
+                    optional=True,
+                    default="basic",
+                    doc_visibility=footprints.doc.visibility.GURU,
+                ),
             ),
-            openpalm_overcommit=dict(
-                info=('Run the OpenPALM driver on the first node in addition ' +
-                      'to existing tasks. Otherwise dedicated tasks are used.'),
-                type=bool,
-                default=True,
-                optional=True,
-                doc_visibility=footprints.doc.visibility.ADVANCED,
-            ),
-            openpalm_binddriver=dict(
-                info='Try to bind the OpenPALM driver binary.',
-                type=bool,
-                optional=True,
-                default=False,
-                doc_visibility=footprints.doc.visibility.ADVANCED,
-            ),
-            openpalm_binkind=dict(
-                info='The binary kind for the OpenPALM driver.',
-                optional=True,
-                default='basic',
-                doc_visibility=footprints.doc.visibility.GURU,
-            ),
-        )),
+        ),
     ]
 
     @property
@@ -2045,19 +2340,28 @@ class ParallelOpenPalmMixin(AlgoComponentMpiDecoMixin):
         """Returns the OpenPALM's driver location."""
         path = self.openpalm_driver
         if path is None:
-            drivers = self.context.sequence.effective_inputs(role='OpenPALMDriver')
+            drivers = self.context.sequence.effective_inputs(
+                role="OpenPALMDriver"
+            )
             if not drivers:
-                raise AlgoComponentError('No OpenPALM driver was provided.')
+                raise AlgoComponentError("No OpenPALM driver was provided.")
             elif len(drivers) > 1:
-                raise AlgoComponentError('Several OpenPALM driver were provided.')
+                raise AlgoComponentError(
+                    "Several OpenPALM driver were provided."
+                )
             path = drivers[0].rh.container.localpath()
         else:
             if not self.system.path.exists(path):
-                raise AlgoComponentError('No OpenPALM driver was provider ({:s} does not exists).'
-                                         .format(path))
+                raise AlgoComponentError(
+                    "No OpenPALM driver was provider ({:s} does not exists).".format(
+                        path
+                    )
+                )
         return path
 
-    def _bootstrap_mpibins_openpalm_hack(self, bins, bins0, rh, opts, use_envelope):
+    def _bootstrap_mpibins_openpalm_hack(
+        self, bins, bins0, rh, opts, use_envelope
+    ):
         """Adds the OpenPALM driver to the binary list."""
         single_bin = len(bins) == 1
         master = bins[0]
@@ -2066,12 +2370,16 @@ class ParallelOpenPalmMixin(AlgoComponentMpiDecoMixin):
             nodes=1,
             tasks=self.env.VORTEX_OPENPALM_DRV_TASKS or 1,
             openmp=self.env.VORTEX_OPENPALM_DRV_OPENMP or 1,
-            allowbind=opts.pop('palmdrv_bind',
-                               self.env.get('VORTEX_OPENPALM_DRV_BIND',
-                                            self.openpalm_binddriver)),
+            allowbind=opts.pop(
+                "palmdrv_bind",
+                self.env.get(
+                    "VORTEX_OPENPALM_DRV_BIND", self.openpalm_binddriver
+                ),
+            ),
         )
-        driver.options = {x[8:]: opts[x]
-                          for x in opts.keys() if x.startswith('palmdrv_')}
+        driver.options = {
+            x[8:]: opts[x] for x in opts.keys() if x.startswith("palmdrv_")
+        }
         driver.master = self._actual_openpalm_driver
         self.system.xperm(driver.master, force=True)
         bins.insert(0, driver)
@@ -2080,57 +2388,75 @@ class ParallelOpenPalmMixin(AlgoComponentMpiDecoMixin):
             # the driver
             # NB: If multiple binaries are provided, the user must do this by
             # himself (i.e. leave enough room for the driver's task).
-            if 'nn' in master.options:
-                master.options['nn'] = master.options['nn'] - 1
+            if "nn" in master.options:
+                master.options["nn"] = master.options["nn"] - 1
             else:
                 # Ok, tweak nprocs instead (an envelope might be defined)
                 try:
                     nprocs = master.nprocs
                 except mpitools.MpiException:
-                    logger.error('Neither the "nn" option nor the nprocs is ' +
-                                 'available for the master binary. Consequently ' +
-                                 'it can be fixed...')
+                    logger.error(
+                        'Neither the "nn" option nor the nprocs is '
+                        + "available for the master binary. Consequently "
+                        + "it can be fixed..."
+                    )
                 else:
-                    master.options['np'] = nprocs - driver.nprocs
+                    master.options["np"] = nprocs - driver.nprocs
         return bins
 
-    _MIXIN_MPIBINS_HOOKS = (_bootstrap_mpibins_openpalm_hack, )
+    _MIXIN_MPIBINS_HOOKS = (_bootstrap_mpibins_openpalm_hack,)
 
-    def _bootstrap_mpienvelope_openpalm_posthack(self, env, env0, rh, opts, mpi):
+    def _bootstrap_mpienvelope_openpalm_posthack(
+        self, env, env0, rh, opts, mpi
+    ):
         """
         Tweak the MPI envelope in order to execute the OpenPALM driver on the
         appropriate node.
         """
-        master = mpi.binaries[1]  # The first "real" program that will be launched
+        master = mpi.binaries[
+            1
+        ]  # The first "real" program that will be launched
         driver = mpi.binaries[0]  # The OpenPALM driver
         if self.openpalm_overcommit:
             # Execute the driver on the first compute node
             if env or env0:
                 env = env or copy.deepcopy(env0)
                 # An envelope is already defined... update it
-                if not ('nn' in env[0] and 'nnp' in env[0]):
-                    raise AlgoComponentError("'nn' and 'nnp' must be defined in the envelope")
-                if env[0]['nn'] > 1:
-                    env[0]['nn'] -= 1
+                if not ("nn" in env[0] and "nnp" in env[0]):
+                    raise AlgoComponentError(
+                        "'nn' and 'nnp' must be defined in the envelope"
+                    )
+                if env[0]["nn"] > 1:
+                    env[0]["nn"] -= 1
                     newenv = copy.copy(env[0])
-                    newenv['nn'] = 1
-                    newenv['nnp'] += driver.nprocs
+                    newenv["nn"] = 1
+                    newenv["nnp"] += driver.nprocs
                     env.insert(0, newenv)
                 else:
-                    env[0]['nnp'] += driver.nprocs
+                    env[0]["nnp"] += driver.nprocs
             else:
                 # Setup a new envelope
-                if not ('nn' in master.options and 'nnp' in master.options):
-                    raise AlgoComponentError("'nn' and 'nnp' must be defined for the master executable")
-                env = [dict(nn=1,
-                            nnp=master.options['nnp'] + driver.nprocs,
-                            openmp=master.options.get('openmp', 1))]
-                if master.options['nn'] > 1:
-                    env.append(dict(nn=master.options['nn'] - 1,
-                                    nnp=master.options['nnp'],
-                                    openmp=master.options.get('openmp', 1)))
+                if not ("nn" in master.options and "nnp" in master.options):
+                    raise AlgoComponentError(
+                        "'nn' and 'nnp' must be defined for the master executable"
+                    )
+                env = [
+                    dict(
+                        nn=1,
+                        nnp=master.options["nnp"] + driver.nprocs,
+                        openmp=master.options.get("openmp", 1),
+                    )
+                ]
+                if master.options["nn"] > 1:
+                    env.append(
+                        dict(
+                            nn=master.options["nn"] - 1,
+                            nnp=master.options["nnp"],
+                            openmp=master.options.get("openmp", 1),
+                        )
+                    )
                 if len(mpi.binaries) > 2:
                     env.extend([b.options for b in mpi.binaries[2:]])
         return env
 
-    _MIXIN_MPIENVELOPE_POSTHOOKS = (_bootstrap_mpienvelope_openpalm_posthack, )
+    _MIXIN_MPIENVELOPE_POSTHOOKS = (_bootstrap_mpienvelope_openpalm_posthack,)

--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -1531,7 +1531,6 @@ class SRun(MpiTool):
         :param list[str] cmdl: the command line as a list
         """
         # Simple case, only one envelope description
-        has_bin_groups = not all([b.group is None for b in self.binaries])
         openmps = {b.options.get("openmp", 1) for b in self.binaries}
         if (
             len(self.envelope) == 1

--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -92,6 +92,7 @@ logger = loggers.getLogger(__name__)
 
 class MpiException(Exception):
     """Raise an exception in the parallel execution mode."""
+
     pass
 
 
@@ -99,89 +100,98 @@ class MpiTool(footprints.FootprintBase):
     """Root class for any :class:`MpiTool` subclass."""
 
     _abstract = True
-    _collector = ('mpitool', )
+    _collector = ("mpitool",)
     _footprint = dict(
-        info = 'MpiTool class in charge of a particular MPI implementation',
-        attr = dict(
-            sysname = dict(
-                info     = 'The current OS name (e.g. Linux)',
+        info="MpiTool class in charge of a particular MPI implementation",
+        attr=dict(
+            sysname=dict(
+                info="The current OS name (e.g. Linux)",
             ),
-            mpiname = dict(
-                info     = 'The MPI implementation one wishes to use',
+            mpiname=dict(
+                info="The MPI implementation one wishes to use",
             ),
-            mpilauncher = dict(
-                info     = 'The MPI launcher command to be used',
-                optional = True
+            mpilauncher=dict(
+                info="The MPI launcher command to be used", optional=True
             ),
-            mpiopts = dict(
-                info     = 'Extra arguments for the MPI command',
-                optional = True,
-                default  = ''
+            mpiopts=dict(
+                info="Extra arguments for the MPI command",
+                optional=True,
+                default="",
             ),
-            mpiwrapstd = dict(
-                info            = "When using the Vortex' global wrapper redirect stderr/stdout",
-                type            = bool,
-                optional        = True,
-                default         = False,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            mpiwrapstd=dict(
+                info="When using the Vortex' global wrapper redirect stderr/stdout",
+                type=bool,
+                optional=True,
+                default=False,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-            mpibind_topology = dict(
-                optional        = True,
-                default         = "numapacked",
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            mpibind_topology=dict(
+                optional=True,
+                default="numapacked",
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-            optsep = dict(
-                info     = 'Separator between MPI options and the program name',
-                optional = True,
-                default  = '--'
+            optsep=dict(
+                info="Separator between MPI options and the program name",
+                optional=True,
+                default="--",
             ),
-            optprefix = dict(
-                info     = 'MPI options prefix',
-                optional = True,
-                default  = '--'
+            optprefix=dict(
+                info="MPI options prefix", optional=True, default="--"
             ),
-            optmap = dict(
-                info     = ('Mapping between MpiBinaryDescription objects ' +
-                            'internal data and actual command line options'),
-                type     = footprints.FPDict,
-                optional = True,
-                default  = footprints.FPDict(nn='nn', nnp='nnp', openmp='openmp')
+            optmap=dict(
+                info=(
+                    "Mapping between MpiBinaryDescription objects "
+                    + "internal data and actual command line options"
+                ),
+                type=footprints.FPDict,
+                optional=True,
+                default=footprints.FPDict(nn="nn", nnp="nnp", openmp="openmp"),
             ),
-            binsep = dict(
-                info     = 'Separator between multiple binary groups',
-                optional = True,
-                default  = '--'
+            binsep=dict(
+                info="Separator between multiple binary groups",
+                optional=True,
+                default="--",
             ),
-            basics = dict(
-                type     = footprints.FPList,
-                optional = True,
-                default  = footprints.FPList(['system', 'env', 'target', 'context', 'ticket', ])
+            basics=dict(
+                type=footprints.FPList,
+                optional=True,
+                default=footprints.FPList(
+                    [
+                        "system",
+                        "env",
+                        "target",
+                        "context",
+                        "ticket",
+                    ]
+                ),
             ),
-            bindingmethod = dict(
-                info            = 'How to bind the MPI processes',
-                values          = ['vortex', ],
-                access          = 'rwx',
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            bindingmethod=dict(
+                info="How to bind the MPI processes",
+                values=[
+                    "vortex",
+                ],
+                access="rwx",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-        )
+        ),
     )
 
-    _envelope_bit_kind = 'basicenvelopebit'
-    _envelope_wrapper_tpl = '@envelope_wrapper_default.tpl'
-    _wrapstd_wrapper_tpl = '@wrapstd_wrapper_default.tpl'
-    _envelope_wrapper_name = './global_envelope_wrapper.py'
-    _wrapstd_wrapper_name = './global_wrapstd_wrapper.py'
-    _envelope_rank_var = 'MPIRANK'
+    _envelope_bit_kind = "basicenvelopebit"
+    _envelope_wrapper_tpl = "@envelope_wrapper_default.tpl"
+    _wrapstd_wrapper_tpl = "@wrapstd_wrapper_default.tpl"
+    _envelope_wrapper_name = "./global_envelope_wrapper.py"
+    _wrapstd_wrapper_name = "./global_wrapstd_wrapper.py"
+    _envelope_rank_var = "MPIRANK"
     _supports_manual_ranks_mapping = False
     _needs_mpilib_specific_mpienv = True
 
     def __init__(self, *args, **kw):
         """After parent initialization, set master, options and basics to undefined."""
-        logger.debug('Abstract mpi tool init %s', self.__class__)
+        logger.debug("Abstract mpi tool init %s", self.__class__)
         super().__init__(*args, **kw)
         self._launcher = self.mpilauncher or self.generic_mpiname
         self._binaries = []
@@ -192,29 +202,31 @@ class MpiTool(footprints.FootprintBase):
         self._ranks_map_cache = None
         self._complex_ranks_map = None
         for k in self.basics:
-            self.__dict__['_' + k] = None
+            self.__dict__["_" + k] = None
 
     @property
     def realkind(self):
-        return 'mpitool'
+        return "mpitool"
 
     @property
     def generic_mpiname(self):
-        return self.mpiname.split('-')[0]
+        return self.mpiname.split("-")[0]
 
     def __getattr__(self, key):
         """Have a look to basics values provided by some proxy."""
         if key in self.basics:
-            return getattr(self, '_' + key)
+            return getattr(self, "_" + key)
         else:
-            raise AttributeError('Attribute [%s] is not a basic mpitool attribute' % key)
+            raise AttributeError(
+                "Attribute [%s] is not a basic mpitool attribute" % key
+            )
 
     def import_basics(self, obj, attrs=None):
         """Import some current values such as system, env, target and context from provided ``obj``."""
         if attrs is None:
             attrs = self.basics
         for k in [x for x in attrs if x in self.basics and hasattr(obj, x)]:
-            setattr(self, '_' + k, getattr(obj, k))
+            setattr(self, "_" + k, getattr(obj, k))
         for bin_obj in self.binaries:
             bin_obj.import_basics(obj, attrs=None)
 
@@ -227,7 +239,9 @@ class MpiTool(footprints.FootprintBase):
 
     def _set_launcher(self, value):
         """Set current launcher mpi name. Should be some special trick, so issue a warning."""
-        logger.warning('Setting a new value [%s] to mpi launcher [%s].', value, self)
+        logger.warning(
+            "Setting a new value [%s] to mpi launcher [%s].", value, self
+        )
         self._launcher = value
 
     launcher = property(_get_launcher, _set_launcher)
@@ -242,11 +256,22 @@ class MpiTool(footprints.FootprintBase):
 
     def _set_envelope(self, value):
         """Set the envelope description."""
-        if not (isinstance(value, collections.abc.Iterable) and
-                all([isinstance(b, dict) and
-                     all([bk in ('nn', 'nnp', 'openmp', 'np') for bk in b.keys()])
-                     for b in value])):
-            raise ValueError('This should be an Iterable of dictionaries.')
+        if not (
+            isinstance(value, collections.abc.Iterable)
+            and all(
+                [
+                    isinstance(b, dict)
+                    and all(
+                        [
+                            bk in ("nn", "nnp", "openmp", "np")
+                            for bk in b.keys()
+                        ]
+                    )
+                    for b in value
+                ]
+            )
+        ):
+            raise ValueError("This should be an Iterable of dictionaries.")
         self._valid_envelope(value)
         self._envelope = list()
         for e in value:
@@ -271,22 +296,33 @@ class MpiTool(footprints.FootprintBase):
         for a_bin in self.binaries:
             if a_bin.group is None:
                 # The usual (and easy) case
-                new_envelope.append({k: v for k, v in a_bin.options.items()
-                                     if k in ('nn', 'nnp', 'openmp', 'np')})
+                new_envelope.append(
+                    {
+                        k: v
+                        for k, v in a_bin.options.items()
+                        if k in ("nn", "nnp", "openmp", "np")
+                    }
+                )
             elif a_bin.group in groups:
                 # Deal with group of binaries
                 group = groups.pop(a_bin.group)
-                n_nodes = {g_bin.options.get('nn', None) for g_bin in group}
+                n_nodes = {g_bin.options.get("nn", None) for g_bin in group}
                 if None in n_nodes:
-                    raise ValueError('To build a proper envelope, ' +
-                                     '"nn" needs to be specified in all binaries')
+                    raise ValueError(
+                        "To build a proper envelope, "
+                        + '"nn" needs to be specified in all binaries'
+                    )
                 done_nodes = 0
                 for n_node in sorted(n_nodes):
                     new_desc = {}
-                    new_desc['nn'] = n_node - done_nodes
-                    new_desc['nnp'] = 0
-                    for g_bin in [g_bin for g_bin in group if g_bin.options['nn'] >= n_node]:
-                        new_desc['nnp'] += g_bin.options['nnp']
+                    new_desc["nn"] = n_node - done_nodes
+                    new_desc["nnp"] = 0
+                    for g_bin in [
+                        g_bin
+                        for g_bin in group
+                        if g_bin.options["nn"] >= n_node
+                    ]:
+                        new_desc["nnp"] += g_bin.options["nnp"]
                     new_envelope.append(new_desc)
                     done_nodes = n_node
         self.envelope = new_envelope
@@ -301,17 +337,27 @@ class MpiTool(footprints.FootprintBase):
 
     def _set_binaries(self, value):
         """Set the list of :class:`MpiBinaryDescription` objects associated with this instance."""
-        if not (isinstance(value, collections.abc.Iterable) and
-                all([isinstance(b, MpiBinary) for b in value])):
-            raise ValueError('This should be an Iterable of MpiBinary instances.')
+        if not (
+            isinstance(value, collections.abc.Iterable)
+            and all([isinstance(b, MpiBinary) for b in value])
+        ):
+            raise ValueError(
+                "This should be an Iterable of MpiBinary instances."
+            )
         has_bin_groups = not all([b.group is None for b in value])
         if not (self._supports_manual_ranks_mapping or not has_bin_groups):
-            raise ValueError('Binary groups are not supported by this MpiTool class')
+            raise ValueError(
+                "Binary groups are not supported by this MpiTool class"
+            )
         has_bin_distribution = not all([b.distribution is None for b in value])
-        if not (self._supports_manual_ranks_mapping or not has_bin_distribution):
-            raise ValueError('Binary distribution option is not supported by this MpiTool class')
+        if not (
+            self._supports_manual_ranks_mapping or not has_bin_distribution
+        ):
+            raise ValueError(
+                "Binary distribution option is not supported by this MpiTool class"
+            )
         self._binaries = value
-        if not self.envelope and self.bindingmethod == 'vortex':
+        if not self.envelope and self.bindingmethod == "vortex":
             self._set_envelope_from_binaries()
         elif not self.envelope and (has_bin_groups or has_bin_distribution):
             self._set_envelope_from_binaries()
@@ -328,8 +374,12 @@ class MpiTool(footprints.FootprintBase):
     def _mpilib_data(self):
         """From the binaries, try to detect MPI library and mpirun paths."""
         if self._mpilib_data_cache is None:
-            mpilib_guesses = ('libmpi.so', 'libmpi_mt.so',
-                              'libmpi_dbg.so', 'libmpi_dbg_mt.so')
+            mpilib_guesses = (
+                "libmpi.so",
+                "libmpi_mt.so",
+                "libmpi_dbg.so",
+                "libmpi_dbg_mt.so",
+            )
             shp = self.system.path
             mpilib_data = set()
             for binary in self.binaries:
@@ -351,19 +401,24 @@ class MpiTool(footprints.FootprintBase):
                     mpilib = shp.normpath(mpilib)
                     mpitoolsdir = None
                     mpidir = shp.dirname(shp.dirname(mpilib))
-                    if shp.exists(shp.join(mpidir, 'bin', 'mpirun')):
-                        mpitoolsdir = shp.join(mpidir, 'bin')
-                    if not mpitoolsdir and shp.exists(shp.join(mpidir, '..', 'bin', 'mpirun')):
-                        mpitoolsdir = shp.normpath(shp.join(mpidir, '..', 'bin'))
+                    if shp.exists(shp.join(mpidir, "bin", "mpirun")):
+                        mpitoolsdir = shp.join(mpidir, "bin")
+                    if not mpitoolsdir and shp.exists(
+                        shp.join(mpidir, "..", "bin", "mpirun")
+                    ):
+                        mpitoolsdir = shp.normpath(
+                            shp.join(mpidir, "..", "bin")
+                        )
                     if mpilib and mpitoolsdir:
-                        mpilib_data.add((shp.realpath(mpilib),
-                                         shp.realpath(mpitoolsdir)))
+                        mpilib_data.add(
+                            (shp.realpath(mpilib), shp.realpath(mpitoolsdir))
+                        )
             # All the binary must use the same library !
             if len(mpilib_data) == 0:
-                logger.info('No MPI library was detected.')
+                logger.info("No MPI library was detected.")
                 self._mpilib_data_cache = ()
             elif len(mpilib_data) > 1:
-                logger.error('Multiple MPI library were detected.')
+                logger.error("Multiple MPI library were detected.")
                 self._mpilib_data_cache = ()
             else:
                 self._mpilib_data_cache = mpilib_data.pop()
@@ -373,8 +428,11 @@ class MpiTool(footprints.FootprintBase):
         for line in rclines:
             matched = regex.match(line)
             if matched:
-                logger.info('MPI implementation detected: %s (%s)',
-                            which, ' '.join(matched.groups()))
+                logger.info(
+                    "MPI implementation detected: %s (%s)",
+                    which,
+                    " ".join(matched.groups()),
+                )
                 return [which] + [int(res) for res in matched.groups()]
         return False
 
@@ -386,7 +444,7 @@ class MpiTool(footprints.FootprintBase):
             mpi_lib, mpi_tools_dir = self._mpilib_data()
             ld_libs_extra = set()
             sh = self.system
-            mpirun_path = sh.path.join(mpi_tools_dir, 'mpirun')
+            mpirun_path = sh.path.join(mpi_tools_dir, "mpirun")
             if sh.path.exists(mpirun_path):
                 try:
                     libs = sh.ldd(mpirun_path)
@@ -399,30 +457,47 @@ class MpiTool(footprints.FootprintBase):
                         for lib, libpath in sh.ldd(binary.master).items():
                             if libpath:
                                 libscache[lib] = sh.path.dirname(libpath)
-                    for missing_lib in [lib for lib, libname in libs.items()
-                                        if libname is None]:
+                    for missing_lib in [
+                        lib for lib, libname in libs.items() if libname is None
+                    ]:
                         if missing_lib in libscache:
                             ld_libs_extra.add(libscache[missing_lib])
                 with self.env.clone() as localenv:
                     for libpath in ld_libs_extra:
-                        localenv.setgenericpath('LD_LIBRARY_PATH', libpath)
-                    rc = sh.spawn([mpirun_path, '--version'], output=True, fatal=False)
+                        localenv.setgenericpath("LD_LIBRARY_PATH", libpath)
+                    rc = sh.spawn(
+                        [mpirun_path, "--version"], output=True, fatal=False
+                    )
                 if rc:
                     id_res = self._mpilib_match_result(
-                        re.compile(r'^.*Intel.*MPI.*Version\s+(\d+)\s+Update\s+(\d+)',
-                                   re.IGNORECASE),
-                        rc, 'intelmpi')
+                        re.compile(
+                            r"^.*Intel.*MPI.*Version\s+(\d+)\s+Update\s+(\d+)",
+                            re.IGNORECASE,
+                        ),
+                        rc,
+                        "intelmpi",
+                    )
                     id_res = id_res or self._mpilib_match_result(
-                        re.compile(r'^.*Open\s*MPI.*\s+(\d+)\.(\d+)(?:\.(\d+))?',
-                                   re.IGNORECASE),
-                        rc, 'openmpi')
+                        re.compile(
+                            r"^.*Open\s*MPI.*\s+(\d+)\.(\d+)(?:\.(\d+))?",
+                            re.IGNORECASE,
+                        ),
+                        rc,
+                        "openmpi",
+                    )
                     if id_res:
                         ld_libs_extra = tuple(sorted(ld_libs_extra))
-                        self._mpilib_identification_cache = tuple([mpi_lib, mpi_tools_dir, ld_libs_extra] +
-                                                                  id_res)
+                        self._mpilib_identification_cache = tuple(
+                            [mpi_lib, mpi_tools_dir, ld_libs_extra] + id_res
+                        )
             if self._mpilib_identification_cache is None:
                 ld_libs_extra = tuple(sorted(ld_libs_extra))
-                self._mpilib_identification_cache = (mpi_lib, mpi_tools_dir, ld_libs_extra, 'unknown')
+                self._mpilib_identification_cache = (
+                    mpi_lib,
+                    mpi_tools_dir,
+                    ld_libs_extra,
+                    "unknown",
+                )
         return self._mpilib_identification_cache
 
     def _get_sources(self):
@@ -432,7 +507,7 @@ class MpiTool(footprints.FootprintBase):
     def _set_sources(self, value):
         """Set the list of of directories that may contain source files."""
         if not isinstance(value, collections.abc.Iterable):
-            raise ValueError('This should be an Iterable.')
+            raise ValueError("This should be an Iterable.")
         self._sources = value
 
     sources = property(_get_sources, _set_sources)
@@ -446,14 +521,16 @@ class MpiTool(footprints.FootprintBase):
         klast = None
         options = collections.defaultdict(list)
         for optdef in shlex.split(self._actual_mpiopts()):
-            if optdef.startswith('-'):
-                optdef = optdef.lstrip('-')
+            if optdef.startswith("-"):
+                optdef = optdef.lstrip("-")
                 options[optdef].append([])
                 klast = optdef
             elif klast is not None:
                 options[klast][-1].append(optdef)
             else:
-                raise MpiException('Badly shaped mpi option around {!s}'.format(optdef))
+                raise MpiException(
+                    "Badly shaped mpi option around {!s}".format(optdef)
+                )
         return options
 
     def _hook_binary_mpiopts(self, binary, options):
@@ -466,14 +543,18 @@ class MpiTool(footprints.FootprintBase):
         if self._ranks_map_cache is None:
             self._complex_ranks_map = False
             if not self.envelope:
-                raise RuntimeError('Ranks mapping should always be used within an envelope.')
+                raise RuntimeError(
+                    "Ranks mapping should always be used within an envelope."
+                )
             # First deal with bingroups
             ranks_map = dict()
             has_bin_groups = not all([b.group is None for b in self.binaries])
             cursor = 0  # The MPI rank we are currently processing
             if has_bin_groups:
                 if not self._supports_manual_ranks_mapping:
-                    raise RuntimeError('This MpiTool class does not supports ranks mapping.')
+                    raise RuntimeError(
+                        "This MpiTool class does not supports ranks mapping."
+                    )
                 self._complex_ranks_map = True
                 cursor0 = 0  # The first available "real" slot
                 group_cache = collections.defaultdict(list)
@@ -487,24 +568,42 @@ class MpiTool(footprints.FootprintBase):
                         if not reserved:
                             # It is the first time this group of binaries is seen
                             # Find out what are the binaries in this group
-                            bin_buddies = [bin_b for bin_b in self.binaries
-                                           if bin_b.group == a_bin.group]
-                            if all(['nn' in bin_b.options for bin_b in bin_buddies]):
+                            bin_buddies = [
+                                bin_b
+                                for bin_b in self.binaries
+                                if bin_b.group == a_bin.group
+                            ]
+                            if all(
+                                [
+                                    "nn" in bin_b.options
+                                    for bin_b in bin_buddies
+                                ]
+                            ):
                                 # Each of the binary descriptions should define the number of nodes
-                                max_nn = max([bin_b.options['nn'] for bin_b in bin_buddies])
+                                max_nn = max(
+                                    [
+                                        bin_b.options["nn"]
+                                        for bin_b in bin_buddies
+                                    ]
+                                )
                                 for i_node in range(max_nn):
                                     for bin_b in bin_buddies:
-                                        if bin_b.options['nn'] > i_node:
-                                            group_cache[bin_b].extend(range(cursor0,
-                                                                            cursor0 +
-                                                                            bin_b.options['nnp']))
-                                            cursor0 += bin_b.options['nnp']
+                                        if bin_b.options["nn"] > i_node:
+                                            group_cache[bin_b].extend(
+                                                range(
+                                                    cursor0,
+                                                    cursor0
+                                                    + bin_b.options["nnp"],
+                                                )
+                                            )
+                                            cursor0 += bin_b.options["nnp"]
                             else:
                                 # If the number of nodes is not defined, revert to the number of tasks.
                                 # This will probably result in strange results !
                                 for bin_b in bin_buddies:
-                                    group_cache[bin_b].extend(range(cursor0,
-                                                                    cursor0 + bin_b.nprocs))
+                                    group_cache[bin_b].extend(
+                                        range(cursor0, cursor0 + bin_b.nprocs)
+                                    )
                                     cursor0 += bin_b.nprocs
                             reserved = group_cache[a_bin]
                     for rank in range(a_bin.nprocs):
@@ -517,37 +616,58 @@ class MpiTool(footprints.FootprintBase):
                         ranks_map[rank + cursor] = rank + cursor
                     cursor += a_bin.nprocs
             # Then deal with distribution
-            do_bin_distribution = not all([b.distribution in (None, "continuous")
-                                           for b in self.binaries])
+            do_bin_distribution = not all(
+                [b.distribution in (None, "continuous") for b in self.binaries]
+            )
             if self._complex_ranks_map or do_bin_distribution:
                 if not self.envelope:
-                    raise RuntimeError('Ranks mapping shoudl always be used within an envelope.')
+                    raise RuntimeError(
+                        "Ranks mapping shoudl always be used within an envelope."
+                    )
             if do_bin_distribution:
                 if not self._supports_manual_ranks_mapping:
-                    raise RuntimeError('This MpiTool class does not supports ranks mapping.')
+                    raise RuntimeError(
+                        "This MpiTool class does not supports ranks mapping."
+                    )
                 self._complex_ranks_map = True
-                if all(['nn' in b.options and 'nnp' in b.options for b in self.envelope]):
+                if all(
+                    [
+                        "nn" in b.options and "nnp" in b.options
+                        for b in self.envelope
+                    ]
+                ):
                     # Extract node information
                     node_cursor = 0
                     nodes_id = list()
                     for e_bit in self.envelope:
-                        for _ in range(e_bit.options['nn']):
-                            nodes_id.extend([node_cursor, ] * e_bit.options['nnp'])
+                        for _ in range(e_bit.options["nn"]):
+                            nodes_id.extend(
+                                [
+                                    node_cursor,
+                                ]
+                                * e_bit.options["nnp"]
+                            )
                             node_cursor += 1
                     # Re-order ranks given the distribution
                     cursor = 0
                     for a_bin in self.binaries:
                         if a_bin.distribution == "roundrobin":
                             # The current list of ranks
-                            actual_ranks = [ranks_map[i]
-                                            for i in range(cursor, cursor + a_bin.nprocs)]
+                            actual_ranks = [
+                                ranks_map[i]
+                                for i in range(cursor, cursor + a_bin.nprocs)
+                            ]
                             # Find the node number associated with each rank
-                            nodes_dict = collections.defaultdict(collections.deque)
+                            nodes_dict = collections.defaultdict(
+                                collections.deque
+                            )
                             for rank in actual_ranks:
                                 nodes_dict[nodes_id[rank]].append(rank)
                             # Create a new list of ranks in a round-robin manner
                             actual_ranks = list()
-                            iter_nodes = itertools.cycle(sorted(nodes_dict.keys()))
+                            iter_nodes = itertools.cycle(
+                                sorted(nodes_dict.keys())
+                            )
                             for _ in range(a_bin.nprocs):
                                 av_ranks = None
                                 while not av_ranks:
@@ -558,8 +678,10 @@ class MpiTool(footprints.FootprintBase):
                                 ranks_map[cursor + i] = actual_ranks[i]
                         cursor += a_bin.nprocs
                 else:
-                    logger.warning('Cannot enforce binary distribution if the envelope' +
-                                   'does not contain nn/nnp information')
+                    logger.warning(
+                        "Cannot enforce binary distribution if the envelope"
+                        + "does not contain nn/nnp information"
+                    )
             # Cache the final result !
             self._ranks_map_cache = ranks_map
         return self._ranks_map_cache
@@ -577,10 +699,10 @@ class MpiTool(footprints.FootprintBase):
         if not self.mpiwrapstd:
             return None
         # Create the launchwrapper
-        wtpl = config.load_template(self.ticket,
-                                    self._wrapstd_wrapper_tpl,
-                                    encoding='utf-8')
-        with open(self._wrapstd_wrapper_name, 'w', encoding='utf-8') as fhw:
+        wtpl = config.load_template(
+            self.ticket, self._wrapstd_wrapper_tpl, encoding="utf-8"
+        )
+        with open(self._wrapstd_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
                 wtpl.substitute(
                     python=self.system.executable,
@@ -599,12 +721,14 @@ class MpiTool(footprints.FootprintBase):
         wrapstd = self._wrapstd_mkwrapper()
         for bin_obj in self.binaries:
             if bin_obj.master is None:
-                raise MpiException('No master defined before launching MPI')
+                raise MpiException("No master defined before launching MPI")
             # If there are no options, do not bother...
             if len(bin_obj.expanded_options()):
                 if effective > 0 and self.binsep:
                     cmdl.append(self.binsep)
-                e_options = self._hook_binary_mpiopts(bin_obj, bin_obj.expanded_options())
+                e_options = self._hook_binary_mpiopts(
+                    bin_obj, bin_obj.expanded_options()
+                )
                 for k in sorted(e_options.keys()):
                     if k in self.optmap:
                         cmdl.append(self.optprefix + str(self.optmap[k]))
@@ -620,8 +744,9 @@ class MpiTool(footprints.FootprintBase):
 
     def _envelope_fix_envelope_bit(self, e_bit, e_desc):
         """Set the envelope fake binary options."""
-        e_bit.options = {k: v for k, v in e_desc.items()
-                         if k not in ('openmp', 'np')}
+        e_bit.options = {
+            k: v for k, v in e_desc.items() if k not in ("openmp", "np")
+        }
         e_bit.master = self._envelope_wrapper_name
 
     def _envelope_mkwrapper_todostack(self):
@@ -630,18 +755,23 @@ class MpiTool(footprints.FootprintBase):
         todostack = dict()
         for bin_obj in self.binaries:
             if bin_obj.master is None:
-                raise MpiException('No master defined before launching MPI')
+                raise MpiException("No master defined before launching MPI")
             # If there are no options, do not bother...
             if bin_obj.options and bin_obj.nprocs != 0:
                 if not bin_obj.nprocs:
-                    raise ValueError('nranks must be provided when using envelopes')
+                    raise ValueError(
+                        "nranks must be provided when using envelopes"
+                    )
                 for mpirank in range(ranksidx, ranksidx + bin_obj.nprocs):
                     if bin_obj.allowbind:
-                        ranks_bsize[mpirank] = bin_obj.options.get('openmp', 1)
+                        ranks_bsize[mpirank] = bin_obj.options.get("openmp", 1)
                     else:
                         ranks_bsize[mpirank] = -1
-                    todostack[mpirank] = (bin_obj.master, bin_obj.arguments,
-                                          bin_obj.options.get('openmp', None))
+                    todostack[mpirank] = (
+                        bin_obj.master,
+                        bin_obj.arguments,
+                        bin_obj.options.get("openmp", None),
+                    )
                 ranksidx += bin_obj.nprocs
         return todostack, ranks_bsize
 
@@ -651,18 +781,25 @@ class MpiTool(footprints.FootprintBase):
         ranks_idx = 0
         dispensers_map = dict()
         for e_bit in self.envelope:
-            if 'nn' in e_bit.options and 'nnp' in e_bit.options:
-                for _ in range(e_bit.options['nn']):
-                    cpu_disp = self.system.cpus_ids_dispenser(topology=self.mpibind_topology)
+            if "nn" in e_bit.options and "nnp" in e_bit.options:
+                for _ in range(e_bit.options["nn"]):
+                    cpu_disp = self.system.cpus_ids_dispenser(
+                        topology=self.mpibind_topology
+                    )
                     if not cpu_disp:
-                        raise MpiException('Unable to detect the CPU layout with topology: {:s}'
-                                           .format(self.mpibind_topology, ))
-                    for _ in range(e_bit.options['nnp']):
+                        raise MpiException(
+                            "Unable to detect the CPU layout with topology: {:s}".format(
+                                self.mpibind_topology,
+                            )
+                        )
+                    for _ in range(e_bit.options["nnp"]):
                         dispensers_map[ranks_idx] = (cpu_disp, totalnodes)
                         ranks_idx += 1
                     totalnodes += 1
             else:
-                logger.error("Cannot compute a proper binding without nn/nnp information")
+                logger.error(
+                    "Cannot compute a proper binding without nn/nnp information"
+                )
                 raise MpiException("Vortex binding error.")
         return dispensers_map
 
@@ -674,72 +811,111 @@ class MpiTool(footprints.FootprintBase):
             # Actually generate the binding map
             ranks_idx = 0
             for e_bit in self.envelope:
-                for _ in range(e_bit.options['nn']):
-                    for _ in range(e_bit.options['nnp']):
-                        cpu_disp, i_node = dispensers_map[self._ranks_mapping[ranks_idx]]
+                for _ in range(e_bit.options["nn"]):
+                    for _ in range(e_bit.options["nnp"]):
+                        cpu_disp, i_node = dispensers_map[
+                            self._ranks_mapping[ranks_idx]
+                        ]
                         if ranks_bsize.get(ranks_idx, 1) != -1:
                             try:
-                                binding_stack[ranks_idx] = cpu_disp(ranks_bsize.get(ranks_idx, 1))
+                                binding_stack[ranks_idx] = cpu_disp(
+                                    ranks_bsize.get(ranks_idx, 1)
+                                )
                             except (StopIteration, IndexError):
                                 # When CPU dispensers are exhausted (it might happened if more tasks
                                 # than available CPUs are requested).
-                                dispensers_map = self._envelope_mkwrapper_cpu_dispensers()
-                                cpu_disp, i_node = dispensers_map[self._ranks_mapping[ranks_idx]]
-                                binding_stack[ranks_idx] = cpu_disp(ranks_bsize.get(ranks_idx, 1))
+                                dispensers_map = (
+                                    self._envelope_mkwrapper_cpu_dispensers()
+                                )
+                                cpu_disp, i_node = dispensers_map[
+                                    self._ranks_mapping[ranks_idx]
+                                ]
+                                binding_stack[ranks_idx] = cpu_disp(
+                                    ranks_bsize.get(ranks_idx, 1)
+                                )
                         else:
-                            binding_stack[ranks_idx] = set(self.system.cpus_info.cpus.keys())
+                            binding_stack[ranks_idx] = set(
+                                self.system.cpus_info.cpus.keys()
+                            )
                         binding_node[ranks_idx] = i_node
                         ranks_idx += 1
         return binding_stack, binding_node
 
     def _envelope_mkwrapper_tplsubs(self, todostack, bindingstack):
-        return dict(python=self.system.executable,
-                    sitepath=self.system.path.join(self.ticket.glove.siteroot, 'site'),
-                    mpirankvariable=self._envelope_rank_var,
-                    todolist=("\n".join(["  {:d}: ('{:s}', [{:s}], {:s}),".format(
-                                         mpi_r,
-                                         what[0],
-                                         ', '.join(["'{:s}'".format(a) for a in what[1]]),
-                                         str(what[2]))
-                                         for mpi_r, what in sorted(todostack.items())])),
-                    bindinglist=("\n".join(["  {:d}: [{:s}],".format(
-                                            mpi_r,
-                                            ', '.join(['{:d}'.format(a) for a in what]))
-                                            for mpi_r, what in sorted(bindingstack.items())])))
+        return dict(
+            python=self.system.executable,
+            sitepath=self.system.path.join(self.ticket.glove.siteroot, "site"),
+            mpirankvariable=self._envelope_rank_var,
+            todolist=(
+                "\n".join(
+                    [
+                        "  {:d}: ('{:s}', [{:s}], {:s}),".format(
+                            mpi_r,
+                            what[0],
+                            ", ".join(["'{:s}'".format(a) for a in what[1]]),
+                            str(what[2]),
+                        )
+                        for mpi_r, what in sorted(todostack.items())
+                    ]
+                )
+            ),
+            bindinglist=(
+                "\n".join(
+                    [
+                        "  {:d}: [{:s}],".format(
+                            mpi_r, ", ".join(["{:d}".format(a) for a in what])
+                        )
+                        for mpi_r, what in sorted(bindingstack.items())
+                    ]
+                )
+            ),
+        )
 
     def _envelope_mkwrapper(self, cmdl):
         """Generate the wrapper script used when an envelope is defined."""
         # Generate the dictionary that associate rank numbers and programs
         todostack, ranks_bsize = self._envelope_mkwrapper_todostack()
         # Generate the binding stuff
-        bindingstack, bindingnode = self._envelope_mkwrapper_bindingstack(ranks_bsize)
+        bindingstack, bindingnode = self._envelope_mkwrapper_bindingstack(
+            ranks_bsize
+        )
         # Print binding details
-        logger.debug('Vortex Envelope Mechanism is used' +
-                     (' & vortex binding is on.' if bindingstack else '.'))
-        env_info_head = '{:5s} {:24s} {:4s}'.format('#rank', 'binary_name', '#OMP')
-        env_info_fmt = '{:5d} {:24s} {:4s}'
+        logger.debug(
+            "Vortex Envelope Mechanism is used"
+            + (" & vortex binding is on." if bindingstack else ".")
+        )
+        env_info_head = "{:5s} {:24s} {:4s}".format(
+            "#rank", "binary_name", "#OMP"
+        )
+        env_info_fmt = "{:5d} {:24s} {:4s}"
         if bindingstack:
-            env_info_head += ' {:5s}   {:s}'.format('#node', 'bindings_list')
-            env_info_fmt2 = ' {:5d}   {:s}'
+            env_info_head += " {:5s}   {:s}".format("#node", "bindings_list")
+            env_info_fmt2 = " {:5d}   {:s}"
         binding_str = [env_info_head]
         for i_rank in sorted(todostack):
-            entry_str = env_info_fmt.format(i_rank,
-                                            self.system.path.basename(todostack[i_rank][0])[:24],
-                                            str(todostack[i_rank][2]))
+            entry_str = env_info_fmt.format(
+                i_rank,
+                self.system.path.basename(todostack[i_rank][0])[:24],
+                str(todostack[i_rank][2]),
+            )
             if bindingstack:
-                entry_str += env_info_fmt2.format(bindingnode[i_rank],
-                                                  ','.join([str(c)
-                                                            for c in sorted(bindingstack[i_rank])]))
+                entry_str += env_info_fmt2.format(
+                    bindingnode[i_rank],
+                    ",".join([str(c) for c in sorted(bindingstack[i_rank])]),
+                )
             binding_str.append(entry_str)
-        logger.debug('Here are the envelope details:\n%s', '\n'.join(binding_str))
+        logger.debug(
+            "Here are the envelope details:\n%s", "\n".join(binding_str)
+        )
         # Create the launchwrapper
-        wtpl = config.load_template(self.ticket,
-                                    self._envelope_wrapper_tpl,
-                                    encoding='utf-8')
-        with open(self._envelope_wrapper_name, 'w', encoding='utf-8') as fhw:
+        wtpl = config.load_template(
+            self.ticket, self._envelope_wrapper_tpl, encoding="utf-8"
+        )
+        with open(self._envelope_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
-                wtpl.substitute(**self._envelope_mkwrapper_tplsubs(todostack,
-                                                                   bindingstack))
+                wtpl.substitute(
+                    **self._envelope_mkwrapper_tplsubs(todostack, bindingstack)
+                )
             )
         self.system.xperm(self._envelope_wrapper_name, force=True)
         return self._envelope_wrapper_name
@@ -754,7 +930,9 @@ class MpiTool(footprints.FootprintBase):
         for effective, e_bit in enumerate(self.envelope):
             if effective > 0 and self.binsep:
                 cmdl.append(self.binsep)
-            e_options = self._hook_binary_mpiopts(e_bit, e_bit.expanded_options())
+            e_options = self._hook_binary_mpiopts(
+                e_bit, e_bit.expanded_options()
+            )
             for k in sorted(e_options.keys()):
                 if k in self.optmap:
                     cmdl.append(self.optprefix + str(self.optmap[k]))
@@ -773,7 +951,9 @@ class MpiTool(footprints.FootprintBase):
 
     def mkcmdline(self):
         """Builds the MPI command line."""
-        cmdl = [self.launcher, ]
+        cmdl = [
+            self.launcher,
+        ]
         for k, instances in sorted(self._reshaped_mpiopts().items()):
             for instance in instances:
                 cmdl.append(self.optprefix + str(k))
@@ -789,17 +969,23 @@ class MpiTool(footprints.FootprintBase):
         """post-execution cleaning."""
         if self.mpiwrapstd:
             # Deal with standard output/error files
-            for outf in sorted(self.system.glob('vwrap_stdeo.*')):
+            for outf in sorted(self.system.glob("vwrap_stdeo.*")):
                 rank = int(outf[12:])
-                with open(outf,
-                          encoding=locale.getlocale()[1] or 'ascii',
-                          errors='replace') as sfh:
-                    for (i, l) in enumerate(sfh):
+                with open(
+                    outf,
+                    encoding=locale.getlocale()[1] or "ascii",
+                    errors="replace",
+                ) as sfh:
+                    for i, l in enumerate(sfh):
                         if i == 0:
-                            self.system.highlight('rank {:d}: stdout/err'.format(rank))
-                        print(l.rstrip('\n'))
+                            self.system.highlight(
+                                "rank {:d}: stdout/err".format(rank)
+                            )
+                        print(l.rstrip("\n"))
                 self.system.remove(outf)
-        if self.envelope and self.system.path.exists(self._envelope_wrapper_name):
+        if self.envelope and self.system.path.exists(
+            self._envelope_wrapper_name
+        ):
             self.system.remove(self._envelope_wrapper_name)
         if self.mpiwrapstd:
             self.system.remove(self._wrapstd_wrapper_name)
@@ -809,16 +995,24 @@ class MpiTool(footprints.FootprintBase):
 
     def find_namelists(self, opts=None):
         """Find any namelists candidates in actual context inputs."""
-        namcandidates = [x.rh for x in
-                         self.context.sequence.effective_inputs(kind=('namelist', 'namelistfp'))]
-        if opts is not None and 'loop' in opts:
+        namcandidates = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                kind=("namelist", "namelistfp")
+            )
+        ]
+        if opts is not None and "loop" in opts:
             namcandidates = [
-                x for x in namcandidates
-                if (hasattr(x.resource, 'term') and x.resource.term == opts['loop'])
+                x
+                for x in namcandidates
+                if (
+                    hasattr(x.resource, "term")
+                    and x.resource.term == opts["loop"]
+                )
             ]
         else:
-            logger.info('No loop option in current parallel execution.')
-        self.system.highlight('Namelist candidates')
+            logger.info("No loop option in current parallel execution.")
+        self.system.highlight("Namelist candidates")
         for nam in namcandidates:
             nam.quickview()
         return namcandidates
@@ -831,18 +1025,30 @@ class MpiTool(footprints.FootprintBase):
         """MPI information to be written in namelists."""
         for namrh in self.find_namelists(opts):
             namc = namrh.contents
-            changed = self.setup_namelist_delta(namc, namrh.container.actualpath())
+            changed = self.setup_namelist_delta(
+                namc, namrh.container.actualpath()
+            )
             # Call the dedicated method en registered MPI binaries
             for bin_obj in self.binaries:
-                changed = bin_obj.setup_namelist_delta(namc, namrh.container.actualpath()) or changed
+                changed = (
+                    bin_obj.setup_namelist_delta(
+                        namc, namrh.container.actualpath()
+                    )
+                    or changed
+                )
             if changed:
                 if namc.dumps_needs_update:
-                    logger.info('Rewritting the %s namelists file.', namrh.container.actualpath())
+                    logger.info(
+                        "Rewritting the %s namelists file.",
+                        namrh.container.actualpath(),
+                    )
                     namc.rewrite(namrh.container)
 
     def _logged_env_set(self, k, v):
         """Set an environment variable *k* and emit a log message."""
-        logger.info('Setting the "%s" environment variable to "%s"', k.upper(), v)
+        logger.info(
+            'Setting the "%s" environment variable to "%s"', k.upper(), v
+        )
         self.env[k] = v
 
     def _logged_env_del(self, k):
@@ -867,8 +1073,11 @@ class MpiTool(footprints.FootprintBase):
                 try:
                     v = str(v).format(**envsub)
                 except KeyError:
-                    logger.warning("Substitution failed for the environment " +
-                                   "variable %s. Ignoring it.", k)
+                    logger.warning(
+                        "Substitution failed for the environment "
+                        + "variable %s. Ignoring it.",
+                        k,
+                    )
                 else:
                     self._logged_env_set(k, v)
         # Call the dedicated method en registered MPI binaries
@@ -885,56 +1094,60 @@ class MpiTool(footprints.FootprintBase):
 class MpiBinaryDescription(footprints.FootprintBase):
     """Root class for any :class:`MpiBinaryDescription` subclass."""
 
-    _collector = ('mpibinary',)
+    _collector = ("mpibinary",)
     _abstract = True
     _footprint = dict(
-        info = 'Holds information about a given MPI binary',
-        attr = dict(
-            kind = dict(
-                info     = "A free form description of the binary's type",
-                values   = ['basic', ],
+        info="Holds information about a given MPI binary",
+        attr=dict(
+            kind=dict(
+                info="A free form description of the binary's type",
+                values=[
+                    "basic",
+                ],
             ),
-            nodes = dict(
-                info     = "The number of nodes for this MPI binary",
-                type     = int,
-                optional = True,
-                access   = 'rwx'
+            nodes=dict(
+                info="The number of nodes for this MPI binary",
+                type=int,
+                optional=True,
+                access="rwx",
             ),
-            tasks = dict(
-                info     = "The number of tasks per node for this MPI binary",
-                type     = int,
-                optional = True,
-                access   = 'rwx'
+            tasks=dict(
+                info="The number of tasks per node for this MPI binary",
+                type=int,
+                optional=True,
+                access="rwx",
             ),
-            openmp = dict(
-                info     = "The number of threads per task for this MPI binary",
-                type     = int,
-                optional = True,
-                access   = 'rwx'
+            openmp=dict(
+                info="The number of threads per task for this MPI binary",
+                type=int,
+                optional=True,
+                access="rwx",
             ),
-            ranks = dict(
-                info     = "The number of MPI ranks to use (only when working in an envelope)",
-                type     = int,
-                optional = True,
-                access   = 'rwx'
+            ranks=dict(
+                info="The number of MPI ranks to use (only when working in an envelope)",
+                type=int,
+                optional=True,
+                access="rwx",
             ),
-            allowbind = dict(
-                info     = "Allow the MpiTool to bind this executable",
-                type     = bool,
-                optional = True,
-                default  = True,
+            allowbind=dict(
+                info="Allow the MpiTool to bind this executable",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            basics = dict(
-                type     = footprints.FPList,
-                optional = True,
-                default  = footprints.FPList(['system', 'env', 'target', 'context'])
-            )
-        )
+            basics=dict(
+                type=footprints.FPList,
+                optional=True,
+                default=footprints.FPList(
+                    ["system", "env", "target", "context"]
+                ),
+            ),
+        ),
     )
 
     def __init__(self, *args, **kw):
         """After parent initialization, set master and options to undefined."""
-        logger.debug('Abstract mpi tool init %s', self.__class__)
+        logger.debug("Abstract mpi tool init %s", self.__class__)
         super().__init__(*args, **kw)
         self._master = None
         self._arguments = ()
@@ -944,16 +1157,18 @@ class MpiBinaryDescription(footprints.FootprintBase):
     def __getattr__(self, key):
         """Have a look to basics values provided by some proxy."""
         if key in self.basics:
-            return getattr(self, '_' + key)
+            return getattr(self, "_" + key)
         else:
-            raise AttributeError('Attribute [%s] is not a basic mpitool attribute' % key)
+            raise AttributeError(
+                "Attribute [%s] is not a basic mpitool attribute" % key
+            )
 
     def import_basics(self, obj, attrs=None):
         """Import some current values such as system, env, target and context from provided ``obj``."""
         if attrs is None:
             attrs = self.basics
         for k in [x for x in attrs if x in self.basics and hasattr(obj, x)]:
-            setattr(self, '_' + k, getattr(obj, k))
+            setattr(self, "_" + k, getattr(obj, k))
 
     def _get_options(self):
         """Retrieve the current set of MPI options."""
@@ -967,25 +1182,25 @@ class MpiBinaryDescription(footprints.FootprintBase):
         if value is None:
             value = dict()
         if self.ranks is not None:
-            self._options['np'] = self.ranks
+            self._options["np"] = self.ranks
             if self.nodes is not None or self.tasks is not None:
-                raise ValueError('Incompatible options provided.')
+                raise ValueError("Incompatible options provided.")
         else:
             if self.nodes is not None:
-                self._options['nn'] = self.nodes
+                self._options["nn"] = self.nodes
             if self.tasks is not None:
-                self._options['nnp'] = self.tasks
+                self._options["nnp"] = self.tasks
         if self.openmp is not None:
-            self._options['openmp'] = self.openmp
+            self._options["openmp"] = self.openmp
         for k, v in value.items():
-            self._options[k.lstrip('-').lower()] = v
+            self._options[k.lstrip("-").lower()] = v
 
     options = property(_get_options, _set_options)
 
     def expanded_options(self):
         """The MPI options actually used by the :class:`MpiTool` object to generate the command line."""
         options = self.options.copy()
-        options.setdefault('np', self.nprocs)
+        options.setdefault("np", self.nprocs)
         return options
 
     def _get_group(self):
@@ -1001,12 +1216,12 @@ class MpiBinaryDescription(footprints.FootprintBase):
     @property
     def nprocs(self):
         """Figure out what is the effective total number of tasks."""
-        if 'np' in self.options:
-            nbproc = int(self.options['np'])
-        elif 'nnp' in self.options and 'nn' in self.options:
-            nbproc = int(self.options.get('nnp')) * int(self.options.get('nn'))
+        if "np" in self.options:
+            nbproc = int(self.options["np"])
+        elif "nnp" in self.options and "nn" in self.options:
+            nbproc = int(self.options.get("nnp")) * int(self.options.get("nn"))
         else:
-            raise MpiException('Impossible to compute nprocs.')
+            raise MpiException("Impossible to compute nprocs.")
         return nbproc
 
     def _get_master(self):
@@ -1030,7 +1245,7 @@ class MpiBinaryDescription(footprints.FootprintBase):
         elif isinstance(args, collections.abc.Iterable):
             self._arguments = [str(a) for a in args]
         else:
-            raise ValueError('Improper *args* argument provided.')
+            raise ValueError("Improper *args* argument provided.")
 
     arguments = property(_get_arguments, _set_arguments)
 
@@ -1051,9 +1266,11 @@ class MpiEnvelopeBit(MpiBinaryDescription):
     """Set NPROC and NBPROC in namelists given the MPI distribution."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['basicenvelopebit', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "basicenvelopebit",
+                ],
             ),
         )
     )
@@ -1061,10 +1278,10 @@ class MpiEnvelopeBit(MpiBinaryDescription):
 
 class MpiBinary(MpiBinaryDescription):
     _footprint = dict(
-        attr = dict(
+        attr=dict(
             distribution=dict(
                 info="Describes how the various nodes are distributed accross nodes",
-                values=['continuous', 'roundrobin'],
+                values=["continuous", "roundrobin"],
                 optional=True,
             ),
         )
@@ -1075,9 +1292,11 @@ class MpiBinaryBasic(MpiBinary):
     """Set NPROC and NBPROC in namelists given the MPI distribution."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['basicsingle', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "basicsingle",
+                ],
             ),
         )
     )
@@ -1090,10 +1309,12 @@ class MpiBinaryBasic(MpiBinary):
         for nam_block in namcontents.values():
             nam_macros.update(nam_block.macros())
         # Look for relevant once
-        nprocs_macros = ('NPROC', 'NBPROC', 'NTASKS')
+        nprocs_macros = ("NPROC", "NBPROC", "NTASKS")
         if any([n in nam_macros for n in nprocs_macros]):
             for n in nprocs_macros:
-                logger.info('Setup macro %s=%s in %s', n, self.nprocs, namlocal)
+                logger.info(
+                    "Setup macro %s=%s in %s", n, self.nprocs, namlocal
+                )
                 namcontents.setmacro(n, self.nprocs)
             namw = True
         return namw
@@ -1103,16 +1324,18 @@ class MpiBinaryIOServer(MpiBinary):
     """Standard binary description for IO Server binaries."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['ioserv', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ioserv",
+                ],
             ),
         )
     )
 
     def __init__(self, *args, **kw):
         """After parent initialization, set launcher value."""
-        logger.debug('Abstract mpi tool init %s', self.__class__)
+        logger.debug("Abstract mpi tool init %s", self.__class__)
         super().__init__(*args, **kw)
         thisenv = env.current()
         if self.ranks is None:
@@ -1136,28 +1359,22 @@ class MpiRun(MpiTool):
     """Standard MPI launcher on most systems: `mpirun`."""
 
     _footprint = dict(
-        attr = dict(
-            sysname = dict(
-                values  = ['Linux', 'Darwin', 'UnitTestLinux']
+        attr=dict(
+            sysname=dict(values=["Linux", "Darwin", "UnitTestLinux"]),
+            mpiname=dict(
+                values=["mpirun", "mpiperso", "default"],
+                remap=dict(default="mpirun"),
             ),
-            mpiname = dict(
-                values  = ['mpirun', 'mpiperso', 'default'],
-                remap   = dict(
-                    default = 'mpirun'
-                ),
+            optsep=dict(
+                default="",
             ),
-            optsep = dict(
-                default = '',
+            optprefix=dict(
+                default="-",
             ),
-            optprefix = dict(
-                default = '-',
+            optmap=dict(default=footprints.FPDict(np="np", nnp="npernode")),
+            binsep=dict(
+                default=":",
             ),
-            optmap = dict(
-                default  = footprints.FPDict(np='np', nnp='npernode')
-            ),
-            binsep = dict(
-                default = ':',
-            )
         )
     )
 
@@ -1166,50 +1383,51 @@ class SRun(MpiTool):
     """SLURM's srun launcher."""
 
     _footprint = dict(
-        attr = dict(
-            sysname = dict(
-                values  = ['Linux', 'UnitTestLinux']
+        attr=dict(
+            sysname=dict(values=["Linux", "UnitTestLinux"]),
+            mpiname=dict(
+                values=[
+                    "srun",
+                ],
             ),
-            mpiname = dict(
-                values  = ['srun', ],
+            optsep=dict(
+                default="",
             ),
-            optsep = dict(
-                default = '',
+            optprefix=dict(
+                default="--",
             ),
-            optprefix = dict(
-                default = '--',
+            optmap=dict(
+                default=footprints.FPDict(
+                    nn="nodes", nnp="ntasks-per-node", np="ntasks"
+                )
             ),
-            optmap = dict(
-                default  = footprints.FPDict(nn='nodes', nnp='ntasks-per-node', np='ntasks')
+            slurmversion=dict(type=int, optional=True),
+            mpiwrapstd=dict(
+                default=True,
             ),
-            slurmversion = dict(
-                type = int,
-                optional = True
-            ),
-            mpiwrapstd = dict(
-                default         = True,
-            ),
-            bindingmethod = dict(
-                info            = 'How to bind the MPI processes',
-                values          = ['native', 'vortex', ],
-                access          = 'rwx',
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            bindingmethod=dict(
+                info="How to bind the MPI processes",
+                values=[
+                    "native",
+                    "vortex",
+                ],
+                access="rwx",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
         )
     )
 
-    _envelope_nodelist_name = './global_envelope_nodelist'
-    _envelope_rank_var = 'SLURM_PROCID'
+    _envelope_nodelist_name = "./global_envelope_nodelist"
+    _envelope_rank_var = "SLURM_PROCID"
     _supports_manual_ranks_mapping = True
 
     @property
     def _actual_slurmversion(self):
         """Return the slurm major version number."""
-        slurmversion = (
-            self.slurmversion or
-            from_config(section="mpitool", key="slurmversion")
+        slurmversion = self.slurmversion or from_config(
+            section="mpitool", key="slurmversion"
         )
         if not slurmversion:
             raise ValueError("No slurm version specified")
@@ -1217,65 +1435,94 @@ class SRun(MpiTool):
 
     def _set_binaries_hack(self, binaries):
         """Set the list of :class:`MpiBinaryDescription` objects associated with this instance."""
-        if not self.envelope and len([binary for binary in binaries if binary.expanded_options()]) > 1:
+        if (
+            not self.envelope
+            and len(
+                [binary for binary in binaries if binary.expanded_options()]
+            )
+            > 1
+        ):
             self._set_envelope_from_binaries()
 
     def _valid_envelope(self, value):
         """Tweak the envelope ddescription values."""
         for e in value:
-            if not ('nn' in e and 'nnp' in e):
-                raise MpiException("Srun needs a nn/nnp specification to build the envelope.")
+            if not ("nn" in e and "nnp" in e):
+                raise MpiException(
+                    "Srun needs a nn/nnp specification to build the envelope."
+                )
 
     def _set_envelope(self, value):
         """Set the envelope description."""
         super()._set_envelope(value)
-        if len(self._envelope) > 1 and self.bindingmethod not in (None, 'vortex'):
+        if len(self._envelope) > 1 and self.bindingmethod not in (
+            None,
+            "vortex",
+        ):
             logger.warning("Resetting the binding method to 'Vortex'.")
-            self.bindingmethod = 'vortex'
+            self.bindingmethod = "vortex"
 
     envelope = property(MpiTool._get_envelope, _set_envelope)
 
     def _set_binaries_envelope_hack(self, binaries):
         """Tweak the envelope after binaries were setup."""
-        if self.bindingmethod not in (None, 'vortex'):
-            openmps = {b.options.get('openmp', None) for b in binaries}
+        if self.bindingmethod not in (None, "vortex"):
+            openmps = {b.options.get("openmp", None) for b in binaries}
             if len(openmps) > 1:
-                logger.warning("Resetting the binding method to 'Vortex' because " +
-                               "the number of threads is not uniform.")
-                self.bindingmethod = 'vortex'
+                logger.warning(
+                    "Resetting the binding method to 'Vortex' because "
+                    + "the number of threads is not uniform."
+                )
+                self.bindingmethod = "vortex"
 
     @property
     def _cpubind_opt(self):
-        return self.optprefix + ('cpu_bind' if self._actual_slurmversion < 18
-                                 else 'cpu-bind')
+        return self.optprefix + (
+            "cpu_bind" if self._actual_slurmversion < 18 else "cpu-bind"
+        )
 
     def _build_cpumask(self, cmdl, what, bsize):
         """Add a --cpu-bind option if needed."""
         cmdl.append(self._cpubind_opt)
-        if self.bindingmethod == 'native':
+        if self.bindingmethod == "native":
             assert len(what) == 1, "Only one item is allowed."
             if what[0].allowbind:
-                ids = self.system.cpus_ids_per_blocks(blocksize=bsize,
-                                                      topology=self.mpibind_topology,
-                                                      hexmask=True)
+                ids = self.system.cpus_ids_per_blocks(
+                    blocksize=bsize,
+                    topology=self.mpibind_topology,
+                    hexmask=True,
+                )
                 if not ids:
-                    raise MpiException('Unable to detect the CPU layout with topology: {:s}'
-                                       .format(self.mpibind_topology, ))
-                masklist = [m for _, m in zip(range(what[0].options['nnp']),
-                                              itertools.cycle(ids))]
-                cmdl.append('mask_cpu:' + ','.join(masklist))
+                    raise MpiException(
+                        "Unable to detect the CPU layout with topology: {:s}".format(
+                            self.mpibind_topology,
+                        )
+                    )
+                masklist = [
+                    m
+                    for _, m in zip(
+                        range(what[0].options["nnp"]), itertools.cycle(ids)
+                    )
+                ]
+                cmdl.append("mask_cpu:" + ",".join(masklist))
             else:
-                cmdl.append('none')
+                cmdl.append("none")
         else:
-            cmdl.append('none')
+            cmdl.append("none")
 
     def _simple_mkcmdline(self, cmdl):
         """Builds the MPI command line when no envelope is used.
 
         :param list[str] cmdl: the command line as a list
         """
-        target_bins = [binary for binary in self.binaries if len(binary.expanded_options())]
-        self._build_cpumask(cmdl, target_bins, target_bins[0].options.get('openmp', 1))
+        target_bins = [
+            binary
+            for binary in self.binaries
+            if len(binary.expanded_options())
+        ]
+        self._build_cpumask(
+            cmdl, target_bins, target_bins[0].options.get("openmp", 1)
+        )
         super()._simple_mkcmdline(cmdl)
 
     def _envelope_mkcmdline(self, cmdl):
@@ -1285,8 +1532,12 @@ class SRun(MpiTool):
         """
         # Simple case, only one envelope description
         has_bin_groups = not all([b.group is None for b in self.binaries])
-        openmps = {b.options.get('openmp', 1) for b in self.binaries}
-        if len(self.envelope) == 1 and not self._complex_ranks_mapping and len(openmps) == 1:
+        openmps = {b.options.get("openmp", 1) for b in self.binaries}
+        if (
+            len(self.envelope) == 1
+            and not self._complex_ranks_mapping
+            and len(openmps) == 1
+        ):
             self._build_cpumask(cmdl, self.envelope, openmps.pop())
             super()._envelope_mkcmdline(cmdl)
         # Multiple entries... use the nodelist stuff :-(
@@ -1295,15 +1546,24 @@ class SRun(MpiTool):
             base_nodelist = []
             totalnodes = 0
             totaltasks = 0
-            availnodes = itertools.cycle(xlist_strings(self.env.SLURM_NODELIST
-                                                       if self._actual_slurmversion < 18
-                                                       else self.env.SLURM_JOB_NODELIST))
+            availnodes = itertools.cycle(
+                xlist_strings(
+                    self.env.SLURM_NODELIST
+                    if self._actual_slurmversion < 18
+                    else self.env.SLURM_JOB_NODELIST
+                )
+            )
             for e_bit in self.envelope:
                 totaltasks += e_bit.nprocs
-                for _ in range(e_bit.options['nn']):
+                for _ in range(e_bit.options["nn"]):
                     availnode = next(availnodes)
-                    logger.debug('Node #%5d is: %s', totalnodes, availnode)
-                    base_nodelist.extend([availnode, ] * e_bit.options['nnp'])
+                    logger.debug("Node #%5d is: %s", totalnodes, availnode)
+                    base_nodelist.extend(
+                        [
+                            availnode,
+                        ]
+                        * e_bit.options["nnp"]
+                    )
                     totalnodes += 1
             # Re-order the nodelist based on the binary groups
             nodelist = list()
@@ -1313,20 +1573,20 @@ class SRun(MpiTool):
                 else:
                     nodelist.append(base_nodelist[i_rank])
             # Write it to the nodefile
-            with open(self._envelope_nodelist_name, 'w') as fhnl:
+            with open(self._envelope_nodelist_name, "w") as fhnl:
                 fhnl.write("\n".join(nodelist))
             # Generate wrappers
             self._envelope_mkwrapper(cmdl)
             wrapstd = self._wrapstd_mkwrapper()
             # Update the command line
-            cmdl.append(self.optprefix + 'nodelist')
+            cmdl.append(self.optprefix + "nodelist")
             cmdl.append(self._envelope_nodelist_name)
-            cmdl.append(self.optprefix + 'ntasks')
+            cmdl.append(self.optprefix + "ntasks")
             cmdl.append(str(totaltasks))
-            cmdl.append(self.optprefix + 'distribution')
-            cmdl.append('arbitrary')
+            cmdl.append(self.optprefix + "distribution")
+            cmdl.append("arbitrary")
             cmdl.append(self._cpubind_opt)
-            cmdl.append('none')
+            cmdl.append("none")
             if wrapstd:
                 cmdl.append(wrapstd)
             cmdl.append(e_bit.master)
@@ -1346,70 +1606,82 @@ class SRun(MpiTool):
         if not shp.exists(self.launcher):
             actlauncher = self.system.which(actlauncher)
             if not actlauncher:
-                logger.error('The SRun launcher could not be found.')
+                logger.error("The SRun launcher could not be found.")
                 return sdict
-        sdict['srunpath'] = actlauncher
+        sdict["srunpath"] = actlauncher
         # Detect the path to the PMI library
-        pmilib = shp.normpath(shp.join(shp.dirname(actlauncher),
-                                       '..', 'lib64', 'libpmi.so'))
+        pmilib = shp.normpath(
+            shp.join(shp.dirname(actlauncher), "..", "lib64", "libpmi.so")
+        )
         if not shp.exists(pmilib):
-            pmilib = shp.normpath(shp.join(shp.dirname(actlauncher),
-                                           '..', 'lib', 'libpmi.so'))
+            pmilib = shp.normpath(
+                shp.join(shp.dirname(actlauncher), "..", "lib", "libpmi.so")
+            )
             if not shp.exists(pmilib):
-                logger.error('Could not find a PMI library')
+                logger.error("Could not find a PMI library")
                 return sdict
-        sdict['pmilib'] = pmilib
+        sdict["pmilib"] = pmilib
         return sdict
 
     def setup_environment(self, opts):
         """Tweak the environment with some srun specific settings."""
         super().setup_environment(opts)
-        if (self._complex_ranks_mapping and
-                self._mpilib_identification() and
-                self._mpilib_identification()[3] == 'intelmpi'):
-            logger.info('(Sadly) with IntelMPI, I_MPI_SLURM_EXT=0 is needed when a complex arbitrary' +
-                        'ranks distribution is used. Exporting it !')
-            self.env['I_MPI_SLURM_EXT'] = 0
+        if (
+            self._complex_ranks_mapping
+            and self._mpilib_identification()
+            and self._mpilib_identification()[3] == "intelmpi"
+        ):
+            logger.info(
+                "(Sadly) with IntelMPI, I_MPI_SLURM_EXT=0 is needed when a complex arbitrary"
+                + "ranks distribution is used. Exporting it !"
+            )
+            self.env["I_MPI_SLURM_EXT"] = 0
         if len(self.binaries) == 1 and not self.envelope:
-            omp = self.binaries[0].options.get('openmp', None)
+            omp = self.binaries[0].options.get("openmp", None)
             if omp is not None:
-                self._logged_env_set('OMP_NUM_THREADS', omp)
-        if self.bindingmethod == 'native' and 'OMP_PROC_BIND' not in self.env:
-            self._logged_env_set('OMP_PROC_BIND', 'true')
+                self._logged_env_set("OMP_NUM_THREADS", omp)
+        if self.bindingmethod == "native" and "OMP_PROC_BIND" not in self.env:
+            self._logged_env_set("OMP_PROC_BIND", "true")
         # cleaning unwanted environment stuff
         unwanted = set()
         for k in self.env:
-            if k.startswith('SLURM_'):
+            if k.startswith("SLURM_"):
                 k = k[6:]
-                if (k in ('NTASKS', 'NPROCS') or
-                        re.match('N?TASKS_PER_', k) or
-                        re.match('N?CPUS_PER_', k)):
+                if (
+                    k in ("NTASKS", "NPROCS")
+                    or re.match("N?TASKS_PER_", k)
+                    or re.match("N?CPUS_PER_", k)
+                ):
                     unwanted.add(k)
         for k in unwanted:
-            self.env.delvar('SLURM_{:s}'.format(k))
+            self.env.delvar("SLURM_{:s}".format(k))
 
 
 class SRunDDT(SRun):
     """SLURM's srun launcher with ARM's DDT."""
 
     _footprint = dict(
-        attr = dict(
-            mpiname = dict(
-                values  = ['srun-ddt', ],
+        attr=dict(
+            mpiname=dict(
+                values=[
+                    "srun-ddt",
+                ],
             ),
         )
     )
 
-    _conf_suffix = '-ddt'
+    _conf_suffix = "-ddt"
 
     def mkcmdline(self):
         """Add the DDT prefix command to the command line"""
         cmdl = super().mkcmdline()
         armtool = ArmForgeTool(self.ticket)
-        for extra_c in reversed(armtool.ddt_prefix_cmd(
-            sources=self.sources,
-            workdir=self.system.path.dirname(self.binaries[0].master)
-        )):
+        for extra_c in reversed(
+            armtool.ddt_prefix_cmd(
+                sources=self.sources,
+                workdir=self.system.path.dirname(self.binaries[0].master),
+            )
+        ):
             cmdl.insert(0, extra_c)
         return cmdl
 
@@ -1418,45 +1690,48 @@ class OmpiMpiRun(MpiTool):
     """OpenMPI's mpirun launcher."""
 
     _footprint = dict(
-        attr = dict(
-            sysname = dict(
-                values         = ['Linux', 'UnitTestLinux']
+        attr=dict(
+            sysname=dict(values=["Linux", "UnitTestLinux"]),
+            mpiname=dict(
+                values=[
+                    "openmpi",
+                ],
             ),
-            mpiname = dict(
-                values         = ['openmpi', ],
+            optsep=dict(
+                default="",
             ),
-            optsep = dict(
-                default        = '',
+            optprefix=dict(
+                default="-",
             ),
-            optprefix = dict(
-                default        = '-',
+            optmap=dict(
+                default=footprints.FPDict(np="np", nnp="npernode", xopenmp="x")
             ),
-            optmap = dict(
-                default        = footprints.FPDict(np='np', nnp='npernode', xopenmp='x')
+            binsep=dict(
+                default=":",
             ),
-            binsep = dict(
-                default        = ':',
+            mpiwrapstd=dict(
+                default=True,
             ),
-            mpiwrapstd = dict(
-                default        = True,
+            bindingmethod=dict(
+                info="How to bind the MPI processes",
+                values=[
+                    "native",
+                    "vortex",
+                ],
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-            bindingmethod = dict(
-                info           = 'How to bind the MPI processes',
-                values         = ['native', 'vortex', ],
-                optional       = True,
-                doc_visibility = footprints.doc.visibility.ADVANCED,
-                doc_zorder     = -90,
-            ),
-            preexistingenv = dict(
-                optional       = True,
-                type           = bool,
-                default        = False,
+            preexistingenv=dict(
+                optional=True,
+                type=bool,
+                default=False,
             ),
         )
     )
 
-    _envelope_rankfile_name = './global_envelope_rankfile'
-    _envelope_rank_var = 'OMPI_COMM_WORLD_RANK'
+    _envelope_rankfile_name = "./global_envelope_rankfile"
+    _envelope_rank_var = "OMPI_COMM_WORLD_RANK"
     _supports_manual_ranks_mapping = True
 
     def _get_launcher(self):
@@ -1466,27 +1741,29 @@ class OmpiMpiRun(MpiTool):
         else:
             mpi_data = self._mpilib_data()
             if mpi_data:
-                return self.system.path.join(mpi_data[1], 'mpirun')
+                return self.system.path.join(mpi_data[1], "mpirun")
             else:
                 return self._launcher
 
     launcher = property(_get_launcher, MpiTool._set_launcher)
 
     def _set_binaries_hack(self, binaries):
-        if not self.envelope and self.bindingmethod == 'native':
+        if not self.envelope and self.bindingmethod == "native":
             self._set_envelope_from_binaries()
 
     def _valid_envelope(self, value):
         """Tweak the envelope description values."""
         for e in value:
-            if not ('nn' in e and 'nnp' in e):
-                raise MpiException("OpenMPI/mpirun needs a nn/nnp specification " +
-                                   "to build the envelope.")
+            if not ("nn" in e and "nnp" in e):
+                raise MpiException(
+                    "OpenMPI/mpirun needs a nn/nnp specification "
+                    + "to build the envelope."
+                )
 
     def _hook_binary_mpiopts(self, binary, options):
-        openmp = options.pop('openmp', None)
+        openmp = options.pop("openmp", None)
         if openmp is not None:
-            options['xopenmp'] = 'OMP_NUM_THREADS={:d}'.format(openmp)
+            options["xopenmp"] = "OMP_NUM_THREADS={:d}".format(openmp)
         return options
 
     def _simple_mkcmdline(self, cmdl):
@@ -1495,7 +1772,9 @@ class OmpiMpiRun(MpiTool):
         :param list[str] cmdl: the command line as a list
         """
         if self.bindingmethod is not None:
-            raise RuntimeError('If bindingmethod is set, an enveloppe should allways be used.')
+            raise RuntimeError(
+                "If bindingmethod is set, an enveloppe should allways be used."
+            )
         super()._simple_mkcmdline(cmdl)
 
     def _create_rankfile(self, rankslist, nodeslist, slotslist):
@@ -1503,9 +1782,9 @@ class OmpiMpiRun(MpiTool):
 
         def _dump_slot_string(slot_strings, s_start, s_end):
             if s_start == s_end:
-                slot_strings.append('{:d}'.format(s_start))
+                slot_strings.append("{:d}".format(s_start))
             else:
-                slot_strings.append('{:d}-{:d}'.format(s_start, s_end))
+                slot_strings.append("{:d}-{:d}".format(s_start, s_end))
 
         for rank, node, slot in zip(rankslist, nodeslist, slotslist):
             slot_strings = list()
@@ -1520,20 +1799,26 @@ class OmpiMpiRun(MpiTool):
                         s_end = s_start = s
                 _dump_slot_string(slot_strings, s_start, s_end)
             rf_strings.append(
-                'rank {:d}={:s} slot={:s}'.format(rank,
-                                                  node,
-                                                  ','.join(slot_strings))
+                "rank {:d}={:s} slot={:s}".format(
+                    rank, node, ",".join(slot_strings)
+                )
             )
-        logger.info('self.preexistingenv = {}'.format(self.preexistingenv))
-        if self.preexistingenv and self.system.path.exists(self._envelope_rankfile_name):
-            logger.info('envelope file found in the directory')
+        logger.info("self.preexistingenv = {}".format(self.preexistingenv))
+        if self.preexistingenv and self.system.path.exists(
+            self._envelope_rankfile_name
+        ):
+            logger.info("envelope file found in the directory")
         else:
             if self.preexistingenv:
-                logger.info('preexistingenv set to true, but no envelope file found')
-                logger.info('Using vortex computed one')
-            logger.debug('Here is the rankfile content:\n%s', '\n'.join(rf_strings))
-            with open(self._envelope_rankfile_name, mode='w') as tmp_rf:
-                tmp_rf.write('\n'.join(rf_strings))
+                logger.info(
+                    "preexistingenv set to true, but no envelope file found"
+                )
+                logger.info("Using vortex computed one")
+            logger.debug(
+                "Here is the rankfile content:\n%s", "\n".join(rf_strings)
+            )
+            with open(self._envelope_rankfile_name, mode="w") as tmp_rf:
+                tmp_rf.write("\n".join(rf_strings))
         return self._envelope_rankfile_name
 
     def _envelope_nodelist(self):
@@ -1541,10 +1826,14 @@ class OmpiMpiRun(MpiTool):
         base_nodelist = []
         totalnodes = 0
         for e_bit in self.envelope:
-            for i_node in range(e_bit.options['nn']):
-                logger.debug('Node #%5d is: +n%d', i_node, totalnodes)
-                base_nodelist.extend(['+n{:d}'.format(totalnodes), ] *
-                                     e_bit.options['nnp'])
+            for i_node in range(e_bit.options["nn"]):
+                logger.debug("Node #%5d is: +n%d", i_node, totalnodes)
+                base_nodelist.extend(
+                    [
+                        "+n{:d}".format(totalnodes),
+                    ]
+                    * e_bit.options["nnp"]
+                )
                 totalnodes += 1
         return base_nodelist
 
@@ -1553,12 +1842,14 @@ class OmpiMpiRun(MpiTool):
 
         :param list[str] args: the command line as a list
         """
-        cmdl.append(self.optprefix + 'oversubscribe')
-        if self.bindingmethod in (None, 'native'):
+        cmdl.append(self.optprefix + "oversubscribe")
+        if self.bindingmethod in (None, "native"):
             # Generate the dictionary that associate rank numbers and programs
             todostack, ranks_bsize = self._envelope_mkwrapper_todostack()
             # Generate the binding stuff
-            bindingstack, _ = self._envelope_mkwrapper_bindingstack(ranks_bsize)
+            bindingstack, _ = self._envelope_mkwrapper_bindingstack(
+                ranks_bsize
+            )
             # Generate a relative nodelist
             base_nodelist = self._envelope_nodelist()
             # Generate the rankfile
@@ -1567,21 +1858,23 @@ class OmpiMpiRun(MpiTool):
             if bindingstack:
                 slots = [bindingstack[r] for r in ranks]
             else:
-                slots = [sorted(self.system.cpus_info.cpus.keys()), ] * len(ranks)
+                slots = [
+                    sorted(self.system.cpus_info.cpus.keys()),
+                ] * len(ranks)
             rfile = self._create_rankfile(ranks, nodes, slots)
             # Add the rankfile on the command line
-            cmdl.append(self.optprefix + 'rankfile')
+            cmdl.append(self.optprefix + "rankfile")
             cmdl.append(rfile)
             # Add the "usual" call to binaries and setup OMP_NUM_THREADS values
             wrapstd = self._wrapstd_mkwrapper()
             for i_bin, a_bin in enumerate(self.binaries):
                 if i_bin > 0:
                     cmdl.append(self.binsep)
-                openmp = a_bin.options.get('openmp', None)
+                openmp = a_bin.options.get("openmp", None)
                 if openmp:
-                    cmdl.append(self.optprefix + 'x')
-                    cmdl.append('OMP_NUM_THREADS={!s}'.format(openmp))
-                cmdl.append(self.optprefix + 'np')
+                    cmdl.append(self.optprefix + "x")
+                    cmdl.append("OMP_NUM_THREADS={!s}".format(openmp))
+                cmdl.append(self.optprefix + "np")
                 cmdl.append(str(a_bin.nprocs))
                 if wrapstd:
                     cmdl.append(wrapstd)
@@ -1591,17 +1884,21 @@ class OmpiMpiRun(MpiTool):
             # Generate a host file but let vortex deal with the rest...
             base_nodelist = self._envelope_nodelist()
             ranks = list(range(len(base_nodelist)))
-            rfile = self._create_rankfile(ranks,
-                                          [base_nodelist[self._ranks_mapping[r]] for r in ranks],
-                                          [sorted(self.system.cpus_info.cpus.keys()), ]
-                                          * len(base_nodelist))
+            rfile = self._create_rankfile(
+                ranks,
+                [base_nodelist[self._ranks_mapping[r]] for r in ranks],
+                [
+                    sorted(self.system.cpus_info.cpus.keys()),
+                ]
+                * len(base_nodelist),
+            )
             # Generate wrappers
             self._envelope_mkwrapper(cmdl)
             wrapstd = self._wrapstd_mkwrapper()
             # Update the command line
-            cmdl.append(self.optprefix + 'rankfile')
+            cmdl.append(self.optprefix + "rankfile")
             cmdl.append(rfile)
-            cmdl.append(self.optprefix + 'np')
+            cmdl.append(self.optprefix + "np")
             cmdl.append(str(len(base_nodelist)))
             if wrapstd:
                 cmdl.append(wrapstd)
@@ -1616,33 +1913,37 @@ class OmpiMpiRun(MpiTool):
     def setup_environment(self, opts):
         """Tweak the environment with some srun specific settings."""
         super().setup_environment(opts)
-        if self.bindingmethod == 'native' and 'OMP_PROC_BIND' not in self.env:
-            self._logged_env_set('OMP_PROC_BIND', 'true')
+        if self.bindingmethod == "native" and "OMP_PROC_BIND" not in self.env:
+            self._logged_env_set("OMP_PROC_BIND", "true")
         for libpath in self._mpilib_identification()[2]:
             logger.info('Adding "%s" to LD_LIBRARY_PATH', libpath)
-            self.env.setgenericpath('LD_LIBRARY_PATH', libpath)
+            self.env.setgenericpath("LD_LIBRARY_PATH", libpath)
 
 
 class OmpiMpiRunDDT(OmpiMpiRun):
     """SLURM's srun launcher with ARM's DDT."""
 
     _footprint = dict(
-        attr = dict(
-            mpiname = dict(
-                values  = ['openmpi-ddt', ],
+        attr=dict(
+            mpiname=dict(
+                values=[
+                    "openmpi-ddt",
+                ],
             ),
         )
     )
 
-    _conf_suffix = '-ddt'
+    _conf_suffix = "-ddt"
 
     def mkcmdline(self):
         """Add the DDT prefix command to the command line"""
         cmdl = super(OmpiMpiRun, self).mkcmdline()
         armtool = ArmForgeTool(self.ticket)
-        for extra_c in reversed(armtool.ddt_prefix_cmd(
-            sources=self.sources,
-            workdir=self.system.path.dirname(self.binaries[0].master)
-        )):
+        for extra_c in reversed(
+            armtool.ddt_prefix_cmd(
+                sources=self.sources,
+                workdir=self.system.path.dirname(self.binaries[0].master),
+            )
+        ):
             cmdl.insert(0, extra_c)
         return cmdl

--- a/src/vortex/algo/serversynctools.py
+++ b/src/vortex/algo/serversynctools.py
@@ -23,30 +23,25 @@ class ServerSyncTool(footprints.FootprintBase):
     """
 
     _abstract = True
-    _collector = ('serversynctool',)
+    _collector = ("serversynctool",)
     _footprint = dict(
-        info='Abstract Server Synchronisation Tool',
+        info="Abstract Server Synchronisation Tool",
         attr=dict(
-            method=dict(
-            ),
+            method=dict(),
             medium=dict(
                 optional=True,
             ),
-            raiseonexit=dict(
-                type=bool,
-                optional=True,
-                default=True
-            ),
+            raiseonexit=dict(type=bool, optional=True, default=True),
             checkinterval=dict(
                 type=int,
                 optional=True,
                 default=10,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Server Synchronisation Tool init %s', self.__class__)
+        logger.debug("Server Synchronisation Tool init %s", self.__class__)
         self._check_callback = lambda: True
         super().__init__(*args, **kw)
 
@@ -80,19 +75,19 @@ class ServerSyncSimpleSocket(ServerSyncTool):
     """
 
     _footprint = dict(
-        info='Server Synchronisation Tool that uses a Socket',
+        info="Server Synchronisation Tool that uses a Socket",
         attr=dict(
             method=dict(
-                values=['simple_socket'],
+                values=["simple_socket"],
             ),
             medium=dict(
                 optional=False,
             ),
             tplname=dict(
                 optional=True,
-                default='@servsync-simplesocket.tpl',
+                default="@servsync-simplesocket.tpl",
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
@@ -102,7 +97,7 @@ class ServerSyncSimpleSocket(ServerSyncTool):
         try:
             self._socket.bind((socket.getfqdn(), 0))
         except OSError:
-            self._socket.bind(('localhost', 0))
+            self._socket.bind(("localhost", 0))
         self._socket.settimeout(self.checkinterval)
         self._socket.listen(1)
         # Current connection
@@ -110,11 +105,13 @@ class ServerSyncSimpleSocket(ServerSyncTool):
         # Create the script that will be called by the server
         t = sessions.current()
         tpl = config.load_template(t, self.tplname)
-        with open(self.medium, 'w') as fd:
-            fd.write(tpl.substitute(
-                python=sys.executable,
-                address=self._socket.getsockname(),
-            ))
+        with open(self.medium, "w") as fd:
+            fd.write(
+                tpl.substitute(
+                    python=sys.executable,
+                    address=self._socket.getsockname(),
+                )
+            )
         t.sh.chmod(self.medium, 0o555)
 
     def __del__(self):
@@ -130,13 +127,13 @@ class ServerSyncSimpleSocket(ServerSyncTool):
         if self._socket_conn is not None:
             logger.info('Sending "%s" to the server.', mess)
             # NB: For send/recv, the settimeout also applies...
-            self._socket_conn.send(mess.encode(encoding='utf-8'))
-            repl = self._socket_conn.recv(255).decode(encoding='utf-8')
+            self._socket_conn.send(mess.encode(encoding="utf-8"))
+            repl = self._socket_conn.recv(255).decode(encoding="utf-8")
             logger.info('Server replied "%s" to %s.', repl, mess)
             self._socket_conn.close()
             self._socket_conn = None
-            if repl != 'OK':
-                raise ValueError(mess + ' failed')
+            if repl != "OK":
+                raise ValueError(mess + " failed")
             return True
         else:
             # This should not happen ! If we are sitting here, it's most likely
@@ -144,27 +141,31 @@ class ServerSyncSimpleSocket(ServerSyncTool):
             return False
 
     def trigger_wait(self):
-        logger.info('Waiting for the server to complete')
+        logger.info("Waiting for the server to complete")
         while self._socket_conn is None and self._check_callback():
             try:
-                self._socket_conn, addr = self._socket.accept()  # @UnusedVariable
+                self._socket_conn, addr = (
+                    self._socket.accept()
+                )  # @UnusedVariable
             except socket.timeout:
-                logger.debug('Socket accept timed-out: checking for the server...')
+                logger.debug(
+                    "Socket accept timed-out: checking for the server..."
+                )
                 self._socket_conn = None
         if self._socket_conn is None:
             if self.raiseonexit:
-                raise OSError('Apparently the server died.')
+                raise OSError("Apparently the server died.")
             else:
-                logger.info('The server stopped.')
+                logger.info("The server stopped.")
         else:
             self._socket_conn.settimeout(self.checkinterval)
-            logger.info('The server is now waiting')
+            logger.info("The server is now waiting")
 
     def trigger_run(self):
         # Tell the server that everything is ready
-        self._command('STEP')
+        self._command("STEP")
         # Wait for the server to complete its work
         self.trigger_wait()
 
     def trigger_stop(self):
-        return self._command('STOP')
+        return self._command("STOP")

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -108,7 +108,6 @@ def is_defined(section, key=None):
 
 
 def get_from_config_w_default(section, key, default):
-    logger.info(f"Reading config value {section}.{key}")
     try:
         return from_config(section, key)
     except KeyError:

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -2,6 +2,7 @@
 the value of configuration options, respectively.
 
 """
+
 import tomli
 
 from bronx.fancies import loggers
@@ -38,21 +39,15 @@ def load_config(configpath="vortex.toml"):
     global VORTEX_CONFIG
     try:
         with open(configpath, "rb") as f:
-             VORTEX_CONFIG = tomli.load(f)
+            VORTEX_CONFIG = tomli.load(f)
         print(f"Successfully read configuration file {configpath}")
     except FileNotFoundError:
-        print(
-            f"Could not read configuration file {configpath}"
-            " (not found)."
-        )
-        print(
-            "Use load_config(/path/to/config) to update the configuration"
-        )
+        print(f"Could not read configuration file {configpath} (not found).")
+        print("Use load_config(/path/to/config) to update the configuration")
 
 
 def print_config():
-    """Print configuration (key, value) pairs
-    """
+    """Print configuration (key, value) pairs"""
     if VORTEX_CONFIG:
         for k, v in VORTEX_CONFIG:
             print(k.upper(), v)
@@ -68,16 +63,18 @@ def from_config(section, key=None):
         subconfig = VORTEX_CONFIG[section]
     except KeyError as e:
         print(f"Could not find section {section} in configuration")
-        raise(e)
+        raise (e)
 
     if not key:
         return subconfig
 
     try:
         value = subconfig[key]
-    except KeyError as e :
-        print(f"Could not find key {key} in section {section} of configuration")
-        raise(e)
+    except KeyError as e:
+        print(
+            f"Could not find key {key} in section {section} of configuration"
+        )
+        raise (e)
     return value
 
 
@@ -87,9 +84,7 @@ def set_config(section, key, value):
     if section not in VORTEX_CONFIG.keys():
         VORTEX_CONFIG[section] = {}
     if key in VORTEX_CONFIG[section]:
-        logger.warning(
-            f"Updating existing configuration {section}:{key}"
-        )
+        logger.warning(f"Updating existing configuration {section}:{key}")
     VORTEX_CONFIG[section][key] = value
 
 

--- a/src/vortex/data/__init__.py
+++ b/src/vortex/data/__init__.py
@@ -4,16 +4,14 @@ Abstract classes involved in data management within VORTEX.
 Actual resources and custom providers should be defined in dedicated packages.
 """
 
-from . import (
-    handlers,
-    resources,
-    containers,
-    contents,
-    providers,
-    executables,
-    stores,
-    geometries,
-)
+from . import handlers as handlers
+from . import resources as resources
+from . import containers as containers
+from . import contents as contents
+from . import providers as providers
+from . import executables as executables
+from . import stores as stores
+from . import geometries as geometries
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/data/__init__.py
+++ b/src/vortex/data/__init__.py
@@ -4,10 +4,18 @@ Abstract classes involved in data management within VORTEX.
 Actual resources and custom providers should be defined in dedicated packages.
 """
 
-from . import handlers, resources, containers, contents, providers, \
-    executables, stores, geometries
+from . import (
+    handlers,
+    resources,
+    containers,
+    contents,
+    providers,
+    executables,
+    stores,
+    geometries,
+)
 
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'Abstract classes involved in data management within VORTEX'
+__tocinfoline__ = "Abstract classes involved in data management within VORTEX"

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -6,7 +6,6 @@ Store objects use the :mod:`footprints` mechanism.
 """
 
 from collections import defaultdict
-import contextlib
 import copy
 import functools
 import re
@@ -28,7 +27,6 @@ from vortex.syntax.stdattrs import (
 from vortex.tools import storage
 from vortex.tools import compression
 from vortex.tools import net
-from vortex.tools.env import vartrue
 from vortex.tools.systems import ExecutionError
 from vortex.syntax.stdattrs import Namespace
 

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -20,7 +20,11 @@ import footprints
 from vortex import sessions
 from vortex.config import from_config
 from vortex.util import config
-from vortex.syntax.stdattrs import hashalgo, hashalgo_avail_list, compressionpipeline
+from vortex.syntax.stdattrs import (
+    hashalgo,
+    hashalgo_avail_list,
+    compressionpipeline,
+)
 from vortex.tools import storage
 from vortex.tools import compression
 from vortex.tools import net
@@ -29,17 +33,17 @@ from vortex.tools.systems import ExecutionError
 from vortex.syntax.stdattrs import Namespace
 
 #: Export base class
-__all__ = ['Store']
+__all__ = ["Store"]
 
 logger = loggers.getLogger(__name__)
 
-OBSERVER_TAG = 'Stores-Activity'
+OBSERVER_TAG = "Stores-Activity"
 
-CACHE_PUT_INTENT = 'in'
-CACHE_GET_INTENT_DEFAULT = 'in'
+CACHE_PUT_INTENT = "in"
+CACHE_GET_INTENT_DEFAULT = "in"
 
-ARCHIVE_PUT_INTENT = 'in'
-ARCHIVE_GET_INTENT_DEFAULT = 'in'
+ARCHIVE_PUT_INTENT = "in"
+ARCHIVE_GET_INTENT_DEFAULT = "in"
 
 
 def observer_board(obsname=None):
@@ -53,36 +57,31 @@ class Store(footprints.FootprintBase):
     """Root class for any :class:`Store` subclasses."""
 
     _abstract = True
-    _collector = ('store',)
+    _collector = ("store",)
     _footprint = [
         hashalgo,
         dict(
-            info = 'Default store',
-            attr = dict(
-                scheme = dict(
-                    alias = ('protocol',)
+            info="Default store",
+            attr=dict(
+                scheme=dict(alias=("protocol",)),
+                netloc=dict(type=Namespace, alias=("domain", "namespace")),
+                storetrack=dict(
+                    type=bool,
+                    default=True,
+                    optional=True,
                 ),
-                netloc = dict(
-                    type  = Namespace,
-                    alias = ('domain', 'namespace')
-                ),
-                storetrack = dict(
-                    type     = bool,
-                    default  = True,
-                    optional = True,
-                ),
-                readonly = dict(
-                    type     = bool,
-                    optional = True,
-                    default  = False,
+                readonly=dict(
+                    type=bool,
+                    optional=True,
+                    default=False,
                 ),
             ),
-        )
+        ),
     ]
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract store init %s', self.__class__)
-        sh = kw.pop('system', sessions.system())
+        logger.debug("Abstract store init %s", self.__class__)
+        sh = kw.pop("system", sessions.system())
         super().__init__(*args, **kw)
         self._sh = sh
         self._observer = observer_board()
@@ -92,7 +91,7 @@ class Store(footprints.FootprintBase):
 
     @property
     def realkind(self):
-        return 'store'
+        return "store"
 
     @property
     def system(self):
@@ -112,15 +111,15 @@ class Store(footprints.FootprintBase):
         return False
 
     def _observer_notify(self, action, rc, remote, local=None, options=None):
-        strack = options is None or options.get('obs_notify', True)
+        strack = options is None or options.get("obs_notify", True)
         if self.storetrack and strack:
             infos = dict(action=action, status=rc, remote=remote)
             # Is a localpath provided ?
             if local is not None:
-                infos['local'] = local
+                infos["local"] = local
             # We may want to cheat on the localpath...
-            if options is not None and 'obs_overridelocal' in options:
-                infos['local'] = options['obs_overridelocal']
+            if options is not None and "obs_overridelocal" in options:
+                infos["local"] = options["obs_overridelocal"]
             self._observer.notify_upd(self, infos)
 
     def notyet(self, *args):
@@ -128,7 +127,7 @@ class Store(footprints.FootprintBase):
         Internal method to be used as a critical backup method
         when a specific method is not yet defined.
         """
-        logger.critical('Scheme %s not yet implemented', self.scheme)
+        logger.critical("Scheme %s not yet implemented", self.scheme)
 
     @property
     def writeable(self):
@@ -136,12 +135,12 @@ class Store(footprints.FootprintBase):
 
     def enforce_readonly(self):
         if self.readonly:
-            raise OSError('This store is in readonly mode')
+            raise OSError("This store is in readonly mode")
 
     @staticmethod
     def _verbose_log(options, level, *kargs, **kwargs):
-        slevel = kwargs.pop('slevel', 'debug')
-        if options is not None and options.get('silent', False):
+        slevel = kwargs.pop("slevel", "debug")
+        if options is not None and options.get("silent", False):
             level = slevel
         getattr(logger, level)(*kargs, **kwargs)
 
@@ -149,10 +148,11 @@ class Store(footprints.FootprintBase):
     def _actual_cpipeline(self):
         """Check if the current store has a CompressionPipeline."""
         if self._cpipeline is False:
-            cpipeline_desc = getattr(self, 'store_compressed', None)
+            cpipeline_desc = getattr(self, "store_compressed", None)
             if cpipeline_desc is not None:
-                self._cpipeline = compression.CompressionPipeline(self.system,
-                                                                  cpipeline_desc)
+                self._cpipeline = compression.CompressionPipeline(
+                    self.system, cpipeline_desc
+                )
             else:
                 self._cpipeline = None
         return self._cpipeline
@@ -164,27 +164,39 @@ class Store(footprints.FootprintBase):
 
     def _incache_inarchive_check(self, options):
         rc = True
-        incache = options.get('incache', False)
-        inarchive = options.get('inarchive', False)
+        incache = options.get("incache", False)
+        inarchive = options.get("inarchive", False)
         if incache and inarchive:
-            raise ValueError("'incache=True' and 'inarchive=True' are mutually exclusive")
+            raise ValueError(
+                "'incache=True' and 'inarchive=True' are mutually exclusive"
+            )
         if incache and not self.use_cache():
-            self._verbose_log(options, 'info',
-                              'Skip this "%s" store because a cache is requested', self.__class__)
+            self._verbose_log(
+                options,
+                "info",
+                'Skip this "%s" store because a cache is requested',
+                self.__class__,
+            )
             rc = False
         if inarchive and not self.use_archive():
-            self._verbose_log(options, 'info',
-                              'Skip this "%s" store because an archive is requested', self.__class__)
+            self._verbose_log(
+                options,
+                "info",
+                'Skip this "%s" store because an archive is requested',
+                self.__class__,
+            )
             rc = False
         return rc
 
     def _hash_check_or_delete(self, callback, remote, options):
         """Check or delete a hash file."""
-        if (self.storehash is None) or (remote['path'].endswith('.' + self.storehash)):
+        if (self.storehash is None) or (
+            remote["path"].endswith("." + self.storehash)
+        ):
             return True
         options = self._hash_store_defaults(options)
         remote = remote.copy()
-        remote['path'] = remote['path'] + '.' + self.storehash
+        remote["path"] = remote["path"] + "." + self.storehash
         return callback(remote, options)
 
     @staticmethod
@@ -193,29 +205,33 @@ class Store(footprints.FootprintBase):
 
     def check(self, remote, options=None):
         """Proxy method to dedicated check method according to scheme."""
-        logger.debug('Store check from %s', remote)
+        logger.debug("Store check from %s", remote)
         options = self._options_fixup(options)
         if not self._incache_inarchive_check(options):
             return False
-        rc = getattr(self, self.scheme + 'check', self.notyet)(remote, options)
-        self._observer_notify('check', rc, remote, options=options)
+        rc = getattr(self, self.scheme + "check", self.notyet)(remote, options)
+        self._observer_notify("check", rc, remote, options=options)
         return rc
 
     def locate(self, remote, options=None):
         """Proxy method to dedicated locate method according to scheme."""
         options = self._options_fixup(options)
-        logger.debug('Store locate %s', remote)
+        logger.debug("Store locate %s", remote)
         if not self._incache_inarchive_check(options):
             return None
-        return getattr(self, self.scheme + 'locate', self.notyet)(remote, options)
+        return getattr(self, self.scheme + "locate", self.notyet)(
+            remote, options
+        )
 
     def list(self, remote, options=None):
         """Proxy method to dedicated list method according to scheme."""
         options = self._options_fixup(options)
-        logger.debug('Store list %s', remote)
+        logger.debug("Store list %s", remote)
         if not self._incache_inarchive_check(options):
             return None
-        return getattr(self, self.scheme + 'list', self.notyet)(remote, options)
+        return getattr(self, self.scheme + "list", self.notyet)(
+            remote, options
+        )
 
     def prestage_advertise(self, remote, options=None):
         """Use the Stores-Activity observer board to advertise the prestaging request.
@@ -224,65 +240,82 @@ class Store(footprints.FootprintBase):
         the request.
         """
         options = self._options_fixup(options)
-        logger.debug('Store prestage through hub %s', remote)
-        infos_cb = getattr(self, self.scheme + 'prestageinfo', None)
+        logger.debug("Store prestage through hub %s", remote)
+        infos_cb = getattr(self, self.scheme + "prestageinfo", None)
         if infos_cb:
             infodict = infos_cb(remote, options)
-            infodict.setdefault('issuerkind', self.realkind)
-            infodict.setdefault('scheme', self.scheme)
-            if options and 'priority' in options:
-                infodict['priority'] = options['priority']
-            infodict['action'] = 'prestage_req'
+            infodict.setdefault("issuerkind", self.realkind)
+            infodict.setdefault("scheme", self.scheme)
+            if options and "priority" in options:
+                infodict["priority"] = options["priority"]
+            infodict["action"] = "prestage_req"
             self._observer.notify_upd(self, infodict)
         else:
-            logger.info('Prestaging is not supported for scheme: %s', self.scheme)
+            logger.info(
+                "Prestaging is not supported for scheme: %s", self.scheme
+            )
         return True
 
     def prestage(self, remote, options=None):
         """Proxy method to dedicated prestage method according to scheme."""
         options = self._options_fixup(options)
-        logger.debug('Store prestage %s', remote)
+        logger.debug("Store prestage %s", remote)
         if not self._incache_inarchive_check(options):
             return True
-        return getattr(self, self.scheme + 'prestage', self.prestage_advertise)(remote, options)
+        return getattr(
+            self, self.scheme + "prestage", self.prestage_advertise
+        )(remote, options)
 
     @staticmethod
     def _hash_store_defaults(options):
         """Update default options when fetching hash files."""
         options = options.copy()
-        options['obs_notify'] = False
-        options['fmt'] = 'ascii'
-        options['intent'] = CACHE_GET_INTENT_DEFAULT
-        options['auto_tarextract'] = False
-        options['auto_dirextract'] = False
+        options["obs_notify"] = False
+        options["fmt"] = "ascii"
+        options["intent"] = CACHE_GET_INTENT_DEFAULT
+        options["auto_tarextract"] = False
+        options["auto_dirextract"] = False
         return options
 
     def _hash_get_check(self, callback, remote, local, options):
         """Update default options when fetching hash files."""
-        if (self.storehash is None) or (remote['path'].endswith('.' + self.storehash)):
+        if (self.storehash is None) or (
+            remote["path"].endswith("." + self.storehash)
+        ):
             return True
         if isinstance(local, str) and not self.system.path.isfile(local):
-            logger.info("< %s > is not a plain file. The control sum can't be checked.", local)
+            logger.info(
+                "< %s > is not a plain file. The control sum can't be checked.",
+                local,
+            )
             return True
         options = self._hash_store_defaults(options)
         remote = remote.copy()
-        remote['path'] = remote['path'] + '.' + self.storehash  # Name of the hash file
-        remote['query'].pop('extract', None)  # Ignore any extract request
+        remote["path"] = (
+            remote["path"] + "." + self.storehash
+        )  # Name of the hash file
+        remote["query"].pop("extract", None)  # Ignore any extract request
         try:
             tempcontainer = None
             try:
                 # First, try to fetch the sum in a real file
                 # (in order to potentially use ftserv...)
-                tempcontainer = footprints.proxy.container(shouldfly=True, mode='rb')
+                tempcontainer = footprints.proxy.container(
+                    shouldfly=True, mode="rb"
+                )
                 try:
                     rc = callback(remote, tempcontainer.iotarget(), options)
                 except (OSError, ExecutionError):
                     # This may happen if the user has insufficient rights on
                     # the current directory
-                    tempcontainer = footprints.proxy.container(incore=True, mode='w+b')
+                    tempcontainer = footprints.proxy.container(
+                        incore=True, mode="w+b"
+                    )
                     rc = callback(remote, tempcontainer.iotarget(), options)
             except (OSError, ExecutionError):
-                logger.warning('Something went very wrong when fetching the hash file ! (assuming rc=False)')
+                logger.warning(
+                    "Something went very wrong when fetching the hash file ! (assuming rc=False)"
+                )
                 rc = False
             # check the hash key
             hadapt = hashutils.HashAdapter(self.storehash)
@@ -298,34 +331,40 @@ class Store(footprints.FootprintBase):
 
     def _actual_get(self, action, remote, local, options, result_id=None):
         """Proxy method to dedicated get method according to scheme."""
-        logger.debug('Store %s from %s to %s', action, remote, local)
+        logger.debug("Store %s from %s to %s", action, remote, local)
         if not self._incache_inarchive_check(options):
             return False
-        if not options.get('insitu', False) or self.use_cache():
+        if not options.get("insitu", False) or self.use_cache():
             if result_id:
-                rc = getattr(self, self.scheme + action, self.notyet)(result_id, remote, local, options)
+                rc = getattr(self, self.scheme + action, self.notyet)(
+                    result_id, remote, local, options
+                )
             else:
-                rc = getattr(self, self.scheme + action, self.notyet)(remote, local, options)
-            self._observer_notify('get', rc, remote, local=local, options=options)
+                rc = getattr(self, self.scheme + action, self.notyet)(
+                    remote, local, options
+                )
+            self._observer_notify(
+                "get", rc, remote, local=local, options=options
+            )
             return rc
         else:
-            logger.error('Only cache stores can be used when insitu is True.')
+            logger.error("Only cache stores can be used when insitu is True.")
             return False
 
     def get(self, remote, local, options=None):
         """Proxy method to dedicated get method according to scheme."""
         options = self._options_fixup(options)
-        return self._actual_get('get', remote, local, options)
+        return self._actual_get("get", remote, local, options)
 
     def earlyget(self, remote, local, options=None):
         options = self._options_fixup(options)
         """Proxy method to dedicated earlyget method according to scheme."""
-        logger.debug('Store earlyget from %s to %s', remote, local)
+        logger.debug("Store earlyget from %s to %s", remote, local)
         if not self._incache_inarchive_check(options):
             return None
         rc = None
-        if not options.get('insitu', False) or self.use_cache():
-            available_dget = getattr(self, self.scheme + 'earlyget', None)
+        if not options.get("insitu", False) or self.use_cache():
+            available_dget = getattr(self, self.scheme + "earlyget", None)
             if available_dget is not None:
                 rc = available_dget(remote, local, options)
         return rc
@@ -333,15 +372,19 @@ class Store(footprints.FootprintBase):
     def finaliseget(self, result_id, remote, local, options=None):
         options = self._options_fixup(options)
         """Proxy method to dedicated finaliseget method according to scheme."""
-        return self._actual_get('finaliseget', remote, local, options, result_id=result_id)
+        return self._actual_get(
+            "finaliseget", remote, local, options, result_id=result_id
+        )
 
     def _hash_put(self, callback, local, remote, options):
         """Put a hash file next to the 'real' file."""
-        if (self.storehash is None) or (remote['path'].endswith('.' + self.storehash)):
+        if (self.storehash is None) or (
+            remote["path"].endswith("." + self.storehash)
+        ):
             return True
         options = self._hash_store_defaults(options)
         remote = remote.copy()
-        remote['path'] = remote['path'] + '.' + self.storehash
+        remote["path"] = remote["path"] + "." + self.storehash
         # Generate the hash sum
         hadapt = hashutils.HashAdapter(self.storehash)
         tmplocal = hadapt.file2hash_fh(local)
@@ -351,33 +394,41 @@ class Store(footprints.FootprintBase):
     def put(self, local, remote, options=None):
         """Proxy method to dedicated put method according to scheme."""
         options = self._options_fixup(options)
-        logger.debug('Store put from %s to %s', local, remote)
+        logger.debug("Store put from %s to %s", local, remote)
         self.enforce_readonly()
         if not self._incache_inarchive_check(options):
             return True
         filtered = False
-        if options is not None and 'urifilter' in options:
-            filtered = options['urifilter'](self, remote)
+        if options is not None and "urifilter" in options:
+            filtered = options["urifilter"](self, remote)
         if filtered:
             rc = True
-            logger.info("This remote URI has been filtered out: we are skipping it.")
+            logger.info(
+                "This remote URI has been filtered out: we are skipping it."
+            )
         else:
             dryrun = False
-            if options is not None and 'dryrun' in options:
-                dryrun = options['dryrun']
-            rc = dryrun or getattr(self, self.scheme + 'put', self.notyet)(local, remote, options)
-            self._observer_notify('put', rc, remote, local=local, options=options)
+            if options is not None and "dryrun" in options:
+                dryrun = options["dryrun"]
+            rc = dryrun or getattr(self, self.scheme + "put", self.notyet)(
+                local, remote, options
+            )
+            self._observer_notify(
+                "put", rc, remote, local=local, options=options
+            )
         return rc
 
     def delete(self, remote, options=None):
         """Proxy method to dedicated delete method according to scheme."""
         options = self._options_fixup(options)
-        logger.debug('Store delete from %s', remote)
+        logger.debug("Store delete from %s", remote)
         self.enforce_readonly()
         if not self._incache_inarchive_check(options):
             return True
-        rc = getattr(self, self.scheme + 'delete', self.notyet)(remote, options)
-        self._observer_notify('del', rc, remote, options=options)
+        rc = getattr(self, self.scheme + "delete", self.notyet)(
+            remote, options
+        )
+        self._observer_notify("del", rc, remote, options=options)
         return rc
 
 
@@ -385,46 +436,41 @@ class MultiStore(footprints.FootprintBase):
     """Agregate various :class:`Store` items."""
 
     _abstract = True
-    _collector = ('store',)
+    _collector = ("store",)
     _footprint = [
         compressionpipeline,  # Not used by cache stores but ok, just in case...
         hashalgo,
         dict(
-            info = 'Multi store',
-            attr = dict(
-                scheme = dict(
-                    alias    = ('protocol',)
-                ),
-                netloc = dict(
-                    type     = Namespace,
-                    alias    = ('domain', 'namespace')
-                ),
-                refillstore = dict(
-                    type     = bool,
-                    optional = True,
-                    default  = False,
+            info="Multi store",
+            attr=dict(
+                scheme=dict(alias=("protocol",)),
+                netloc=dict(type=Namespace, alias=("domain", "namespace")),
+                refillstore=dict(
+                    type=bool,
+                    optional=True,
+                    default=False,
                 ),
                 storehash=dict(
-                    values   = hashalgo_avail_list,
+                    values=hashalgo_avail_list,
                 ),
                 # ArchiveStores only be harmless for others...
-                storage = dict(
-                    optional = True,
-                    default  = None,
+                storage=dict(
+                    optional=True,
+                    default=None,
                 ),
-                storetube = dict(
-                    optional = True,
+                storetube=dict(
+                    optional=True,
                 ),
-                storeroot = dict(
-                    optional = True,
-                )
+                storeroot=dict(
+                    optional=True,
+                ),
             ),
-        )
+        ),
     ]
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract multi store init %s', self.__class__)
-        sh = kw.pop('system', sessions.system())
+        logger.debug("Abstract multi store init %s", self.__class__)
+        sh = kw.pop("system", sessions.system())
         super().__init__(*args, **kw)
         self._sh = sh
         self._openedstores = self.loadstores()
@@ -432,7 +478,7 @@ class MultiStore(footprints.FootprintBase):
 
     @property
     def realkind(self):
-        return 'multistore'
+        return "multistore"
 
     @property
     def system(self):
@@ -441,8 +487,8 @@ class MultiStore(footprints.FootprintBase):
 
     @staticmethod
     def _verbose_log(options, level, *kargs, **kwargs):
-        slevel = kwargs.pop('slevel', 'debug')
-        if options is not None and options.get('silent', False):
+        slevel = kwargs.pop("slevel", "debug")
+        if options is not None and options.get("silent", False):
             level = slevel
         getattr(logger, level)(*kargs, **kwargs)
 
@@ -459,7 +505,9 @@ class MultiStore(footprints.FootprintBase):
             xstore = footprints.proxy.store(**desc)
             if xstore:
                 activestores.append(xstore)
-        logger.debug('Multistore %s includes active stores %s', self, activestores)
+        logger.debug(
+            "Multistore %s includes active stores %s", self, activestores
+        )
         return activestores
 
     @property
@@ -490,11 +538,17 @@ class MultiStore(footprints.FootprintBase):
         while loading alternates stores.
         """
         return [
-            dict(system=self.system,
-                 storehash=self.storehash, store_compressed=self.store_compressed,
-                 storage=self.storage, storetube=self.storetube,
-                 storeroot=self.storeroot,
-                 scheme=x, netloc=y, ** self.alternates_fpextras())
+            dict(
+                system=self.system,
+                storehash=self.storehash,
+                store_compressed=self.store_compressed,
+                storage=self.storage,
+                storetube=self.storetube,
+                storeroot=self.storeroot,
+                scheme=x,
+                netloc=y,
+                **self.alternates_fpextras(),
+            )
             for x in self.alternates_scheme()
             for y in self.alternates_netloc()
         ]
@@ -526,7 +580,7 @@ class MultiStore(footprints.FootprintBase):
     def check(self, remote, options=None):
         """Go through internal opened stores and check for the resource."""
         options = self._options_fixup(options)
-        logger.debug('Multistore check from %s', remote)
+        logger.debug("Multistore check from %s", remote)
         rc = False
         for sto in self.filtered_readable_openedstores(remote):
             rc = sto.check(remote.copy(), options)
@@ -537,25 +591,25 @@ class MultiStore(footprints.FootprintBase):
     def locate(self, remote, options=None):
         """Go through internal opened stores and locate the expected resource for each of them."""
         options = self._options_fixup(options)
-        logger.debug('Multistore locate %s', remote)
+        logger.debug("Multistore locate %s", remote)
         f_ostores = self.filtered_readable_openedstores(remote)
         if not f_ostores:
             return False
         rloc = list()
         for sto in f_ostores:
-            logger.debug('Multistore locate at %s', sto)
+            logger.debug("Multistore locate at %s", sto)
             tmp_rloc = sto.locate(remote.copy(), options)
             if tmp_rloc:
                 rloc.append(tmp_rloc)
-        return ';'.join(rloc)
+        return ";".join(rloc)
 
     def list(self, remote, options=None):
         """Go through internal opened stores and list the expected resource for each of them."""
         options = self._options_fixup(options)
-        logger.debug('Multistore list %s', remote)
+        logger.debug("Multistore list %s", remote)
         rlist = set()
         for sto in self.filtered_readable_openedstores(remote):
-            logger.debug('Multistore list at %s', sto)
+            logger.debug("Multistore list at %s", sto)
             tmp_rloc = sto.list(remote.copy(), options)
             if isinstance(tmp_rloc, (list, tuple, set)):
                 rlist.update(tmp_rloc)
@@ -566,18 +620,18 @@ class MultiStore(footprints.FootprintBase):
     def prestage(self, remote, options=None):
         """Go through internal opened stores and prestage the resource for each of them."""
         options = self._options_fixup(options)
-        logger.debug('Multistore prestage %s', remote)
+        logger.debug("Multistore prestage %s", remote)
         f_ostores = self.filtered_readable_openedstores(remote)
         if not f_ostores:
             return False
         if len(f_ostores) == 1:
-            logger.debug('Multistore prestage at %s', f_ostores[0])
+            logger.debug("Multistore prestage at %s", f_ostores[0])
             rc = f_ostores[0].prestage(remote.copy(), options)
         else:
             rc = True
             for sto in f_ostores:
                 if sto.check(remote.copy(), options):
-                    logger.debug('Multistore prestage at %s', sto)
+                    logger.debug("Multistore prestage at %s", sto)
                     rc = sto.prestage(remote.copy(), options)
                     break
         return rc
@@ -590,13 +644,17 @@ class MultiStore(footprints.FootprintBase):
         if self.refillstore:
             f_wr_ostores = self.filtered_writeable_openedstores(remote)
         get_options = copy.copy(options)
-        get_options['silent'] = True
+        get_options["silent"] = True
         while refill_in_progress:
             for num, sto in enumerate(f_rd_ostores):
-                logger.debug('Multistore get at %s', sto)
+                logger.debug("Multistore get at %s", sto)
                 if result_id and num == len(f_rd_ostores) - 1:
-                    rc = sto.finaliseget(result_id, remote.copy(), local, get_options)
-                    result_id = None  # result_ids can not be re-used during refill
+                    rc = sto.finaliseget(
+                        result_id, remote.copy(), local, get_options
+                    )
+                    result_id = (
+                        None  # result_ids can not be re-used during refill
+                    )
                 else:
                     rc = sto.get(remote.copy(), local, get_options)
                     if rc:
@@ -604,51 +662,82 @@ class MultiStore(footprints.FootprintBase):
                 # Are we trying a refill ? -> find the previous writeable store
                 restores = []
                 if rc and self.refillstore and num > 0:
-                    restores = [ostore for ostore in f_rd_ostores[:num]
-                                if (ostore.writeable and ostore in f_wr_ostores and
-                                    ostore.use_cache())]
+                    restores = [
+                        ostore
+                        for ostore in f_rd_ostores[:num]
+                        if (
+                            ostore.writeable
+                            and ostore in f_wr_ostores
+                            and ostore.use_cache()
+                        )
+                    ]
                 # Do the refills and check if one of them succeed
                 refill_in_progress = False
                 for restore in restores:
                     # Another refill may have filled the gap...
                     if not restore.check(remote.copy(), options):
-                        logger.info('Refill back in writeable store [%s].', restore)
+                        logger.info(
+                            "Refill back in writeable store [%s].", restore
+                        )
                         try:
-                            refill_in_progress = ((restore.put(local, remote.copy(), options) and
-                                                   (options.get('intent', CACHE_GET_INTENT_DEFAULT) !=
-                                                    CACHE_PUT_INTENT)) or
-                                                  refill_in_progress)
+                            refill_in_progress = (
+                                restore.put(local, remote.copy(), options)
+                                and (
+                                    options.get(
+                                        "intent", CACHE_GET_INTENT_DEFAULT
+                                    )
+                                    != CACHE_PUT_INTENT
+                                )
+                            ) or refill_in_progress
                         except (ExecutionError, OSError) as e:
-                            logger.error("An ExecutionError happened during the refill: %s", str(e))
-                            logger.error("This error is ignored... but that's ugly !")
+                            logger.error(
+                                "An ExecutionError happened during the refill: %s",
+                                str(e),
+                            )
+                            logger.error(
+                                "This error is ignored... but that's ugly !"
+                            )
                 if refill_in_progress:
-                    logger.info("Starting another round because at least one refill succeeded.")
+                    logger.info(
+                        "Starting another round because at least one refill succeeded."
+                    )
                 # Whatever the refill's outcome, that's fine
                 if rc:
                     break
         if not rc:
-            self._verbose_log(options, 'warning',
-                              "Multistore get {:s}://{:s}: none of the opened store succeeded."
-                              .format(self.scheme, self.netloc), slevel='info')
+            self._verbose_log(
+                options,
+                "warning",
+                "Multistore get {:s}://{:s}: none of the opened store succeeded.".format(
+                    self.scheme, self.netloc
+                ),
+                slevel="info",
+            )
         return rc
 
     def get(self, remote, local, options=None):
         """Go through internal opened stores for the first available resource."""
         options = self._options_fixup(options)
-        logger.debug('Multistore get from %s to %s', remote, local)
+        logger.debug("Multistore get from %s to %s", remote, local)
         return self._refilling_get(remote, local, options)
 
     def earlyget(self, remote, local, options=None):
         options = self._options_fixup(options)
-        logger.debug('Multistore earlyget from %s to %s', remote, local)
+        logger.debug("Multistore earlyget from %s to %s", remote, local)
         f_ostores = self.filtered_readable_openedstores(remote)
         get_options = copy.copy(options)
         if len(f_ostores) > 1:
             first_checkable = all([s.has_fast_check() for s in f_ostores[:-1]])
             # Early-fetch is only available on the last resort store...
-            if first_checkable and all([not s.check(remote.copy(), get_options)
-                                        for s in f_ostores[:-1]]):
-                return f_ostores[-1].earlyget(remote.copy(), local, get_options)
+            if first_checkable and all(
+                [
+                    not s.check(remote.copy(), get_options)
+                    for s in f_ostores[:-1]
+                ]
+            ):
+                return f_ostores[-1].earlyget(
+                    remote.copy(), local, get_options
+                )
             else:
                 return None
         elif len(f_ostores) == 1:
@@ -658,33 +747,33 @@ class MultiStore(footprints.FootprintBase):
 
     def finaliseget(self, result_id, remote, local, options=None):
         options = self._options_fixup(options)
-        logger.debug('Multistore finaliseget from %s to %s', remote, local)
+        logger.debug("Multistore finaliseget from %s to %s", remote, local)
         return self._refilling_get(remote, local, options, result_id=result_id)
 
     def put(self, local, remote, options=None):
         """Go through internal opened stores and put resource for each of them."""
         options = self._options_fixup(options)
-        logger.debug('Multistore put from %s to %s', local, remote)
+        logger.debug("Multistore put from %s to %s", local, remote)
         f_ostores = self.filtered_writeable_openedstores(remote)
         if not f_ostores:
-            logger.warning('Funny attempt to put on an empty multistore...')
+            logger.warning("Funny attempt to put on an empty multistore...")
             return False
         rc = True
         for sto in [ostore for ostore in f_ostores if ostore.writeable]:
-            logger.debug('Multistore put at %s', sto)
+            logger.debug("Multistore put at %s", sto)
             rcloc = sto.put(local, remote.copy(), options)
-            logger.debug('Multistore out = %s', rcloc)
+            logger.debug("Multistore out = %s", rcloc)
             rc = rc and rcloc
         return rc
 
     def delete(self, remote, options=None):
         """Go through internal opened stores and delete the resource."""
         options = self._options_fixup(options)
-        logger.debug('Multistore delete from %s', remote)
+        logger.debug("Multistore delete from %s", remote)
         f_ostores = self.filtered_writeable_openedstores(remote)
         rc = False
         for sto in [ostore for ostore in f_ostores if ostore.writeable]:
-            logger.debug('Multistore delete at %s', sto)
+            logger.debug("Multistore delete at %s", sto)
             rc = sto.delete(remote.copy(), options)
             if not rc:
                 break
@@ -700,40 +789,42 @@ class ArchiveStore(Store):
     _footprint = [
         compressionpipeline,
         dict(
-            info = 'Generic archive store',
-            attr = dict(
-                scheme = dict(
-                    values   = ['inarchive', ],
+            info="Generic archive store",
+            attr=dict(
+                scheme=dict(
+                    values=[
+                        "inarchive",
+                    ],
                 ),
-                netloc = dict(
-                    values   = ['open.archive.fr'],
+                netloc=dict(
+                    values=["open.archive.fr"],
                 ),
-                storehash = dict(
-                    values   = hashalgo_avail_list,
+                storehash=dict(
+                    values=hashalgo_avail_list,
                 ),
-                storage = dict(
-                    optional = True,
+                storage=dict(
+                    optional=True,
                 ),
-                storetube = dict(
-                    optional = True,
+                storetube=dict(
+                    optional=True,
                 ),
-                storeroot = dict(
-                    optional = True,
+                storeroot=dict(
+                    optional=True,
                 ),
-                storehead = dict(
-                    optional = True,
+                storehead=dict(
+                    optional=True,
                 ),
-                storetrue = dict(
-                    type     = bool,
-                    optional = True,
-                    default  = True,
+                storetrue=dict(
+                    type=bool,
+                    optional=True,
+                    default=True,
                 ),
-            )
+            ),
         ),
     ]
 
     def __init__(self, *args, **kw):
-        logger.debug('Archive store init %s', self.__class__)
+        logger.debug("Archive store init %s", self.__class__)
         self._archive = None
         self._actual_storage = None
         self._actual_storetube = None
@@ -743,33 +834,33 @@ class ArchiveStore(Store):
 
     @property
     def realkind(self):
-        return 'archivestore'
+        return "archivestore"
 
     @property
     def tracking_extraargs(self):
         tea = super().tracking_extraargs
         if self.storage:
-            tea['storage'] = self.storage
+            tea["storage"] = self.storage
         return tea
 
     def _str_more(self):
-        return 'archive={!r}'.format(self.archive)
+        return "archive={!r}".format(self.archive)
 
     @property
     def underlying_archive_kind(self):
-        return 'std'
+        return "std"
 
     @property
     def actual_storage(self):
         """This archive network name (potentially read form the configuration file)."""
         if self._actual_storage is None:
             self._actual_storage = (
-                self.system.env.VORTEX_DEFAULT_STORAGE or
-                self.system.glove.default_fthost or
-                from_config(section="storage", key="address")
+                self.system.env.VORTEX_DEFAULT_STORAGE
+                or self.system.glove.default_fthost
+                or from_config(section="storage", key="address")
             )
             if self._actual_storage is None:
-                raise ValueError('Unable to find the archive network name.')
+                raise ValueError("Unable to find the archive network name.")
         return self._actual_storage
 
     @property
@@ -777,10 +868,11 @@ class ArchiveStore(Store):
         """This archive network name (potentially read form the configuration file)."""
         if self._actual_storetube is None:
             self._actual_storetube = from_config(
-                section="storage", key="protocol",
+                section="storage",
+                key="protocol",
             )
             if self._actual_storetube is None:
-                raise ValueError('Unable to find the archive access method.')
+                raise ValueError("Unable to find the archive access method.")
         return self._actual_storetube
 
     def _get_archive(self):
@@ -808,12 +900,12 @@ class ArchiveStore(Store):
 
     def _inarchiveformatpath(self, remote):
         # Remove extra slashes
-        formatted = remote['path'].lstrip(self.system.path.sep)
+        formatted = remote["path"].lstrip(self.system.path.sep)
         # Store head ?
         if self.storehead:
             formatted = self.system.path.join(self.storehead, formatted)
         # Store root (if specified)
-        pathroot = remote.get('root', self.storeroot)
+        pathroot = remote.get("root", self.storeroot)
         if pathroot is not None:
             formatted = self.system.path.join(pathroot, formatted)
         return formatted
@@ -822,101 +914,141 @@ class ArchiveStore(Store):
         """Use the archive object to check if **remote** exists."""
         # Try to delete the md5 file but ignore errors...
         if self._hash_check_or_delete(self.inarchivecheck, remote, options):
-            return self.archive.check(self._inarchiveformatpath(remote),
-                                      username=remote.get('username', None),
-                                      fmt=options.get('fmt', 'foo'),
-                                      compressionpipeline=self._actual_cpipeline)
+            return self.archive.check(
+                self._inarchiveformatpath(remote),
+                username=remote.get("username", None),
+                fmt=options.get("fmt", "foo"),
+                compressionpipeline=self._actual_cpipeline,
+            )
         else:
             return False
 
     def inarchivelocate(self, remote, options):
         """Use the archive object to obtain **remote** physical location."""
-        return self.archive.fullpath(self._inarchiveformatpath(remote),
-                                     username=remote.get('username', None),
-                                     fmt=options.get('fmt', 'foo'),
-                                     compressionpipeline=self._actual_cpipeline)
+        return self.archive.fullpath(
+            self._inarchiveformatpath(remote),
+            username=remote.get("username", None),
+            fmt=options.get("fmt", "foo"),
+            compressionpipeline=self._actual_cpipeline,
+        )
 
     def inarchivelist(self, remote, options):
         """Use the archive object to list available files."""
-        return self.archive.list(self._inarchiveformatpath(remote),
-                                 username=remote.get('username', None))
+        return self.archive.list(
+            self._inarchiveformatpath(remote),
+            username=remote.get("username", None),
+        )
 
     def inarchiveprestageinfo(self, remote, options):
         """Returns the prestaging informations"""
-        return self.archive.prestageinfo(self._inarchiveformatpath(remote),
-                                         username=remote.get('username', None),
-                                         fmt=options.get('fmt', 'foo'),
-                                         compressionpipeline=self._actual_cpipeline)
+        return self.archive.prestageinfo(
+            self._inarchiveformatpath(remote),
+            username=remote.get("username", None),
+            fmt=options.get("fmt", "foo"),
+            compressionpipeline=self._actual_cpipeline,
+        )
 
     def inarchiveget(self, remote, local, options):
         """Use the archive object to retrieve **remote** in **local**."""
-        logger.info('inarchiveget on %s://%s/%s (to: %s)',
-                    self.scheme, self.netloc, self._inarchiveformatpath(remote), local)
+        logger.info(
+            "inarchiveget on %s://%s/%s (to: %s)",
+            self.scheme,
+            self.netloc,
+            self._inarchiveformatpath(remote),
+            local,
+        )
         rc = self.archive.retrieve(
-            self._inarchiveformatpath(remote), local,
-            intent=options.get('intent', ARCHIVE_GET_INTENT_DEFAULT),
-            fmt=options.get('fmt', 'foo'),
-            info=options.get('rhandler', None),
-            username=remote['username'],
+            self._inarchiveformatpath(remote),
+            local,
+            intent=options.get("intent", ARCHIVE_GET_INTENT_DEFAULT),
+            fmt=options.get("fmt", "foo"),
+            info=options.get("rhandler", None),
+            username=remote["username"],
             compressionpipeline=self._actual_cpipeline,
         )
-        return rc and self._hash_get_check(self.inarchiveget, remote, local, options)
+        return rc and self._hash_get_check(
+            self.inarchiveget, remote, local, options
+        )
 
     def inarchiveearlyget(self, remote, local, options):
         """Use the archive object to initiate an early get request on **remote**."""
-        logger.debug('inarchiveearlyget on %s://%s/%s (to: %s)',
-                     self.scheme, self.netloc, self._inarchiveformatpath(remote), local)
+        logger.debug(
+            "inarchiveearlyget on %s://%s/%s (to: %s)",
+            self.scheme,
+            self.netloc,
+            self._inarchiveformatpath(remote),
+            local,
+        )
         rc = self.archive.earlyretrieve(
-            self._inarchiveformatpath(remote), local,
-            intent=options.get('intent', ARCHIVE_GET_INTENT_DEFAULT),
-            fmt=options.get('fmt', 'foo'),
-            info=options.get('rhandler', None),
-            username=remote['username'],
+            self._inarchiveformatpath(remote),
+            local,
+            intent=options.get("intent", ARCHIVE_GET_INTENT_DEFAULT),
+            fmt=options.get("fmt", "foo"),
+            info=options.get("rhandler", None),
+            username=remote["username"],
             compressionpipeline=self._actual_cpipeline,
         )
         return rc
 
     def inarchivefinaliseget(self, result_id, remote, local, options):
         """Use the archive object to finalise the **result_id** early get request."""
-        logger.info('inarchivefinaliseget on %s://%s/%s (to: %s)',
-                    self.scheme, self.netloc, self._inarchiveformatpath(remote), local)
+        logger.info(
+            "inarchivefinaliseget on %s://%s/%s (to: %s)",
+            self.scheme,
+            self.netloc,
+            self._inarchiveformatpath(remote),
+            local,
+        )
         rc = self.archive.finaliseretrieve(
             result_id,
-            self._inarchiveformatpath(remote), local,
-            intent=options.get('intent', ARCHIVE_GET_INTENT_DEFAULT),
-            fmt=options.get('fmt', 'foo'),
-            info=options.get('rhandler', None),
-            username=remote['username'],
+            self._inarchiveformatpath(remote),
+            local,
+            intent=options.get("intent", ARCHIVE_GET_INTENT_DEFAULT),
+            fmt=options.get("fmt", "foo"),
+            info=options.get("rhandler", None),
+            username=remote["username"],
             compressionpipeline=self._actual_cpipeline,
         )
-        return rc and self._hash_get_check(self.inarchiveget, remote, local, options)
+        return rc and self._hash_get_check(
+            self.inarchiveget, remote, local, options
+        )
 
     def inarchiveput(self, local, remote, options):
         """Use the archive object to put **local** to **remote**"""
-        logger.info('inarchiveput to %s://%s/%s (from: %s)',
-                    self.scheme, self.netloc, self._inarchiveformatpath(remote), local)
+        logger.info(
+            "inarchiveput to %s://%s/%s (from: %s)",
+            self.scheme,
+            self.netloc,
+            self._inarchiveformatpath(remote),
+            local,
+        )
         rc = self.archive.insert(
-            self._inarchiveformatpath(remote), local,
+            self._inarchiveformatpath(remote),
+            local,
             intent=ARCHIVE_PUT_INTENT,
-            fmt=options.get('fmt', 'foo'),
-            info=options.get('rhandler'),
-            username=remote['username'],
+            fmt=options.get("fmt", "foo"),
+            info=options.get("rhandler"),
+            username=remote["username"],
             compressionpipeline=self._actual_cpipeline,
-            enforcesync=options.get('enforcesync', False),
-            usejeeves=options.get('delayed', None),
+            enforcesync=options.get("enforcesync", False),
+            usejeeves=options.get("delayed", None),
         )
         return rc and self._hash_put(self.inarchiveput, local, remote, options)
 
     def inarchivedelete(self, remote, options):
-        logger.info('inarchivedelete on %s://%s/%s',
-                    self.scheme, self.netloc, self._inarchiveformatpath(remote))
+        logger.info(
+            "inarchivedelete on %s://%s/%s",
+            self.scheme,
+            self.netloc,
+            self._inarchiveformatpath(remote),
+        )
         # Try to delete the md5 file but ignore errors...
         self._hash_check_or_delete(self.inarchivedelete, remote, options)
         return self.archive.delete(
             self._inarchiveformatpath(remote),
-            fmt=options.get('fmt', 'foo'),
-            info=options.get('rhandler', None),
-            username=remote['username'],
+            fmt=options.get("fmt", "foo"),
+            info=options.get("rhandler", None),
+            username=remote["username"],
             compressionpipeline=self._actual_cpipeline,
         )
 
@@ -935,12 +1067,12 @@ class ConfigurableArchiveStore:
     #: Path to the Store configuration file (please overwrite !)
     _store_global_config = None
     _datastore_id = None
-    _re_subhosting = re.compile(r'(.*)\s+hosted\s+by\s+([-\w]+)$')
+    _re_subhosting = re.compile(r"(.*)\s+hosted\s+by\s+([-\w]+)$")
 
     @staticmethod
     def _get_remote_config(store, url, container):
         """Fetch a configuration file from **url** using **store**."""
-        rc = store.get(url, container.iotarget(), dict(fmt='ascii'))
+        rc = store.get(url, container.iotarget(), dict(fmt="ascii"))
         if rc:
             return config.GenericConfigParser(inifile=container.iotarget())
         else:
@@ -948,57 +1080,75 @@ class ConfigurableArchiveStore:
 
     @staticmethod
     def _please_fix(what):
-        logger.error('Please fix that quickly... Meanwhile, "%s" is ignored !', what)
+        logger.error(
+            'Please fix that quickly... Meanwhile, "%s" is ignored !', what
+        )
 
     def _process_location_section(self, section, section_items):
         section_data = dict()
         m_section = self._re_subhosting.match(section)
         if m_section:
             # A "hosted by" section
-            section_data['idrestricts'] = list()
+            section_data["idrestricts"] = list()
             for k, v in section_items:
-                if k.endswith('_idrestrict'):
+                if k.endswith("_idrestrict"):
                     try:
                         compiled_re = re.compile(v)
-                        section_data['idrestricts'].append(compiled_re)
+                        section_data["idrestricts"].append(compiled_re)
                     except re.error as e:
-                        logger.error('The regex provided for "%s" in section "%s" does not compile !: "%s".',
-                                     k, section, str(e))
+                        logger.error(
+                            'The regex provided for "%s" in section "%s" does not compile !: "%s".',
+                            k,
+                            section,
+                            str(e),
+                        )
                         self._please_fix(k)
-                elif k == 'idrestricts':
-                    logger.error('A "%s" entrey was found in section "%s". This is not ok.', k, section)
+                elif k == "idrestricts":
+                    logger.error(
+                        'A "%s" entrey was found in section "%s". This is not ok.',
+                        k,
+                        section,
+                    )
                     self._please_fix(k)
                 else:
                     section_data[k] = v
-            if section_data['idrestricts']:
+            if section_data["idrestricts"]:
                 return m_section.group(1), m_section.group(2), section_data
             else:
-                logger.error('No acceptable "_idrestrict" entry was found in section "%s".', section)
+                logger.error(
+                    'No acceptable "_idrestrict" entry was found in section "%s".',
+                    section,
+                )
                 self._please_fix(section)
                 return None, None, None
         else:
             # The usual/generic section
             for k, v in section_items:
-                if k.endswith('_idrestrict') or k == 'idrestricts':
-                    logger.error('A "*idrestrict*" entry was found in section "%s". This is not ok.', section)
+                if k.endswith("_idrestrict") or k == "idrestricts":
+                    logger.error(
+                        'A "*idrestrict*" entry was found in section "%s". This is not ok.',
+                        section,
+                    )
                     self._please_fix(section)
                     return None, None, None
                 section_data[k] = v
             return section, None, section_data
 
     def _ingest_remote_config(self, r_id, r_confdict, global_confdict):
-        logger.info("Reading config file: %s (id=%s)", r_confdict['uri'], r_id)
-        url = net.uriparse(r_confdict['uri'])
+        logger.info("Reading config file: %s (id=%s)", r_confdict["uri"], r_id)
+        url = net.uriparse(r_confdict["uri"])
         tempstore = footprints.proxy.store(
-            scheme=url['scheme'],
-            netloc=url['netloc'],
+            scheme=url["scheme"],
+            netloc=url["netloc"],
             storetrack=False,
         )
         retry = False
         # First, try with a temporary ShouldFly
         try:
             tempcontainer = footprints.proxy.container(shouldfly=True)
-            remotecfg_parser = self._get_remote_config(tempstore, url, tempcontainer)
+            remotecfg_parser = self._get_remote_config(
+                tempstore, url, tempcontainer
+            )
         except OSError:
             # This may happen if the user has insufficient rights on
             # the current directory
@@ -1007,31 +1157,43 @@ class ConfigurableArchiveStore:
             self.system.remove(tempcontainer.filename)
         # Is retry needed ? This time a completely virtual file is used.
         if retry:
-            remotecfg_parser = self._get_remote_config(tempstore, url,
-                                                       footprints.proxy.container(incore=True))
+            remotecfg_parser = self._get_remote_config(
+                tempstore, url, footprints.proxy.container(incore=True)
+            )
         # Update the configuration using the parser
         if remotecfg_parser is not None:
             for section in remotecfg_parser.sections():
                 s_loc, s_entry, s_data = self._process_location_section(
-                    section,
-                    remotecfg_parser.items(section)
+                    section, remotecfg_parser.items(section)
                 )
                 if s_loc is not None:
-                    logger.debug("New location entry found: %s (subentry: %s)", s_loc, s_entry)
+                    logger.debug(
+                        "New location entry found: %s (subentry: %s)",
+                        s_loc,
+                        s_entry,
+                    )
                     # Filtering based on the regex : No collisions allowed !
-                    if r_confdict['restrict'] is not None:
-                        if r_confdict['restrict'].search(s_loc):
-                            global_confdict['locations'][s_loc][s_entry] = s_data
+                    if r_confdict["restrict"] is not None:
+                        if r_confdict["restrict"].search(s_loc):
+                            global_confdict["locations"][s_loc][s_entry] = (
+                                s_data
+                            )
                         else:
-                            logger.error('According to the "restrict" clause, ' +
-                                         'you are not allowed to define the "%s" location !', s_loc)
+                            logger.error(
+                                'According to the "restrict" clause, '
+                                + 'you are not allowed to define the "%s" location !',
+                                s_loc,
+                            )
                             self._please_fix(section)
                     else:
-                        global_confdict['locations'][s_loc][s_entry] = s_data
-            r_confdict['seen'] = True
+                        global_confdict["locations"][s_loc][s_entry] = s_data
+            r_confdict["seen"] = True
         else:
-            raise OSError("The remote configuration {:s} couldn't be found."
-                          .format(r_confdict['uri']))
+            raise OSError(
+                "The remote configuration {:s} couldn't be found.".format(
+                    r_confdict["uri"]
+                )
+            )
 
     def _load_config(self, conf, tlocation):
         """Load the store configuration.
@@ -1053,72 +1215,100 @@ class ConfigurableArchiveStore:
 
         if not conf:
             # This is the first call to this method
-            logger.info("Some store configuration data is needed (for %s://%s)",
-                        self.scheme, self.netloc)
+            logger.info(
+                "Some store configuration data is needed (for %s://%s)",
+                self.scheme,
+                self.netloc,
+            )
 
             # Global configuration file
             logger.info("Reading config file: %s", self._store_global_config)
-            maincfg = config.GenericConfigParser(inifile=self._store_global_config)
+            maincfg = config.GenericConfigParser(
+                inifile=self._store_global_config
+            )
             if self.actual_storage in maincfg.sections():
-                conf['host'] = dict(maincfg.items(self.actual_storage))
+                conf["host"] = dict(maincfg.items(self.actual_storage))
             else:
-                conf['host'] = dict(maincfg.defaults())
+                conf["host"] = dict(maincfg.defaults())
 
-            conf['locations'] = defaultdict(functools.partial(defaultdict, dict))
-            conf['remoteconfigs'] = defaultdict(_default_remoteconfig_dict)
-            conf['uuids_cache'] = dict()
+            conf["locations"] = defaultdict(
+                functools.partial(defaultdict, dict)
+            )
+            conf["remoteconfigs"] = defaultdict(_default_remoteconfig_dict)
+            conf["uuids_cache"] = dict()
 
             # Look for a local configuration file
-            localcfg = conf['host'].get('localconf', None)
+            localcfg = conf["host"].get("localconf", None)
             if localcfg is not None:
                 logger.info("Reading config file: %s", localcfg)
                 localcfg = config.GenericConfigParser(inifile=localcfg)
-                conf['locations']['generic'][None] = localcfg.defaults()
+                conf["locations"]["generic"][None] = localcfg.defaults()
                 for section in localcfg.sections():
                     s_loc, s_entry, s_data = self._process_location_section(
-                        section,
-                        localcfg.items(section)
+                        section, localcfg.items(section)
                     )
                     if s_loc is not None:
-                        logger.debug("New location entry found: %s (subentry: %s)", s_loc, s_entry)
-                        conf['locations'][s_loc][s_entry] = s_data
+                        logger.debug(
+                            "New location entry found: %s (subentry: %s)",
+                            s_loc,
+                            s_entry,
+                        )
+                        conf["locations"][s_loc][s_entry] = s_data
 
             # Look for remote configurations
             tg_inet = self.system.default_target.inetname
-            for key in conf['host'].keys():
-                k_match = re.match(r'generic_(remoteconf\w*)_uri$', key)
+            for key in conf["host"].keys():
+                k_match = re.match(r"generic_(remoteconf\w*)_uri$", key)
                 if k_match:
                     r_id = k_match.group(1)
                     g_uri_key = key
-                    i_uri_key = '{:s}_{:s}_uri'.format(tg_inet, r_id)
-                    g_restrict_key = 'generic_{:s}_restrict'.format(r_id)
-                    i_restrict_key = '{:s}_{:s}_restrict'.format(tg_inet, r_id)
-                    if i_uri_key in conf['host'].keys():
-                        conf['remoteconfigs'][r_id]['uri'] = conf['host'][i_uri_key]
+                    i_uri_key = "{:s}_{:s}_uri".format(tg_inet, r_id)
+                    g_restrict_key = "generic_{:s}_restrict".format(r_id)
+                    i_restrict_key = "{:s}_{:s}_restrict".format(tg_inet, r_id)
+                    if i_uri_key in conf["host"].keys():
+                        conf["remoteconfigs"][r_id]["uri"] = conf["host"][
+                            i_uri_key
+                        ]
                     else:
-                        conf['remoteconfigs'][r_id]['uri'] = conf['host'][g_uri_key]
-                    if i_restrict_key in conf['host'].keys():
-                        conf['remoteconfigs'][r_id]['restrict'] = conf['host'][i_restrict_key]
-                    elif g_restrict_key in conf['host'].keys():
-                        conf['remoteconfigs'][r_id]['restrict'] = conf['host'][g_restrict_key]
+                        conf["remoteconfigs"][r_id]["uri"] = conf["host"][
+                            g_uri_key
+                        ]
+                    if i_restrict_key in conf["host"].keys():
+                        conf["remoteconfigs"][r_id]["restrict"] = conf["host"][
+                            i_restrict_key
+                        ]
+                    elif g_restrict_key in conf["host"].keys():
+                        conf["remoteconfigs"][r_id]["restrict"] = conf["host"][
+                            g_restrict_key
+                        ]
                     # Trying to compile the regex !
-                    if conf['remoteconfigs'][r_id]['restrict'] is not None:
+                    if conf["remoteconfigs"][r_id]["restrict"] is not None:
                         try:
-                            compiled_re = re.compile(conf['remoteconfigs'][r_id]['restrict'])
-                            conf['remoteconfigs'][r_id]['restrict'] = compiled_re
+                            compiled_re = re.compile(
+                                conf["remoteconfigs"][r_id]["restrict"]
+                            )
+                            conf["remoteconfigs"][r_id]["restrict"] = (
+                                compiled_re
+                            )
                         except re.error as e:
-                            logger.error('The regex provided for "%s" does not compile !: "%s".',
-                                         r_id, str(e))
+                            logger.error(
+                                'The regex provided for "%s" does not compile !: "%s".',
+                                r_id,
+                                str(e),
+                            )
                             self._please_fix(r_id)
-                            del conf['remoteconfigs'][r_id]
+                            del conf["remoteconfigs"][r_id]
 
-            for r_confk, r_conf in conf['remoteconfigs'].items():
-                if r_conf['restrict'] is None:
+            for r_confk, r_conf in conf["remoteconfigs"].items():
+                if r_conf["restrict"] is None:
                     self._ingest_remote_config(r_confk, r_conf, conf)
 
-        for r_confk, r_conf in conf['remoteconfigs'].items():
-            if ((not r_conf['seen']) and r_conf['restrict'] is not None and
-                    r_conf['restrict'].search(tlocation)):
+        for r_confk, r_conf in conf["remoteconfigs"].items():
+            if (
+                (not r_conf["seen"])
+                and r_conf["restrict"] is not None
+                and r_conf["restrict"].search(tlocation)
+            ):
                 self._ingest_remote_config(r_confk, r_conf, conf)
 
     def _actual_fromconf(self, uuid, item):
@@ -1130,38 +1320,52 @@ class ConfigurableArchiveStore:
         method
         """
         ds = sessions.current().datastore
-        conf = ds.get(self._datastore_id, dict(storage=self.actual_storage),
-                      default_payload=dict(), readonly=True)
-        if (uuid, item) in conf.get('uuids_cache', dict()):
-            return conf['uuids_cache'][(uuid, item)]
+        conf = ds.get(
+            self._datastore_id,
+            dict(storage=self.actual_storage),
+            default_payload=dict(),
+            readonly=True,
+        )
+        if (uuid, item) in conf.get("uuids_cache", dict()):
+            return conf["uuids_cache"][(uuid, item)]
         else:
-            logger.debug('Looking for %s''s "%s" in config.', uuid, item)
+            logger.debug('Looking for %ss "%s" in config.', uuid, item)
             mylocation = uuid.location
             self._load_config(conf, mylocation)
             st_item = None
-            if mylocation in conf['locations']:
+            if mylocation in conf["locations"]:
                 # The default
-                if None in conf['locations'][mylocation]:
-                    st_item = conf['locations'][mylocation][None].get(item, None)
+                if None in conf["locations"][mylocation]:
+                    st_item = conf["locations"][mylocation][None].get(
+                        item, None
+                    )
                 # Id based
-                for s_entry, s_entry_d in conf['locations'][mylocation].items():
+                for s_entry, s_entry_d in conf["locations"][
+                    mylocation
+                ].items():
                     if s_entry is not None:
-                        if any([idrestrict.search(uuid.id)
-                                for idrestrict in s_entry_d['idrestricts']]):
+                        if any(
+                            [
+                                idrestrict.search(uuid.id)
+                                for idrestrict in s_entry_d["idrestricts"]
+                            ]
+                        ):
                             st_item = s_entry_d.get(item, None)
-            st_item = st_item or conf['locations']['generic'][None].get(item, None)
-            conf['uuids_cache'][(uuid, item)] = st_item
+            st_item = st_item or conf["locations"]["generic"][None].get(
+                item, None
+            )
+            conf["uuids_cache"][(uuid, item)] = st_item
             return st_item
 
     def _actual_storeroot(self, uuid):
         """For a given **uuid**, determine the proper storeroot."""
         if self.storeroot is None:
             # Read the storeroot from the configuration data
-            st_root = self._actual_fromconf(uuid, 'storeroot')
+            st_root = self._actual_fromconf(uuid, "storeroot")
             if st_root is None:
                 raise OSError("No valid storeroot could be found.")
             # The location may be an alias: find the real username
-            realname = self._actual_fromconf(uuid, 'realname')
+            realname = self._actual_fromconf(uuid, "realname")
             if realname is None:
                 mylocation = uuid.location
             else:
@@ -1180,46 +1384,46 @@ class CacheStore(Store):
 
     _abstract = True
     _footprint = dict(
-        info = 'Generic cache store',
-        attr = dict(
-            scheme = dict(
-                values   = ['incache'],
+        info="Generic cache store",
+        attr=dict(
+            scheme=dict(
+                values=["incache"],
             ),
-            netloc = dict(
-                values   = ['open.cache.fr'],
+            netloc=dict(
+                values=["open.cache.fr"],
             ),
-            storehash = dict(
-                values = hashalgo_avail_list,
+            storehash=dict(
+                values=hashalgo_avail_list,
             ),
-            strategy = dict(
-                optional = True,
-                default  = 'std',
+            strategy=dict(
+                optional=True,
+                default="std",
             ),
-            headdir = dict(
-                optional = True,
-                default  = 'conf',
+            headdir=dict(
+                optional=True,
+                default="conf",
             ),
-            rtouch = dict(
-                type     = bool,
-                optional = True,
-                default  = False,
+            rtouch=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            rtouchskip = dict(
-                type     = int,
-                optional = True,
-                default  = 0,
+            rtouchskip=dict(
+                type=int,
+                optional=True,
+                default=0,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
         del self.cache
-        logger.debug('Generic cache store init %s', self.__class__)
+        logger.debug("Generic cache store init %s", self.__class__)
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
-        return 'cachestore'
+        return "cachestore"
 
     def use_cache(self):
         """Boolean value to insure that this store is using a cache."""
@@ -1241,7 +1445,7 @@ class CacheStore(Store):
                 headdir=self.headdir,
                 rtouch=self.rtouch,
                 rtouchskip=self.rtouchskip,
-                readonly=self.readonly
+                readonly=self.readonly,
             )
             self._caches_object_stack.add(self._cache)
         return self._cache
@@ -1258,74 +1462,98 @@ class CacheStore(Store):
     cache = property(_get_cache, _set_cache, _del_cache)
 
     def _str_more(self):
-        return 'entry={:s}'.format(self.cache.entry)
+        return "entry={:s}".format(self.cache.entry)
 
     def incachecheck(self, remote, options):
         """Returns a stat-like object if the ``remote`` exists in the current cache."""
         if self._hash_check_or_delete(self.incachecheck, remote, options):
-            st = self.cache.check(remote['path'])
-            if options.get('isfile', False) and st:
-                st = self.system.path.isfile(self.incachelocate(remote, options))
+            st = self.cache.check(remote["path"])
+            if options.get("isfile", False) and st:
+                st = self.system.path.isfile(
+                    self.incachelocate(remote, options)
+                )
             return st
         else:
             return False
 
     def incachelocate(self, remote, options):
         """Agregates cache to remote subpath."""
-        return self.cache.fullpath(remote['path'])
+        return self.cache.fullpath(remote["path"])
 
     def incachelist(self, remote, options):
         """List the content of a remote path."""
-        return self.cache.list(remote['path'])
+        return self.cache.list(remote["path"])
 
     def incacheprestageinfo(self, remote, options):
         """Returns pre-staging informations."""
-        return self.cache.prestageinfo(remote['path'])
+        return self.cache.prestageinfo(remote["path"])
 
     def incacheget(self, remote, local, options):
         """Simple copy from current cache cache to ``local``."""
-        logger.info('incacheget on %s://%s/%s (to: %s)',
-                    self.scheme, self.netloc, remote['path'], local)
-        rc = self.cache.retrieve(
-            remote['path'],
+        logger.info(
+            "incacheget on %s://%s/%s (to: %s)",
+            self.scheme,
+            self.netloc,
+            remote["path"],
             local,
-            intent=options.get('intent', CACHE_GET_INTENT_DEFAULT),
-            fmt=options.get('fmt'),
-            info=options.get('rhandler', None),
-            tarextract=options.get('auto_tarextract', False),
-            dirextract=options.get('auto_dirextract', False),
-            uniquelevel_ignore=options.get('uniquelevel_ignore', True),
-            silent=options.get('silent', False),
         )
-        if rc or not options.get('silent', False):
-            logger.info('incacheget retrieve rc=%s location=%s', str(rc),
-                        str(self.incachelocate(remote, options)))
-        return rc and self._hash_get_check(self.incacheget, remote, local, options)
+        rc = self.cache.retrieve(
+            remote["path"],
+            local,
+            intent=options.get("intent", CACHE_GET_INTENT_DEFAULT),
+            fmt=options.get("fmt"),
+            info=options.get("rhandler", None),
+            tarextract=options.get("auto_tarextract", False),
+            dirextract=options.get("auto_dirextract", False),
+            uniquelevel_ignore=options.get("uniquelevel_ignore", True),
+            silent=options.get("silent", False),
+        )
+        if rc or not options.get("silent", False):
+            logger.info(
+                "incacheget retrieve rc=%s location=%s",
+                str(rc),
+                str(self.incachelocate(remote, options)),
+            )
+        return rc and self._hash_get_check(
+            self.incacheget, remote, local, options
+        )
 
     def incacheput(self, local, remote, options):
         """Simple copy from ``local`` to the current cache in readonly mode."""
-        logger.info('incacheput to %s://%s/%s (from: %s)',
-                    self.scheme, self.netloc, remote['path'], local)
+        logger.info(
+            "incacheput to %s://%s/%s (from: %s)",
+            self.scheme,
+            self.netloc,
+            remote["path"],
+            local,
+        )
         rc = self.cache.insert(
-            remote['path'],
+            remote["path"],
             local,
             intent=CACHE_PUT_INTENT,
-            fmt=options.get('fmt'),
-            info=options.get('rhandler', None),
+            fmt=options.get("fmt"),
+            info=options.get("rhandler", None),
         )
-        logger.info('incacheput insert rc=%s location=%s', str(rc),
-                    str(self.incachelocate(remote, options)))
+        logger.info(
+            "incacheput insert rc=%s location=%s",
+            str(rc),
+            str(self.incachelocate(remote, options)),
+        )
         return rc and self._hash_put(self.incacheput, local, remote, options)
 
     def incachedelete(self, remote, options):
         """Simple removing of the remote resource in cache."""
-        logger.info('incachedelete on %s://%s/%s',
-                    self.scheme, self.netloc, remote['path'])
+        logger.info(
+            "incachedelete on %s://%s/%s",
+            self.scheme,
+            self.netloc,
+            remote["path"],
+        )
         self._hash_check_or_delete(self.incachedelete, remote, options)
         return self.cache.delete(
-            remote['path'],
-            fmt=options.get('fmt'),
-            info=options.get('rhandler', None),
+            remote["path"],
+            fmt=options.get("fmt"),
+            info=options.get("rhandler", None),
         )
 
 
@@ -1333,38 +1561,33 @@ class PromiseStore(footprints.FootprintBase):
     """Combined a Promise Store for expected resources and any other matching Store."""
 
     _abstract = True
-    _collector = ('store',)
+    _collector = ("store",)
     _footprint = dict(
-        info = 'Promise store',
-        attr = dict(
-            scheme = dict(
-                alias    = ('protocol',)
+        info="Promise store",
+        attr=dict(
+            scheme=dict(alias=("protocol",)),
+            netloc=dict(type=Namespace, alias=("domain", "namespace")),
+            storetrack=dict(
+                type=bool,
+                default=True,
+                optional=True,
             ),
-            netloc = dict(
-                type     = Namespace,
-                alias    = ('domain', 'namespace')
-            ),
-            storetrack = dict(
-                type  = bool,
-                default = True,
-                optional = True,
-            ),
-            prstorename = dict(
-                type     = Namespace,
-                optional = True,
-                default  = 'promise.cache.fr',
+            prstorename=dict(
+                type=Namespace,
+                optional=True,
+                default="promise.cache.fr",
             ),
         ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract promise store init %s', self.__class__)
-        sh = kw.pop('system', sessions.system())
+        logger.debug("Abstract promise store init %s", self.__class__)
+        sh = kw.pop("system", sessions.system())
         super().__init__(*args, **kw)
         self._sh = sh
 
         # Assume that the actual scheme is the current scheme without "x" prefix
-        self.proxyscheme = self.scheme.lstrip('x')
+        self.proxyscheme = self.scheme.lstrip("x")
 
         # Find a store for the promised resources
         self.promise = footprints.proxy.store(
@@ -1373,9 +1596,12 @@ class PromiseStore(footprints.FootprintBase):
             storetrack=self.storetrack,
         )
         if self.promise is None:
-            logger.critical('Could not find store scheme <%s> netloc <%s>',
-                            self.proxyscheme, self.prstorename)
-            raise ValueError('Could not get a Promise Store')
+            logger.critical(
+                "Could not find store scheme <%s> netloc <%s>",
+                self.proxyscheme,
+                self.prstorename,
+            )
+            raise ValueError("Could not get a Promise Store")
 
         # Find the other "real" store (could be a multi-store)
         self.other = footprints.proxy.store(
@@ -1384,15 +1610,19 @@ class PromiseStore(footprints.FootprintBase):
             storetrack=self.storetrack,
         )
         if self.other is None:
-            logger.critical('Could not find store scheme <%s> netloc <%s>', self.proxyscheme, self.netloc)
-            raise ValueError('Could not get an Other Store')
+            logger.critical(
+                "Could not find store scheme <%s> netloc <%s>",
+                self.proxyscheme,
+                self.netloc,
+            )
+            raise ValueError("Could not get an Other Store")
 
         self.openedstores = (self.promise, self.other)
         self.delayed = False
 
     @property
     def realkind(self):
-        return 'promisestore'
+        return "promisestore"
 
     @property
     def system(self):
@@ -1410,13 +1640,13 @@ class PromiseStore(footprints.FootprintBase):
             stamp=date.stamp(),
             itself=self.promise.locate(remote, options),
             locate=self.other.locate(remote, options),
-            datafmt=options.get('fmt', None),
-            rhandler=options.get('rhandler', None),
+            datafmt=options.get("fmt", None),
+            rhandler=options.get("rhandler", None),
         )
 
     def mkpromise_file(self, info, local):
         """Build a virtual container with specified informations."""
-        pfile = local + '.pr'
+        pfile = local + ".pr"
         self.system.json_dump(info, pfile, sort_keys=True, indent=4)
         return pfile
 
@@ -1427,45 +1657,49 @@ class PromiseStore(footprints.FootprintBase):
     def check(self, remote, options=None):
         """Go through internal opened stores and check for the resource."""
         options = self._options_fixup(options)
-        logger.debug('Promise check from %s', remote)
-        return self.other.check(remote.copy(), options) or self.promise.check(remote.copy(), options)
+        logger.debug("Promise check from %s", remote)
+        return self.other.check(remote.copy(), options) or self.promise.check(
+            remote.copy(), options
+        )
 
     def locate(self, remote, options=None):
         """Go through internal opened stores and locate the expected resource for each of them."""
         options = self._options_fixup(options)
-        logger.debug('Promise locate %s', remote)
+        logger.debug("Promise locate %s", remote)
         inpromise = True
         if options:
-            inpromise = options.get('inpromise', True)
+            inpromise = options.get("inpromise", True)
 
         locate_other = self.other.locate(remote.copy(), options)
         if inpromise:
             locate_promised = self.promise.locate(remote.copy(), options)
-            return locate_promised + ';' + locate_other
+            return locate_promised + ";" + locate_other
         return locate_other
 
     def get(self, remote, local, options=None):
         """Go through internal opened stores for the first available resource."""
         options = self._options_fixup(options)
-        logger.debug('Promise get %s', remote)
+        logger.debug("Promise get %s", remote)
         self.delayed = False
-        logger.info('Try promise from store %s', self.promise)
+        logger.info("Try promise from store %s", self.promise)
         try:
             rc = self.promise.get(remote.copy(), local, options)
         except OSError as e:
             # If something goes wrong, assume that the promise file had been
             # deleted during the execution of self.promise.check (which can cause
             # IOError or OSError to be raised).
-            logger.info('An error occurred while fetching the promise file: %s', str(e))
-            logger.info('Assuming this is a negative result...')
+            logger.info(
+                "An error occurred while fetching the promise file: %s", str(e)
+            )
+            logger.info("Assuming this is a negative result...")
             rc = False
         if rc:
             self.delayed = True
         else:
-            logger.info('Try promise from store %s', self.other)
+            logger.info("Try promise from store %s", self.other)
             rc = self.other.get(remote.copy(), local, options)
-        if not rc and options.get('pretend', False):
-            logger.warning('Pretending to get a promise for <%s>', local)
+        if not rc and options.get("pretend", False):
+            logger.warning("Pretending to get a promise for <%s>", local)
             pr_info = self.mkpromise_info(remote, options)
             pr_file = self.mkpromise_file(pr_info, local)
             self.system.move(pr_file, local)
@@ -1475,14 +1709,18 @@ class PromiseStore(footprints.FootprintBase):
     def earlyget(self, remote, local, options=None):
         """Possible early-get on the target store."""
         options = self._options_fixup(options)
-        logger.debug('Promise early-get %s', remote)
+        logger.debug("Promise early-get %s", remote)
         result_id = None
         try:
-            rc = (self.promise.has_fast_check and
-                  self.promise.check(remote.copy(), options))
+            rc = self.promise.has_fast_check and self.promise.check(
+                remote.copy(), options
+            )
         except OSError as e:
-            logger.debug('An error occurred while checking for the promise file: %s', str(e))
-            logger.debug('Assuming this is a negative result...')
+            logger.debug(
+                "An error occurred while checking for the promise file: %s",
+                str(e),
+            )
+            logger.debug("Assuming this is a negative result...")
             rc = False
         if not rc:
             result_id = self.other.earlyget(remote.copy(), local, options)
@@ -1490,70 +1728,87 @@ class PromiseStore(footprints.FootprintBase):
 
     def finaliseget(self, result_id, remote, local, options=None):
         options = self._options_fixup(options)
-        logger.debug('Promise finalise-get %s', remote)
+        logger.debug("Promise finalise-get %s", remote)
         self.delayed = False
-        logger.info('Try promise from store %s', self.promise)
+        logger.info("Try promise from store %s", self.promise)
         try:
             rc = self.promise.get(remote.copy(), local, options)
         except OSError as e:
-            logger.debug('An error occurred while fetching the promise file: %s', str(e))
-            logger.debug('Assuming this is a negative result...')
+            logger.debug(
+                "An error occurred while fetching the promise file: %s", str(e)
+            )
+            logger.debug("Assuming this is a negative result...")
             rc = False
         if rc:
             self.delayed = True
         else:
-            logger.info('Try promise from store %s', self.other)
-            rc = self.other.finaliseget(result_id, remote.copy(), local, options)
+            logger.info("Try promise from store %s", self.other)
+            rc = self.other.finaliseget(
+                result_id, remote.copy(), local, options
+            )
         return rc
 
     @staticmethod
     def _clean_pr_json(prjson):
-        del prjson['stamp']
-        if 'options' in prjson['rhandler']:
-            prjson['rhandler']['options'].pop('storetrack', False)
+        del prjson["stamp"]
+        if "options" in prjson["rhandler"]:
+            prjson["rhandler"]["options"].pop("storetrack", False)
         return prjson
 
     def put(self, local, remote, options=None):
         """Put a promise or the actual resource if available."""
         options = self._options_fixup(options)
-        logger.debug('Multistore put from %s to %s', local, remote)
-        if options.get('force', False) or not self.system.path.exists(local):
+        logger.debug("Multistore put from %s to %s", local, remote)
+        if options.get("force", False) or not self.system.path.exists(local):
             options = options.copy()
             if not self.other.use_cache():
-                logger.critical('Could not promise resource without other cache <%s>', self.other)
-                raise ValueError('Could not promise: other store does not use cache')
+                logger.critical(
+                    "Could not promise resource without other cache <%s>",
+                    self.other,
+                )
+                raise ValueError(
+                    "Could not promise: other store does not use cache"
+                )
             pr_info = self.mkpromise_info(remote, options)
             pr_file = self.mkpromise_file(pr_info, local)
             # Check if a previous promise with the same description exists
             preexisting = self.promise.check(remote.copy(), options)
             if preexisting:
                 pr_old_file = self.promise.locate(remote.copy())
-                prcheck = self._clean_pr_json(self.system.json_load(pr_old_file))
+                prcheck = self._clean_pr_json(
+                    self.system.json_load(pr_old_file)
+                )
                 prnew = self._clean_pr_json(self.system.json_load(pr_file))
                 preexisting = prcheck == prnew
                 if preexisting:
-                    logger.info("The promise file <%s> preexisted and is compatible",
-                                pr_old_file)
+                    logger.info(
+                        "The promise file <%s> preexisted and is compatible",
+                        pr_old_file,
+                    )
                     rc = True
                 else:
-                    logger.warning("The promise file <%s> already exists but doesn't match",
-                                   pr_old_file)
+                    logger.warning(
+                        "The promise file <%s> already exists but doesn't match",
+                        pr_old_file,
+                    )
 
             # Put the new promise file in the PromiseCache
-            options['obs_overridelocal'] = local  # Pretty nasty :-(
+            options["obs_overridelocal"] = local  # Pretty nasty :-(
             if not preexisting:
-                logger.warning('Log a promise instead of missing resource <%s>', local)
+                logger.warning(
+                    "Log a promise instead of missing resource <%s>", local
+                )
                 rc = self.promise.put(pr_file, remote.copy(), options)
                 if rc:
-                    del options['obs_overridelocal']
+                    del options["obs_overridelocal"]
                     self.other.delete(remote.copy(), options)
             else:
-                options['dryrun'] = True  # Just update the tracker
+                options["dryrun"] = True  # Just update the tracker
                 rc = self.promise.put(pr_file, remote.copy(), options)
             self.system.remove(pr_file)
 
         else:
-            logger.info('Actual promise does exists <%s>', local)
+            logger.info("Actual promise does exists <%s>", local)
             rc = self.other.put(local, remote.copy(), options)
             if rc:
                 self.promise.delete(remote.copy(), options)
@@ -1562,11 +1817,13 @@ class PromiseStore(footprints.FootprintBase):
     def delete(self, remote, options=None):
         """Go through internal opened stores and delete the resource."""
         options = self._options_fixup(options)
-        logger.debug('Promise delete from %s', remote)
-        return self.promise.delete(remote.copy(), options) and self.other.delete(remote.copy(), options)
+        logger.debug("Promise delete from %s", remote)
+        return self.promise.delete(
+            remote.copy(), options
+        ) and self.other.delete(remote.copy(), options)
 
 
 # Activate the footprint's fasttrack on the stores collector
-fcollect = footprints.collectors.get(tag='store')
-fcollect.fasttrack = ('netloc', 'scheme')
+fcollect = footprints.collectors.get(tag="store")
+fcollect.fasttrack = ("netloc", "scheme")
 del fcollect

--- a/src/vortex/data/containers.py
+++ b/src/vortex/data/containers.py
@@ -24,7 +24,7 @@ from vortex import sessions
 from vortex.syntax.stdattrs import a_actualfmt
 
 #: Automatic export
-__all__ = ['Container']
+__all__ = ["Container"]
 
 logger = loggers.getLogger(__name__)
 
@@ -34,6 +34,7 @@ CONTAINER_MAXREADSIZE = 1048576 * 200
 
 class DataSizeTooBig(IOError):
     """Exception raised when totasize is over the container MaxReadSize limit."""
+
     pass
 
 
@@ -41,44 +42,58 @@ class Container(footprints.FootprintBase):
     """Abstract class for any Container."""
 
     _abstract = True
-    _collector = ('container',)
+    _collector = ("container",)
     _footprint = dict(
-        info = 'Abstract Container',
-        attr = dict(
-            actualfmt = a_actualfmt,
-            maxreadsize = dict(
-                info            = "The maximum amount of data that can be read (in bytes).",
-                type            = int,
-                optional        = True,
-                default         = CONTAINER_MAXREADSIZE,
-                doc_visibility  = footprints.doc.visibility.GURU,
+        info="Abstract Container",
+        attr=dict(
+            actualfmt=a_actualfmt,
+            maxreadsize=dict(
+                info="The maximum amount of data that can be read (in bytes).",
+                type=int,
+                optional=True,
+                default=CONTAINER_MAXREADSIZE,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            mode = dict(
-                info            = "The file mode used to open the container.",
-                optional        = True,
-                values          = ['a', 'a+', 'ab', 'a+b', 'ab+',
-                                   'r', 'r+', 'rb', 'rb+', 'r+b',
-                                   'w', 'w+', 'wb', 'w+b', 'wb+'],
-                remap           = {'a+b': 'ab+', 'r+b': 'rb+', 'w+b': 'wb+'},
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            mode=dict(
+                info="The file mode used to open the container.",
+                optional=True,
+                values=[
+                    "a",
+                    "a+",
+                    "ab",
+                    "a+b",
+                    "ab+",
+                    "r",
+                    "r+",
+                    "rb",
+                    "rb+",
+                    "r+b",
+                    "w",
+                    "w+",
+                    "wb",
+                    "w+b",
+                    "wb+",
+                ],
+                remap={"a+b": "ab+", "r+b": "rb+", "w+b": "wb+"},
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            encoding = dict(
-                info            = "When opened in text mode, the encoding that will be used.",
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            encoding=dict(
+                info="When opened in text mode, the encoding that will be used.",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-        )
+        ),
     )
 
-    _DEFAULTMODE = 'rb'
+    _DEFAULTMODE = "rb"
 
     @property
     def realkind(self):
-        return 'container'
+        return "container"
 
     def __init__(self, *args, **kw):
         """Preset to None or False hidden attributes ``iod``, ``iomode`` and ``filled``."""
-        logger.debug('Container %s init', self.__class__)
+        logger.debug("Container %s init", self.__class__)
         super().__init__(*args, **kw)
         self._iod = None
         self._iomode = None
@@ -93,24 +108,28 @@ class Container(footprints.FootprintBase):
     def __getstate__(self):
         d = super().__getstate__()
         # Start from a clean slate regarding IO descriptors
-        d['_iod'] = None
-        d['_acmode'] = None
-        d['_acencoding'] = None
+        d["_iod"] = None
+        d["_acmode"] = None
+        d["_acencoding"] = None
         return d
 
     @secure_getattr
     def __getattr__(self, key):
         """Gateway to undefined method or attributes if present in internal io descriptor."""
         # It avoids to call self.iodesc() when footprint_export is called...
-        if (key.startswith('footprint_export') or
-                key in ('export_dict', 'as_dump', 'as_dict', '_iod')):
-            raise AttributeError('Could not get an io descriptor')
+        if key.startswith("footprint_export") or key in (
+            "export_dict",
+            "as_dump",
+            "as_dict",
+            "_iod",
+        ):
+            raise AttributeError("Could not get an io descriptor")
         # Normal processing
         iod = self.iodesc()
         if iod:
             return getattr(iod, key)
         else:
-            raise AttributeError('Could not get an io descriptor')
+            raise AttributeError("Could not get an io descriptor")
 
     @contextlib.contextmanager
     def iod_context(self):
@@ -132,8 +151,12 @@ class Container(footprints.FootprintBase):
     def iodesc(self, mode=None, encoding=None):
         """Returns the file object descriptor."""
         mode1, encoding1 = self._get_mode(mode, encoding)
-        if not (self._iod and not self._iod.closed and
-                mode1 == self._acmode and encoding1 == self._acencoding):
+        if not (
+            self._iod
+            and not self._iod.closed
+            and mode1 == self._acmode
+            and encoding1 == self._acencoding
+        ):
             if self._iod and not self._iod.closed:
                 self.close()
                 mode1, encoding1 = self._get_mode(mode, encoding)
@@ -193,7 +216,9 @@ class Container(footprints.FootprintBase):
         if self.totalsize < self.maxreadsize or (0 < n < self.maxreadsize):
             return iod.read(n)
         else:
-            raise DataSizeTooBig('Input is more than {:d} bytes.'.format(self.maxreadsize))
+            raise DataSizeTooBig(
+                "Input is more than {:d} bytes.".format(self.maxreadsize)
+            )
 
     def dataread(self, mode=None, encoding=None):
         """
@@ -218,7 +243,11 @@ class Container(footprints.FootprintBase):
                 lines.append(iod.readline())
                 lsize += len(lines[-1])
                 if lsize > self.maxreadsize:
-                    raise DataSizeTooBig('Input is more than {:d} bytes.'.format(self.maxreadsize))
+                    raise DataSizeTooBig(
+                        "Input is more than {:d} bytes.".format(
+                            self.maxreadsize
+                        )
+                    )
                 nread += 1
             return lines
 
@@ -230,7 +259,9 @@ class Container(footprints.FootprintBase):
                 self.rewind()
                 return iod.readlines()
             else:
-                raise DataSizeTooBig('Input is more than {:d} bytes.'.format(self.maxreadsize))
+                raise DataSizeTooBig(
+                    "Input is more than {:d} bytes.".format(self.maxreadsize)
+                )
 
     def __iter__(self):
         with self.preferred_decoding(byte=False):
@@ -267,22 +298,22 @@ class Container(footprints.FootprintBase):
     @staticmethod
     def _set_amode(actualmode):
         """Upgrade the ``actualmode`` to a append-compatible mode."""
-        am = re.sub('[rw]', 'a', actualmode)
-        am = am.replace('+', '')
-        return am + '+'
+        am = re.sub("[rw]", "a", actualmode)
+        am = am.replace("+", "")
+        return am + "+"
 
     @staticmethod
     def _set_wmode(actualmode):
         """Upgrade the ``actualmode`` to a write-compatible mode."""
-        wm = re.sub('r', 'w', actualmode)
-        wm = wm.replace('+', '')
-        return wm + '+'
+        wm = re.sub("r", "w", actualmode)
+        wm = wm.replace("+", "")
+        return wm + "+"
 
     @staticmethod
     def _set_bmode(actualmode):
         """Upgrade the ``actualmode`` to byte mode."""
-        if 'b' not in actualmode:
-            wm = re.sub(r'([arw])', r'\1b', actualmode)
+        if "b" not in actualmode:
+            wm = re.sub(r"([arw])", r"\1b", actualmode)
             return wm
         else:
             return actualmode
@@ -290,7 +321,7 @@ class Container(footprints.FootprintBase):
     @staticmethod
     def _set_tmode(actualmode):
         """Upgrade the ``actualmode`` to a text-mode."""
-        wm = actualmode.replace('b', '')
+        wm = actualmode.replace("b", "")
         return wm
 
     @contextlib.contextmanager
@@ -366,7 +397,7 @@ class Container(footprints.FootprintBase):
                 pos = iod.tell()
                 iod.seek(0)
                 for xchunk in iod:
-                    print(xchunk.rstrip('\n'))
+                    print(xchunk.rstrip("\n"))
                 iod.seek(pos)
 
     def is_virtual(self):
@@ -378,21 +409,20 @@ class Container(footprints.FootprintBase):
 
 
 class Virtual(Container):
-
     _abstract = True
     _footprint = dict(
-        info = 'Abstract Virtual Container',
-        attr = dict(
-            prefix = dict(
-                info            = "Prefix used if a temporary file needs to be written.",
-                optional        = True,
-                default         = 'vortex.tmp.',
-                doc_visibility  = footprints.doc.visibility.GURU,
+        info="Abstract Virtual Container",
+        attr=dict(
+            prefix=dict(
+                info="Prefix used if a temporary file needs to be written.",
+                optional=True,
+                default="vortex.tmp.",
+                doc_visibility=footprints.doc.visibility.GURU,
             )
-        )
+        ),
     )
 
-    _DEFAULTMODE = 'wb+'
+    _DEFAULTMODE = "wb+"
 
     def is_virtual(self):
         """
@@ -411,32 +441,33 @@ class Virtual(Container):
 
 
 class InCore(Virtual):
-
     _footprint = dict(
-        info = 'Incore container (data are kept in memory as long as possible).',
-        attr = dict(
-            incore = dict(
-                info        = 'Activate the incore container.',
-                type        = bool,
-                values      = [True, ],
-                alias       = ('mem', 'memory'),
-                doc_zorder = 90,
+        info="Incore container (data are kept in memory as long as possible).",
+        attr=dict(
+            incore=dict(
+                info="Activate the incore container.",
+                type=bool,
+                values=[
+                    True,
+                ],
+                alias=("mem", "memory"),
+                doc_zorder=90,
             ),
-            incorelimit = dict(
-                info            = 'If this limit (in bytes) is exceeded, data are flushed to file.',
-                type            = int,
-                optional        = True,
-                default         = CONTAINER_INCORELIMIT,
-                alias           = ('memlimit', 'spooledlimit', 'maxsize'),
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            incorelimit=dict(
+                info="If this limit (in bytes) is exceeded, data are flushed to file.",
+                type=int,
+                optional=True,
+                default=CONTAINER_INCORELIMIT,
+                alias=("memlimit", "spooledlimit", "maxsize"),
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
         ),
-        fastkeys = {'incore'}
+        fastkeys={"incore"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('InCore container init %s', self.__class__)
-        kw.setdefault('incore', True)
+        logger.debug("InCore container init %s", self.__class__)
+        kw.setdefault("incore", True)
         super().__init__(*args, **kw)
         self._tempo = False
 
@@ -446,14 +477,16 @@ class InCore(Virtual):
             if self._tempo or self._iod._rolled:
                 actualfile = self._iod.name
             else:
-                actualfile = 'MemoryResident'
+                actualfile = "MemoryResident"
         else:
-            actualfile = 'NotSpooled'
+            actualfile = "NotSpooled"
         return actualfile
 
     def _str_more(self):
         """Additional information to print representation."""
-        return 'incorelimit={:d} tmpfile="{:s}"'.format(self.incorelimit, self.actualpath())
+        return 'incorelimit={:d} tmpfile="{:s}"'.format(
+            self.incorelimit, self.actualpath()
+        )
 
     def _new_iodesc(self, mode, encoding):
         """Returns an active (opened) spooled file descriptor in binary read mode by default."""
@@ -464,7 +497,7 @@ class InCore(Virtual):
                 prefix=self.prefix,
                 dir=os.getcwd(),
                 delete=True,
-                encoding=encoding
+                encoding=encoding,
             )
         else:
             iod = tempfile.SpooledTemporaryFile(
@@ -472,7 +505,7 @@ class InCore(Virtual):
                 prefix=self.prefix,
                 dir=os.getcwd(),
                 max_size=self.incorelimit,
-                encoding=encoding
+                encoding=encoding,
             )
         return iod
 
@@ -491,7 +524,7 @@ class InCore(Virtual):
                 prefix=self.prefix,
                 dir=os.getcwd(),
                 delete=True,
-                encoding=self._acencoding
+                encoding=self._acencoding,
             )
             for data in iomem:
                 self._iod.write(data)
@@ -509,7 +542,7 @@ class InCore(Virtual):
                 prefix=self.prefix,
                 dir=os.getcwd(),
                 max_size=self.incorelimit,
-                encoding=self._acencoding
+                encoding=self._acencoding,
             )
             for data in iotmp:
                 self._iod.write(data)
@@ -525,36 +558,39 @@ class InCore(Virtual):
         try:
             return iod.name
         except Exception:
-            logger.warning('Could not get local temporary rolled file pathname %s', self)
+            logger.warning(
+                "Could not get local temporary rolled file pathname %s", self
+            )
             raise
 
 
 class MayFly(Virtual):
-
     _footprint = dict(
-        info = 'MayFly container (a temporary file is created only when needed).',
-        attr = dict(
-            mayfly = dict(
-                info       = 'Activate the mayfly container.',
-                type       = bool,
-                values     = [True, ],
-                alias      = ('tempo',),
-                doc_zorder = 90,
+        info="MayFly container (a temporary file is created only when needed).",
+        attr=dict(
+            mayfly=dict(
+                info="Activate the mayfly container.",
+                type=bool,
+                values=[
+                    True,
+                ],
+                alias=("tempo",),
+                doc_zorder=90,
             ),
-            delete = dict(
-                info            = 'Delete the file when the container object is destroyed.',
-                type            = bool,
-                optional        = True,
-                default         = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            delete=dict(
+                info="Delete the file when the container object is destroyed.",
+                type=bool,
+                optional=True,
+                default=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
         ),
-        fastkeys = {'mayfly'}
+        fastkeys={"mayfly"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('MayFly container init %s', self.__class__)
-        kw.setdefault('mayfly', True)
+        logger.debug("MayFly container init %s", self.__class__)
+        kw.setdefault("mayfly", True)
         super().__init__(*args, **kw)
 
     def actualpath(self):
@@ -562,12 +598,14 @@ class MayFly(Virtual):
         if self._iod:
             return self._iod.name
         else:
-            return 'NotDefined'
+            return "NotDefined"
 
     def _str_more(self):
         """Additional information to internal representation."""
 
-        return 'delete={!s} tmpfile="{:s}"'.format(self.delete, self.actualpath())
+        return 'delete={!s} tmpfile="{:s}"'.format(
+            self.delete, self.actualpath()
+        )
 
     def _new_iodesc(self, mode, encoding):
         """Returns an active (opened) temporary file descriptor in binary read mode by default."""
@@ -577,7 +615,7 @@ class MayFly(Virtual):
             prefix=self.prefix,
             dir=os.getcwd(),
             delete=self.delete,
-            encoding=encoding
+            encoding=encoding,
         )
 
     def localpath(self):
@@ -589,7 +627,9 @@ class MayFly(Virtual):
         try:
             return iod.name
         except Exception:
-            logger.warning('Could not get local temporary file pathname %s', self)
+            logger.warning(
+                "Could not get local temporary file pathname %s", self
+            )
             raise
 
 
@@ -597,23 +637,24 @@ class _SingleFileStyle(Container):
     """
     Template for any file container. Data is stored as a file object.
     """
-    _abstract = True,
+
+    _abstract = (True,)
     _footprint = dict(
-        info = 'File container',
-        attr = dict(
-            cwdtied = dict(
-                info            = "If *filename* is a relative path, replace it by its absolute path.",
-                type            = bool,
-                optional        = True,
-                default         = False,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+        info="File container",
+        attr=dict(
+            cwdtied=dict(
+                info="If *filename* is a relative path, replace it by its absolute path.",
+                type=bool,
+                optional=True,
+                default=False,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
         """Business as usual... but define actualpath according to ``cwdtied`` attribute."""
-        logger.debug('_SingleFileStyle container init %s', self.__class__)
+        logger.debug("_SingleFileStyle container init %s", self.__class__)
         super().__init__(*args, **kw)
         if self.cwdtied:
             self._actualpath = os.path.realpath(self.filename)
@@ -646,7 +687,7 @@ class _SingleFileStyle(Container):
 
     def _str_more(self):
         """Additional information to print representation."""
-        return 'path=\'{:s}\''.format(self.actualpath())
+        return "path='{:s}'".format(self.actualpath())
 
     def localpath(self):
         """Returns the actual name of the file object."""
@@ -655,7 +696,11 @@ class _SingleFileStyle(Container):
     def _new_iodesc(self, mode, encoding):
         """Returns an active (opened) file descriptor in binary read mode by default."""
         self.close()
-        currentpath = self._actualpath if self.cwdtied else os.path.realpath(self.filename)
+        currentpath = (
+            self._actualpath
+            if self.cwdtied
+            else os.path.realpath(self.filename)
+        )
         return open(currentpath, mode, encoding=encoding)
 
     def iotarget(self):
@@ -667,7 +712,7 @@ class _SingleFileStyle(Container):
         rst = super().clear(*kargs, **kw)
         # Physically delete the file if it exists
         if self.exists():
-            sh = kw.pop('system', sessions.system())
+            sh = kw.pop("system", sessions.system())
             rst = rst and sh.remove(self.localpath(), fmt=self.actualfmt)
         return rst
 
@@ -680,15 +725,16 @@ class SingleFile(_SingleFileStyle):
     """
     Default file container. Data is stored as a file object.
     """
+
     _footprint = dict(
-        attr = dict(
-            filename = dict(
-                info        = 'Path to the file where data are stored.',
-                alias       = ('filepath', 'local'),
-                doc_zorder  = 50,
+        attr=dict(
+            filename=dict(
+                info="Path to the file where data are stored.",
+                alias=("filepath", "local"),
+                doc_zorder=50,
             ),
         ),
-        fastkeys = {'filename'}
+        fastkeys={"filename"},
     )
 
 
@@ -697,27 +743,30 @@ class UnnamedSingleFile(_SingleFileStyle):
 
     The filename is chosen arbitrarily when the object is created.
     """
+
     _footprint = dict(
-        info = 'File container (a temporary filename is chosen at runtime)',
-        attr = dict(
-            shouldfly = dict(
-                info       = 'Activate the UnnamedSingleFile container',
-                type       = bool,
-                values     = [True, ],
-                doc_zorder = 90,
+        info="File container (a temporary filename is chosen at runtime)",
+        attr=dict(
+            shouldfly=dict(
+                info="Activate the UnnamedSingleFile container",
+                type=bool,
+                values=[
+                    True,
+                ],
+                doc_zorder=90,
             ),
-            cwdtied = dict(
-                default = True,
-                doc_visibility  = footprints.doc.visibility.GURU,
+            cwdtied=dict(
+                default=True,
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
         ),
-        fastkeys = {'shouldfly'}
+        fastkeys={"shouldfly"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('UnnamedSingleFile container init %s', self.__class__)
+        logger.debug("UnnamedSingleFile container init %s", self.__class__)
         self._auto_filename = None
-        kw.setdefault('shouldfly', True)
+        kw.setdefault("shouldfly", True)
         super().__init__(*args, **kw)
 
     @property
@@ -730,51 +779,57 @@ class UnnamedSingleFile(_SingleFileStyle):
 
     def __getstate__(self):
         st = super().__getstate__()
-        st['_auto_filename'] = None
+        st["_auto_filename"] = None
         return st
 
     def exists(self, empty=False):
         """Check the existence of the actual file."""
-        return (os.path.exists(self.localpath()) and
-                (empty or os.path.getsize(self.localpath())))
+        return os.path.exists(self.localpath()) and (
+            empty or os.path.getsize(self.localpath())
+        )
 
 
 class Uuid4UnamedSingleFile(_SingleFileStyle):
     """Unamed file container created in a temporary diectory."""
 
     _footprint = dict(
-        info = 'File container (a temporary filename is chosen at runtime)',
-        attr = dict(
-            uuid4fly = dict(
-                info       = 'Activate the Uuid4UnnamedSingleFile container',
-                type       = bool,
-                values     = [True, ],
-                doc_zorder = 90,
+        info="File container (a temporary filename is chosen at runtime)",
+        attr=dict(
+            uuid4fly=dict(
+                info="Activate the Uuid4UnnamedSingleFile container",
+                type=bool,
+                values=[
+                    True,
+                ],
+                doc_zorder=90,
             ),
-            uuid4flydir = dict(
-                info       = 'The subdirectory where to create the unamed file',
-                optional   = True,
-                default    = '.',
-                doc_zorder = 90,
+            uuid4flydir=dict(
+                info="The subdirectory where to create the unamed file",
+                optional=True,
+                default=".",
+                doc_zorder=90,
             ),
         ),
-        fastkeys = {'uuid4fly'}
+        fastkeys={"uuid4fly"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('UuidBasedUnamedSingleFile container init %s', self.__class__)
+        logger.debug(
+            "UuidBasedUnamedSingleFile container init %s", self.__class__
+        )
         self._auto_filename = None
-        kw.setdefault('uuid4fly', True)
+        kw.setdefault("uuid4fly", True)
         super().__init__(*args, **kw)
 
     @property
     def filename(self):
         if self._auto_filename is None:
-            self._auto_filename = os.path.join(self.uuid4flydir,
-                                               uuid.uuid4().hex)
+            self._auto_filename = os.path.join(
+                self.uuid4flydir, uuid.uuid4().hex
+            )
         return self._auto_filename
 
     def __getstate__(self):
         st = super().__getstate__()
-        st['_auto_filename'] = None
+        st["_auto_filename"] = None
         return st

--- a/src/vortex/data/executables.py
+++ b/src/vortex/data/executables.py
@@ -24,6 +24,7 @@ __all__ = []
 
 class Jacket:
     """The class definition of in and out resources from a given executable."""
+
     def __init__(self, afile=None):
         if afile:
             self.config = JacketConfigParser(afile)
@@ -44,25 +45,25 @@ class Executable(Resource):
 
     _abstract = True
     _footprint = dict(
-        info = 'Miscellaneaous executable resource',
-        attr = dict(
-            cycle = dict(
-                info     = "Any kind of cycle name",
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+        info="Miscellaneaous executable resource",
+        attr=dict(
+            cycle=dict(
+                info="Any kind of cycle name",
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            kind = dict(
-                info        = "The resource's kind.",
-                doc_zorder  = 90,
+            kind=dict(
+                info="The resource's kind.",
+                doc_zorder=90,
             ),
-            nativefmt = dict(
-                doc_visibility = footprints.doc.visibility.GURU,
+            nativefmt=dict(
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            clscontents = dict(
-                doc_visibility = footprints.doc.visibility.GURU,
-            )
-        )
+            clscontents=dict(
+                doc_visibility=footprints.doc.visibility.GURU,
+            ),
+        ),
     )
 
     def stdin_text(self, **opts):
@@ -74,33 +75,33 @@ class Script(Executable):
     """Basic interpreted executable associated to a specific language."""
 
     _footprint = dict(
-        attr = dict(
-            rawopts = dict(
-                info     = "Options that will be passed directly to the script",
-                optional = True,
-                default  = '',
+        attr=dict(
+            rawopts=dict(
+                info="Options that will be passed directly to the script",
+                optional=True,
+                default="",
             ),
-            language = dict(
-                info     = "The programming language",
-                values   = ['perl', 'python', 'ksh', 'bash', 'sh', 'awk'],
+            language=dict(
+                info="The programming language",
+                values=["perl", "python", "ksh", "bash", "sh", "awk"],
             ),
-            kind = dict(
-                optional = True,
-                default  = 'script',
-                values   = ['script'],
-            )
+            kind=dict(
+                optional=True,
+                default="script",
+                values=["script"],
+            ),
         ),
-        fastkeys = {'language'},
+        fastkeys={"language"},
     )
 
     @property
     def realkind(self):
-        return 'script'
+        return "script"
 
     def command_line(self, **opts):
         """Returns optional attribute :attr:`rawopts`."""
         if self.rawopts is None:
-            return ''
+            return ""
         else:
             return self.rawopts
 
@@ -109,28 +110,31 @@ class GnuScript(Executable):
     """Basic interpreted executable with standard command line arguments."""
 
     _footprint = dict(
-        attr = dict(
-            language = dict(
-                info     = "The programming language",
-                values   = ['perl', 'python', 'ksh', 'bash', 'sh', 'awk'],
+        attr=dict(
+            language=dict(
+                info="The programming language",
+                values=["perl", "python", "ksh", "bash", "sh", "awk"],
             ),
-            kind = dict(
-                default  = 'gnuscript',
-                values   = ['gnuscript', 'argscript'],
-            )
+            kind=dict(
+                default="gnuscript",
+                values=["gnuscript", "argscript"],
+            ),
         ),
-        fastkeys = {'kind', 'language'},
+        fastkeys={"kind", "language"},
     )
 
     @property
     def realkind(self):
-        return 'script'
+        return "script"
 
     def command_line(self, **opts):
         """Returns a blank separated list of options."""
-        return ' '.join(['--' + k + ' ' + ' '.join([str(x)
-                                                    for x in mktuple(v)])
-                         for k, v in opts.items()])
+        return " ".join(
+            [
+                "--" + k + " " + " ".join([str(x) for x in mktuple(v)])
+                for k, v in opts.items()
+            ]
+        )
 
 
 class Binary(Executable):
@@ -138,25 +142,25 @@ class Binary(Executable):
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            static = dict(
-                info     = "Statically linked binary.",
-                type     = bool,
-                optional = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+        attr=dict(
+            static=dict(
+                info="Statically linked binary.",
+                type=bool,
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            jacket = dict(
-                type            = Jacket,
-                optional        = True,
-                default         = Jacket(),
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-            )
+            jacket=dict(
+                type=Jacket,
+                optional=True,
+                default=Jacket(),
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+            ),
         )
     )
 
     @property
     def realkind(self):
-        return 'binary'
+        return "binary"
 
     def guess_binary_sources(self, provider):  # @UnusedVariable
         """A list of path that contains source files (for debugging purposes)."""
@@ -167,15 +171,15 @@ class BlackBox(Binary):
     """Binary resource with explicit command line options."""
 
     _footprint = dict(
-        attr = dict(
-            binopts = dict(
-                info     = "Options that will be passed directly to the binary",
-                optional = True,
-                default  = '',
+        attr=dict(
+            binopts=dict(
+                info="Options that will be passed directly to the binary",
+                optional=True,
+                default="",
             ),
-            kind = dict(
-                values   = ['binbox', 'blackbox'],
-                remap    = dict(binbox = 'blackbox'),
+            kind=dict(
+                values=["binbox", "blackbox"],
+                remap=dict(binbox="blackbox"),
             ),
         )
     )
@@ -191,23 +195,16 @@ class NWPModel(Binary):
     _abstract = True
     _footprint = [
         model_deco,
-        dict(
-            info = 'NWP Model',
-            attr = dict(
-                kind = dict(
-                    values = ['nwpmodel']
-                )
-            )
-        )
+        dict(info="NWP Model", attr=dict(kind=dict(values=["nwpmodel"]))),
     ]
 
     @property
     def realkind(self):
-        return 'nwpmodel'
+        return "nwpmodel"
 
     def command_line(self, **opts):
         """Abstract method."""
-        return ''
+        return ""
 
 
 class OceanographicModel(Binary):
@@ -217,68 +214,62 @@ class OceanographicModel(Binary):
     _footprint = [
         model_deco,
         dict(
-            info = 'Oceanographic Model',
-            attr = dict(
-                kind = dict(
-                    values = ['oceanmodel']
-                )
-            )
-        )
+            info="Oceanographic Model",
+            attr=dict(kind=dict(values=["oceanmodel"])),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'oceanmodel'
+        return "oceanmodel"
 
     def command_line(self, **opts):
         """Abstract method."""
-        return ''
+        return ""
 
 
 class SurfaceModel(Binary):
-
     _abstract = True
     _footprint = [
         model_deco,
         dict(
-            info = 'Model used for the Safran-Surfex-Mepra chain.',
-            attr = dict(
-                kind  = dict(
-                    values = ['surfacemodel', 'snowmodel'],
-                    remap = dict(autoremap = 'first'),
+            info="Model used for the Safran-Surfex-Mepra chain.",
+            attr=dict(
+                kind=dict(
+                    values=["surfacemodel", "snowmodel"],
+                    remap=dict(autoremap="first"),
                 ),
             ),
-        )
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'surfacemodel'
+        return "surfacemodel"
 
     def command_line(self, **opts):
         """Abstract method."""
-        return ''
+        return ""
 
 
 class ChemistryModel(Binary):
-
     _abstract = True
     _footprint = [
         model_deco,
         dict(
-            info = 'Base class for Chemistry models.',
-            attr = dict(
-                kind  = dict(
-                    values = ['chemistrymodel'],
+            info="Base class for Chemistry models.",
+            attr=dict(
+                kind=dict(
+                    values=["chemistrymodel"],
                 ),
             ),
-        )
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'chemistrymodel'
+        return "chemistrymodel"
 
     def command_line(self, **opts):
         """Abstract method."""
-        return ''
+        return ""

--- a/src/vortex/data/flow.py
+++ b/src/vortex/data/flow.py
@@ -12,7 +12,13 @@ from .resources import Resource
 from .geometries import hgeometry_deco
 from .contents import FormatAdapter
 
-from vortex.syntax.stdattrs import model_deco, date_deco, dateperiod_deco, cutoff_deco, term_deco
+from vortex.syntax.stdattrs import (
+    model_deco,
+    date_deco,
+    dateperiod_deco,
+    cutoff_deco,
+    term_deco,
+)
 from vortex.syntax.stddeco import namebuilding_insert
 
 #: No automatic export
@@ -26,40 +32,38 @@ class FlowResource(Resource):
     _footprint = [model_deco, date_deco, cutoff_deco]
 
 
-@namebuilding_insert('radical', lambda s: s.nickname)
+@namebuilding_insert("radical", lambda s: s.nickname)
 class UnknownFlow(FlowResource):
-
     _footprint = [
         term_deco,
         dict(
-            info = 'Unknown assumed NWP Flow-Resource (development only !)',
-            attr = dict(
-                unknownflow = dict(
-                    info = "Activate the unknown flow resource",
-                    type = bool
+            info="Unknown assumed NWP Flow-Resource (development only !)",
+            attr=dict(
+                unknownflow=dict(
+                    info="Activate the unknown flow resource", type=bool
                 ),
-                term = dict(
-                    optional = True,
+                term=dict(
+                    optional=True,
                 ),
-                nickname = dict(
-                    info = "The string that serves the purpose of Vortex's basename radical",
-                    optional = True,
-                    default = 'unknown'
+                nickname=dict(
+                    info="The string that serves the purpose of Vortex's basename radical",
+                    optional=True,
+                    default="unknown",
                 ),
-                clscontents = dict(
-                    default = FormatAdapter
-                ),
+                clscontents=dict(default=FormatAdapter),
             ),
-            fastkeys = {'unknownflow'},
-        )
+            fastkeys={"unknownflow"},
+        ),
     ]
 
-    _extension_remap = {k: None for k in ('auto', 'autoconfig', 'foo', 'unknown')}
+    _extension_remap = {
+        k: None for k in ("auto", "autoconfig", "foo", "unknown")
+    }
 
     def olive_basename(self):
         target = self.nickname
         if self.term is not None:
-            target += '+' + self.term.fmth
+            target += "+" + self.term.fmth
         return target
 
 
@@ -70,12 +74,12 @@ class GeoFlowResource(FlowResource):
     _footprint = [
         hgeometry_deco,
         dict(
-            attr = dict(
-                clscontents = dict(
-                    default = FormatAdapter,
+            attr=dict(
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             )
-        )
+        ),
     ]
 
 
@@ -86,14 +90,16 @@ class PeriodFlowResource(Resource):
     _footprint = [model_deco, dateperiod_deco, cutoff_deco]
 
     _footprint = [
-        model_deco, dateperiod_deco, cutoff_deco,
+        model_deco,
+        dateperiod_deco,
+        cutoff_deco,
         dict(
-            attr = dict(
-                cutoff = dict(
-                    optional = True,
+            attr=dict(
+                cutoff=dict(
+                    optional=True,
                 ),
             )
-        )
+        ),
     ]
 
 
@@ -104,10 +110,10 @@ class GeoPeriodFlowResource(PeriodFlowResource):
     _footprint = [
         hgeometry_deco,
         dict(
-            attr = dict(
-                clscontents = dict(
-                    default = FormatAdapter,
+            attr=dict(
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             )
-        )
+        ),
     ]

--- a/src/vortex/data/geometries.py
+++ b/src/vortex/data/geometries.py
@@ -72,6 +72,7 @@ logger = loggers.getLogger(__name__)
 
 # Module Interface
 
+
 def get(**kw):
     """Return actual geometry object matching description.
 
@@ -111,6 +112,7 @@ def grep(**kw):
 
 # Abstract geometry classes
 
+
 class Geometry(bronx.patterns.getbytag.GetByTag):
     """Abstract geometry."""
 
@@ -124,18 +126,21 @@ class Geometry(bronx.patterns.getbytag.GetByTag):
 
         .. note:: This is an abstract class, do not instantiate.
         """
-        self.info = 'anonymous'
+        self.info = "anonymous"
         self.inifile = None
         self.__dict__.update(kw)
-        self.kind = 'abstract'
+        self.kind = "abstract"
         self._init_attributes = {k: v for k, v in kw.items() if v is not None}
-        logger.debug('Abstract Geometry init kw=%s', str(kw))
+        logger.debug("Abstract Geometry init kw=%s", str(kw))
 
     @classmethod
     def _tag_implicit_new_error(cls, tag):
         """Called whenever a tag does not exists and _tag_implicit_new = False."""
-        raise RuntimeError('The "{:s}" {:s} object does not exist yet...'.
-                           format(tag, cls.__name__))
+        raise RuntimeError(
+            'The "{:s}" {:s} object does not exist yet...'.format(
+                tag, cls.__name__
+            )
+        )
 
     @classmethod
     def tag_clean(self, tag):
@@ -144,7 +149,7 @@ class Geometry(bronx.patterns.getbytag.GetByTag):
 
     def __repr__(self):
         """Nicer represenation for geometries."""
-        return '<{:s}.{:s} (tag=\'{:s}\') object at {:#x}>'.format(
+        return "<{:s}.{:s} (tag='{:s}') object at {:#x}>".format(
             self.__module__, self.__class__.__name__, self.tag, id(self)
         )
 
@@ -153,14 +158,14 @@ class Geometry(bronx.patterns.getbytag.GetByTag):
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
-        return 'kind={:s}'.format(self.kind)
+        return "kind={:s}".format(self.kind)
 
     def to_inifile(self):
         """Format geometry to put in the inifile."""
         self._init_attributes.update(kind=self.kind)
-        s = '[{}]\n'.format(self.tag)
+        s = "[{}]\n".format(self.tag)
         for k in sorted(self._init_attributes.keys()):
-            s += '{:10s} = {}\n'.format(k, self._init_attributes[k])
+            s += "{:10s} = {}\n".format(k, self._init_attributes[k])
         return s
 
 
@@ -178,8 +183,10 @@ class VerticalGeometry(Geometry):
         .. note:: This is an abstract class, do not instantiate.
         """
         super().__init__(**kw)
-        self.kind = 'vertical'
-        logger.debug('Abstract Vertical Geometry init %s %s', str(self), str(kw))
+        self.kind = "vertical"
+        logger.debug(
+            "Abstract Vertical Geometry init %s %s", str(self), str(kw)
+        )
 
 
 class HorizontalGeometry(Geometry):
@@ -197,7 +204,7 @@ class HorizontalGeometry(Geometry):
         .. note:: This is an abstract class, do not instantiate.
         """
         desc = dict(
-            info='anonymous',
+            info="anonymous",
             gridtype=None,
             area=None,
             nlon=None,
@@ -205,8 +212,8 @@ class HorizontalGeometry(Geometry):
             nlat=None,
             ni=None,
             nj=None,
-            resolution=0.,
-            expected_resolution=0.,
+            resolution=0.0,
+            expected_resolution=0.0,
             runit=None,
             truncation=None,
             truncationtype=None,
@@ -220,22 +227,30 @@ class HorizontalGeometry(Geometry):
         desc.update(kw)
         super().__init__(**desc)
         for k, v in self.__dict__.items():
-            if isinstance(v, str) and re.match('none', v, re.IGNORECASE):
+            if isinstance(v, str) and re.match("none", v, re.IGNORECASE):
                 self.__dict__[k] = None
-            if isinstance(v, str) and re.match('true', v, re.IGNORECASE):
+            if isinstance(v, str) and re.match("true", v, re.IGNORECASE):
                 self.__dict__[k] = True
-            if isinstance(v, str) and re.match('false', v, re.IGNORECASE):
+            if isinstance(v, str) and re.match("false", v, re.IGNORECASE):
                 self.__dict__[k] = False
-        for item in ('nlon', 'nlat', 'ni', 'nj', 'nmassif', 'nposts', 'truncation'):
+        for item in (
+            "nlon",
+            "nlat",
+            "ni",
+            "nj",
+            "nmassif",
+            "nposts",
+            "truncation",
+        ):
             cv = getattr(self, item)
             if cv is not None:
                 setattr(self, item, int(cv))
-        for item in ('stretching', 'resolution', 'lonmin', 'latmin'):
+        for item in ("stretching", "resolution", "lonmin", "latmin"):
             cv = getattr(self, item)
             if cv is not None:
                 setattr(self, item, float(cv))
         self._check_attributes()
-        logger.debug('Abstract Horizontal Geometry init %s', str(self))
+        logger.debug("Abstract Horizontal Geometry init %s", str(self))
 
     def _check_attributes(self):
         if self.lam and (self.area is None):
@@ -250,15 +265,15 @@ class HorizontalGeometry(Geometry):
     def rnice(self):
         """Returns a string with a nice representation of the resolution (if sensible)."""
         if self.runit is not None:
-            if self.runit == 'km':
-                res = '{:05.2f}'.format(self.resolution)
-            elif self.runit in ('s', 'min'):
-                res = '{:04.1f}'.format(self.resolution)
+            if self.runit == "km":
+                res = "{:05.2f}".format(self.resolution)
+            elif self.runit in ("s", "min"):
+                res = "{:04.1f}".format(self.resolution)
             else:
-                res = '{:06.3f}'.format(self.resolution)
-            return re.sub(r'\.', self.runit, res, 1)
+                res = "{:06.3f}".format(self.resolution)
+            return re.sub(r"\.", self.runit, res, 1)
         else:
-            return 'Unknown Resolution'
+            return "Unknown Resolution"
 
     @property
     def rnice_u(self):
@@ -266,16 +281,20 @@ class HorizontalGeometry(Geometry):
 
     @property
     def gco_grid_def(self):
-        return ('{0.area}' + ('_{0.rnice}' if self.runit is not None else '')).format(self)
+        return (
+            "{0.area}" + ("_{0.rnice}" if self.runit is not None else "")
+        ).format(self)
 
     def anonymous_info(self, *args):  # @UnusedVariable
         """Try to build a meaningful information from an anonymous geometry."""
-        return '{!s}, {:s}'.format(self.area, self.rnice)
+        return "{!s}, {:s}".format(self.area, self.rnice)
 
     def __str__(self):
         """Very short presentation."""
-        if self.info == 'anonymous':
-            return '{:s}({:s})'.format(self.__class__.__name__, self.anonymous_info())
+        if self.info == "anonymous":
+            return "{:s}({:s})".format(
+                self.__class__.__name__, self.anonymous_info()
+            )
         else:
             return self.info
 
@@ -284,41 +303,61 @@ class HorizontalGeometry(Geometry):
         Returns a multilines documentation string with a summary
         of the valuable information contained by this geometry.
         """
-        indent = ' ' * indent
+        indent = " " * indent
         # Basics...
-        card = "\n".join((
-            '{0}Geometry {1!r}',
-            '{0}{0}Info       : {2:s}',
-            '{0}{0}LAM        : {3!s}',
-        )).format(indent, self, self.info, self.lam)
+        card = "\n".join(
+            (
+                "{0}Geometry {1!r}",
+                "{0}{0}Info       : {2:s}",
+                "{0}{0}LAM        : {3!s}",
+            )
+        ).format(indent, self, self.info, self.lam)
         # Optional infos
-        for attr in [k for k in ('area', 'resolution', 'truncation',
-                                 'stretching', 'nlon', 'nlat', 'ni', 'nj',
-                                 'nmassif', 'nposts')
-                     if getattr(self, k, False)]:
-            card += "\n{0}{0}{1:10s} : {2!s}".format(indent, attr.title(),
-                                                     getattr(self, attr))
+        for attr in [
+            k
+            for k in (
+                "area",
+                "resolution",
+                "truncation",
+                "stretching",
+                "nlon",
+                "nlat",
+                "ni",
+                "nj",
+                "nmassif",
+                "nposts",
+            )
+            if getattr(self, k, False)
+        ]:
+            card += "\n{0}{0}{1:10s} : {2!s}".format(
+                indent, attr.title(), getattr(self, attr)
+            )
         return card
 
     def strheader(self):
         """Return the beginning of the formatted print representation."""
-        header = '{:s}.{:s} | tag=\'{}\' id=\'{:s}\''.format(
+        header = "{:s}.{:s} | tag='{}' id='{:s}'".format(
             self.__module__,
             self.__class__.__name__,
             self.tag,
             self.info,
         )
         if self.lam:
-            header += ' area=\'{:s}\''.format(self.area)
+            header += " area='{:s}'".format(self.area)
         return header
 
     @property
     def coordinates(self):
-        if any([getattr(self, x) is None for x in ('lonmin', 'latmin', 'nlat', 'nlon', 'resolution')]):
+        if any(
+            [
+                getattr(self, x) is None
+                for x in ("lonmin", "latmin", "nlat", "nlon", "resolution")
+            ]
+        ):
             return dict()
         coordinates = dict(lonmin=self.lonmin, latmin=self.latmin)
-        coordinates['latmax'] = self.latmin + self.resolution * (self.nlat - 1)
-        coordinates['lonmax'] = self.lonmin + self.resolution * (self.nlon - 1)
+        coordinates["latmax"] = self.latmin + self.resolution * (self.nlat - 1)
+        coordinates["lonmax"] = self.lonmin + self.resolution * (self.nlon - 1)
         return coordinates
 
 
@@ -330,10 +369,13 @@ class SpectralAwareHorizontalGeometry(HorizontalGeometry):
     def _check_attributes(self):
         super()._check_attributes()
         if self.truncationtype is None:
-            self.truncationtype = 'linear'
-        if self.truncationtype not in ('linear', 'quadratic', 'cubic'):
-            raise ValueError("Improper value {:s} for *truncationtype*"
-                             .format(self.truncationtype))
+            self.truncationtype = "linear"
+        if self.truncationtype not in ("linear", "quadratic", "cubic"):
+            raise ValueError(
+                "Improper value {:s} for *truncationtype*".format(
+                    self.truncationtype
+                )
+            )
 
     @property
     def short_truncationtype(self):
@@ -341,10 +383,13 @@ class SpectralAwareHorizontalGeometry(HorizontalGeometry):
 
     @property
     def xtruncationtype(self):
-        return dict(quadratic='quad').get(self.truncationtype, self.truncationtype)
+        return dict(quadratic="quad").get(
+            self.truncationtype, self.truncationtype
+        )
 
 
 # Combined geometry (not used at the present time)
+
 
 class CombinedGeometry(Geometry):
     """Combine horizontal and vertical geometry (not used at the present time)."""
@@ -362,11 +407,12 @@ class CombinedGeometry(Geometry):
         self.hgeo = None
         self.vgeo = None
         super().__init__(**kw)
-        self.kind = 'combined'
-        logger.debug('Combined Geometry init %s %s', str(self), str(kw))
+        self.kind = "combined"
+        logger.debug("Combined Geometry init %s %s", str(self), str(kw))
 
 
 # Concrete geometry classes
+
 
 class GaussGeometry(SpectralAwareHorizontalGeometry):
     """
@@ -392,8 +438,8 @@ class GaussGeometry(SpectralAwareHorizontalGeometry):
         .. note:: Gaussian grids are always global grids.
         """
         super().__init__(**kw)
-        self.kind = 'gauss'
-        logger.debug('Gauss Geometry init %s', str(self))
+        self.kind = "gauss"
+        logger.debug("Gauss Geometry init %s", str(self))
 
     def _check_attributes(self):
         self.lam = False  # Always false for gaussian grid
@@ -401,39 +447,48 @@ class GaussGeometry(SpectralAwareHorizontalGeometry):
         if self.truncation is None or self.stretching is None:
             raise AttributeError("Some mandatory arguments are missing")
         if self.gridtype is None:
-            self.gridtype = 'rgrid'
-        if self.gridtype not in ('rgrid', 'octahedral'):
-            raise ValueError("Improper value {:s} for *gridtype*"
-                             .format(self.gridtype))
+            self.gridtype = "rgrid"
+        if self.gridtype not in ("rgrid", "octahedral"):
+            raise ValueError(
+                "Improper value {:s} for *gridtype*".format(self.gridtype)
+            )
 
     @property
     def short_gridtype(self):
-        return self.gridtype[0] if self.gridtype != 'rgrid' else ''
+        return self.gridtype[0] if self.gridtype != "rgrid" else ""
 
     @property
     def gco_grid_def(self):
-        geotag_f = 't'
-        if self.truncationtype != 'linear' or self.gridtype != 'rgrid':
-            geotag_f += '{0.short_truncationtype}'
-        geotag_f += '{0.short_gridtype}{0.truncation:d}'
+        geotag_f = "t"
+        if self.truncationtype != "linear" or self.gridtype != "rgrid":
+            geotag_f += "{0.short_truncationtype}"
+        geotag_f += "{0.short_gridtype}{0.truncation:d}"
         return geotag_f.format(self)
 
     def __str__(self):
         """Standard formatted print representation."""
-        return '<{:s} t{:s}{:s}={:d} c={:g}>'.format(self.strheader(),
-                                                     self.short_truncationtype,
-                                                     self.short_gridtype,
-                                                     self.truncation,
-                                                     self.stretching)
+        return "<{:s} t{:s}{:s}={:d} c={:g}>".format(
+            self.strheader(),
+            self.short_truncationtype,
+            self.short_gridtype,
+            self.truncation,
+            self.stretching,
+        )
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
         if self.stretching > 1:
-            fmts = 'kind={0:s}, t{1:s}{2:s}={3:d}, c={4:g} (pole of interest over {5!s})'
+            fmts = "kind={0:s}, t{1:s}{2:s}={3:d}, c={4:g} (pole of interest over {5!s})"
         else:
-            fmts = 'kind={0:s}, t{1:s}{2:s}={3:d}, c={4:g}'
-        return fmts.format(self.kind, self.short_truncationtype, self.short_gridtype,
-                           self.truncation, self.stretching, self.area)
+            fmts = "kind={0:s}, t{1:s}{2:s}={3:d}, c={4:g}"
+        return fmts.format(
+            self.kind,
+            self.short_truncationtype,
+            self.short_gridtype,
+            self.truncation,
+            self.stretching,
+            self.area,
+        )
 
 
 class ProjectedGeometry(SpectralAwareHorizontalGeometry):
@@ -451,10 +506,10 @@ class ProjectedGeometry(SpectralAwareHorizontalGeometry):
         :param str runit: The unit of the resolution (km, ...) (km by default)
         :param str area: The grid location (needed if **lam** is *True*)
         """
-        kw.setdefault('runit', 'km')
+        kw.setdefault("runit", "km")
         super().__init__(**kw)
-        self.kind = 'projected'
-        logger.debug('Projected Geometry init %s', str(self))
+        self.kind = "projected"
+        logger.debug("Projected Geometry init %s", str(self))
 
     def _check_attributes(self):
         super()._check_attributes()
@@ -463,23 +518,30 @@ class ProjectedGeometry(SpectralAwareHorizontalGeometry):
 
     @property
     def gco_grid_def(self):
-        geotag_f = ('{0.area}_{0.rnice}' if self.truncationtype == 'linear' else
-                    '{0.area}_{0.xtruncationtype}_{0.rnice}')
+        geotag_f = (
+            "{0.area}_{0.rnice}"
+            if self.truncationtype == "linear"
+            else "{0.area}_{0.xtruncationtype}_{0.rnice}"
+        )
         return geotag_f.format(self)
 
     def __str__(self):
         """Standard formatted print representation."""
-        return '<{:s} r=\'{:s}\' {:s}>'.format(self.strheader(),
-                                               self.rnice,
-                                               self.truncationtype)
+        return "<{:s} r='{:s}' {:s}>".format(
+            self.strheader(), self.rnice, self.truncationtype
+        )
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
         if self.lam:
-            fmts = 'kind={0:s}, r={1:s}, truncationtype={2:s}, limited-area={3:s}'
+            fmts = (
+                "kind={0:s}, r={1:s}, truncationtype={2:s}, limited-area={3:s}"
+            )
         else:
-            fmts = 'kind={0:s}, r={1:s}, truncationtype={2:s}, global'
-        return fmts.format(self.kind, self.rnice, self.truncationtype, self.area)
+            fmts = "kind={0:s}, r={1:s}, truncationtype={2:s}, global"
+        return fmts.format(
+            self.kind, self.rnice, self.truncationtype, self.area
+        )
 
 
 class LonlatGeometry(HorizontalGeometry):
@@ -499,23 +561,25 @@ class LonlatGeometry(HorizontalGeometry):
         :param int nlat: The number of latitude points in the grid
         :param str area: The grid location (needed if **lam** is *True*)
         """
-        kw.setdefault('runit', 'dg')
+        kw.setdefault("runit", "dg")
         super().__init__(**kw)
-        self.kind = 'lonlat'
+        self.kind = "lonlat"
         # TODO: coherence entre les coordonnees et nlon/nlat/resolution
-        logger.debug('Lon/Lat Geometry init %s', str(self))
+        logger.debug("Lon/Lat Geometry init %s", str(self))
 
     def __str__(self):
         """Standard formatted print representation."""
-        return '<{:s} r=\'{:s}\'>'.format(self.strheader(), self.rnice)
+        return "<{:s} r='{:s}'>".format(self.strheader(), self.rnice)
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
         if self.lam:
-            fmts = 'kind={0:s}, r={1:s}, limited-area={2:s}, nlon={3!s}, nlat={4!s}'
+            fmts = "kind={0:s}, r={1:s}, limited-area={2:s}, nlon={3!s}, nlat={4!s}"
         else:
-            fmts = 'kind={0:s}, r={1:s}, global, nlon={3!s}, nlat={4!s}'
-        return fmts.format(self.kind, self.rnice, self.area, self.nlon, self.nlat)
+            fmts = "kind={0:s}, r={1:s}, global, nlon={3!s}, nlat={4!s}"
+        return fmts.format(
+            self.kind, self.rnice, self.area, self.nlon, self.nlat
+        )
 
 
 class UnstructuredGeometry(HorizontalGeometry):
@@ -533,19 +597,19 @@ class UnstructuredGeometry(HorizontalGeometry):
         .. note:: This is an abstract class, do not instantiate.
         """
         super().__init__(**kw)
-        self.kind = 'unstructured'
-        logger.debug('Unstructured Geometry init %s', str(self))
+        self.kind = "unstructured"
+        logger.debug("Unstructured Geometry init %s", str(self))
 
     def __str__(self):
         """Standard formatted print representation."""
-        return '<{:s}>'.format(self.strheader())
+        return "<{:s}>".format(self.strheader())
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
         if self.area:
-            fmts = 'kind={0:s}, area={1:s}'
+            fmts = "kind={0:s}, area={1:s}"
         else:
-            fmts = 'kind={0:s}'
+            fmts = "kind={0:s}"
         return fmts.format(self.kind, self.area)
 
 
@@ -565,7 +629,7 @@ class CurvlinearGeometry(UnstructuredGeometry):
         :param str area: The grid location (needed if **lam** is *True*)
         """
         super().__init__(**kw)
-        self.kind = 'curvlinear'
+        self.kind = "curvlinear"
 
     def _check_attributes(self):
         super()._check_attributes()
@@ -575,10 +639,14 @@ class CurvlinearGeometry(UnstructuredGeometry):
     def doc_export(self):
         """Relevant informations to print in the documentation."""
         if self.lam:
-            fmts = 'kind={0:s}, r={1:s}, limited-area={2:s}, ni={3!s}, nj={4!s}'
+            fmts = (
+                "kind={0:s}, r={1:s}, limited-area={2:s}, ni={3!s}, nj={4!s}"
+            )
         else:
-            fmts = 'kind={0:s}, r={1:s}, global, ni={3!s}, nj={4!s}'
-        return fmts.format(self.kind, self.rnice, self.area, self.nlon, self.nlat)
+            fmts = "kind={0:s}, r={1:s}, global, ni={3!s}, nj={4!s}"
+        return fmts.format(
+            self.kind, self.rnice, self.area, self.nlon, self.nlat
+        )
 
 
 class RedgridGeometry(HorizontalGeometry):
@@ -598,28 +666,34 @@ class RedgridGeometry(HorizontalGeometry):
                                         ``longitudes = expected_resolution * cos(lat)``
         :param str area: The grid location (needed if **lam** is *True*)
         """
-        kw.setdefault('runit', 'dg')
-        kw.setdefault('lam', False)
+        kw.setdefault("runit", "dg")
+        kw.setdefault("lam", False)
         super().__init__(**kw)
-        self.kind = 'redgrid'
+        self.kind = "redgrid"
 
     def _check_attributes(self):
-        if self.nlonmax is None or self.nlat is None or self.resolution is None:
+        if (
+            self.nlonmax is None
+            or self.nlat is None
+            or self.resolution is None
+        ):
             raise AttributeError("Some mandatory arguments are missing")
         super()._check_attributes()
         if self.lam is False:
-            self.area = 'global'
+            self.area = "global"
 
     def __str__(self):
         """Standard formatted print representation."""
-        return '<{:s} area=\'{:s}\' r=\'{:s}\'>'.format(self.strheader(),
-                                                        self.area,
-                                                        self.rnice)
+        return "<{:s} area='{:s}' r='{:s}'>".format(
+            self.strheader(), self.area, self.rnice
+        )
 
     def doc_export(self):
         """Relevant informations to print in the documentation."""
-        fmts = 'kind={0:s}, r={1:s}, area={2:s}, nlonmax={3!s}, nlat={4!s}'
-        return fmts.format(self.kind, self.rnice, self.area, self.nlonmax, self.nlat)
+        fmts = "kind={0:s}, r={1:s}, area={2:s}, nlonmax={3!s}, nlat={4!s}"
+        return fmts.format(
+            self.kind, self.rnice, self.area, self.nlonmax, self.nlat
+        )
 
 
 # Pre-defined footprint attribute for any HorizontalGeometry
@@ -637,60 +711,83 @@ def _add_geo2basename_info(cls):
     def _geo2basename_info(self, add_stretching=True):
         """Return an array describing the geometry for the Vortex's name builder."""
         if isinstance(self.geometry, GaussGeometry):
-            lgeo = [{'truncation': (self.geometry.truncation,
-                                    self.geometry.short_truncationtype,
-                                    self.geometry.short_gridtype)}, ]
+            lgeo = [
+                {
+                    "truncation": (
+                        self.geometry.truncation,
+                        self.geometry.short_truncationtype,
+                        self.geometry.short_gridtype,
+                    )
+                },
+            ]
             if add_stretching:
-                lgeo.append({'stretching': self.geometry.stretching})
+                lgeo.append({"stretching": self.geometry.stretching})
         elif isinstance(self.geometry, (ProjectedGeometry, RedgridGeometry)):
             lgeo = [self.geometry.area, self.geometry.rnice]
-            if (self.geometry.truncationtype is not None and
-                    self.geometry.truncationtype != 'linear'):
+            if (
+                self.geometry.truncationtype is not None
+                and self.geometry.truncationtype != "linear"
+            ):
                 lgeo.append(self.geometry.xtruncationtype)
         else:
             lgeo = self.geometry.area  # Default: always defined
         return lgeo
 
-    if not hasattr(cls, '_geo2basename_info'):
+    if not hasattr(cls, "_geo2basename_info"):
         cls._geo2basename_info = _geo2basename_info
     return cls
 
 
 #: Abstract footprint definition of the ``geometry`` attribute.
-hgeometry = footprints.Footprint(info='Abstract Horizontal Geometry',
-                                 attr=dict(geometry=a_hgeometry))
+hgeometry = footprints.Footprint(
+    info="Abstract Horizontal Geometry", attr=dict(geometry=a_hgeometry)
+)
 
 #: Abstract footprint definition of the ``geometry`` attribute with decorators
 #: that alter the ``namebuilding_info`` method
 hgeometry_deco = footprints.DecorativeFootprint(
     hgeometry,
-    decorator=[_add_geo2basename_info,
-               namebuilding_insert('geo', lambda self: self._geo2basename_info()),
-               generic_pathname_insert('geometry', lambda self: self.geometry, setdefault=True)])
+    decorator=[
+        _add_geo2basename_info,
+        namebuilding_insert("geo", lambda self: self._geo2basename_info()),
+        generic_pathname_insert(
+            "geometry", lambda self: self.geometry, setdefault=True
+        ),
+    ],
+)
 
 
 # Load default geometries when the module is first imported
 
-def load(inifile='@geometries.ini', refresh=False, verbose=True):
+
+def load(inifile="@geometries.ini", refresh=False, verbose=True):
     """Load a set of pre-defined geometries from a configuration file.
 
     The class that will be instantiated depends on the "kind" keyword..
     """
     iniconf = configparser.ConfigParser()
     with importlib.resources.open_text(
-            "vortex.data", "geometries.ini",
+        "vortex.data",
+        "geometries.ini",
     ) as fh:
         iniconf.read_file(fh)
     for item in iniconf.sections():
         gdesc = dict(iniconf.items(item))
-        gkind = gdesc.get('kind')
+        gkind = gdesc.get("kind")
         try:
-            thisclass = [x for x in Geometry.tag_classes()
-                         if x.__name__.lower().startswith(gkind.lower())].pop()
+            thisclass = [
+                x
+                for x in Geometry.tag_classes()
+                if x.__name__.lower().startswith(gkind.lower())
+            ].pop()
         except IndexError:
-            raise AttributeError('Kind={:s} is unknown (for geometry [{:s}])'.format(gkind, item))
+            raise AttributeError(
+                "Kind={:s} is unknown (for geometry [{:s}])".format(
+                    gkind, item
+                )
+            )
         if verbose:
-            print('+ Load', item.ljust(16), 'as', thisclass)
+            print("+ Load", item.ljust(16), "as", thisclass)
         if refresh:
             # Always recreate the Geometry...
             thisclass(tag=item, new=True, **gdesc)

--- a/src/vortex/data/geometries.py
+++ b/src/vortex/data/geometries.py
@@ -62,7 +62,6 @@ import bronx.patterns.getbytag
 import footprints
 
 from vortex.syntax.stddeco import namebuilding_insert, generic_pathname_insert
-from vortex.util.config import GenericConfigParser
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/data/handlers.py
+++ b/src/vortex/data/handlers.py
@@ -4,7 +4,6 @@ objects are in charge of manipulating data between the working directory and
 the various caches or archives".
 """
 
-
 import functools
 import re
 import sys
@@ -28,11 +27,12 @@ __all__ = []
 
 logger = loggers.getLogger(__name__)
 
-OBSERVER_TAG = 'Resources-Handlers'
+OBSERVER_TAG = "Resources-Handlers"
 
 
 class HandlerError(RuntimeError):
     """Exception in case of missing resource during the wait mechanism."""
+
     pass
 
 
@@ -65,27 +65,31 @@ class IdCardAttrDumper(bronx.fancies.dump.TxtDumper):
         if level + 1 > self.max_depth:
             return "{}{{...}}{}".format(
                 self._indent(level, self.break_before_dict_begin),
-                self._indent(level, self.break_after_dict_end)
+                self._indent(level, self.break_after_dict_end),
             )
         else:
-            items = ["{}{} = {}{},".format(self._indent(level + 1, self.break_before_dict_key),
-                                           str(k),
-                                           self._indent(level + 2, self.break_before_dict_value),
-                                           self._recursive_dump(v, level + 1))
-                     for k, v in sorted(fpobj.footprint_as_shallow_dict().items())]
-            return ' '.join(items)
+            items = [
+                "{}{} = {}{},".format(
+                    self._indent(level + 1, self.break_before_dict_key),
+                    str(k),
+                    self._indent(level + 2, self.break_before_dict_value),
+                    self._recursive_dump(v, level + 1),
+                )
+                for k, v in sorted(fpobj.footprint_as_shallow_dict().items())
+            ]
+            return " ".join(items)
 
     def dump_default(self, obj, level=0, nextline=True):
         """Generic dump function. Concise view for GetByTag objects."""
         if level + 1 > self.max_depth:
             return " <%s...>" % type(obj).__class__
         else:
-            if hasattr(obj, 'tag'):
+            if hasattr(obj, "tag"):
                 return "{:s} obj: tag={:s}".format(type(obj).__name__, obj.tag)
             else:
-                parent_dump = super(bronx.fancies.dump.TxtDumper, self).dump_default(obj, level,
-                                                                                     nextline and
-                                                                                     self.break_default)
+                parent_dump = super(
+                    bronx.fancies.dump.TxtDumper, self
+                ).dump_default(obj, level, nextline and self.break_default)
                 return "{:s} obj: {!s}".format(type(obj).__name__, parent_dump)
 
 
@@ -98,32 +102,32 @@ class Handler:
     """
 
     def __init__(self, rd, **kw):
-        if 'glove' in rd:
-            del rd['glove']
-        self._resource = rd.pop('resource', None)
-        self._provider = rd.pop('provider', None)
-        self._container = rd.pop('container', None)
-        self._empty = rd.pop('empty', False)
+        if "glove" in rd:
+            del rd["glove"]
+        self._resource = rd.pop("resource", None)
+        self._provider = rd.pop("provider", None)
+        self._container = rd.pop("container", None)
+        self._empty = rd.pop("empty", False)
         self._contents = None
         self._uridata = None
         self._options = rd.copy()
-        self._observer = observer_board(obsname=kw.pop('observer', None))
+        self._observer = observer_board(obsname=kw.pop("observer", None))
         self._options.update(kw)
-        self._mdcheck = self._options.pop('metadatacheck', False)
-        self._mddelta = self._options.pop('metadatadelta', dict())
-        self._ghost = self._options.pop('ghost', False)
-        hook_names = [x for x in self._options.keys() if x.startswith('hook_')]
+        self._mdcheck = self._options.pop("metadatacheck", False)
+        self._mddelta = self._options.pop("metadatadelta", dict())
+        self._ghost = self._options.pop("ghost", False)
+        hook_names = [x for x in self._options.keys() if x.startswith("hook_")]
         self._hooks = {x[5:]: self._options.pop(x) for x in hook_names}
-        self._delayhooks = self._options.pop('delayhooks', False)
+        self._delayhooks = self._options.pop("delayhooks", False)
 
-        self._history = History(tag='data-handler')
-        self._history.append(self.__class__.__name__, 'init', True)
-        self._stage = ['load']
-        self._observer.notify_new(self, dict(stage='load'))
+        self._history = History(tag="data-handler")
+        self._history.append(self.__class__.__name__, "init", True)
+        self._stage = ["load"]
+        self._observer.notify_new(self, dict(stage="load"))
         self._localpr_cache = None  # To cache the promise dictionary
         self._latest_earlyget_id = None
         self._latest_earlyget_opts = None
-        logger.debug('New resource handler %s', self.__dict__)
+        logger.debug("New resource handler %s", self.__dict__)
 
     def __str__(self):
         return str(self.__dict__)
@@ -140,7 +144,9 @@ class Handler:
             self._notifyhash(oldhash)
             self.reset_contents()
         else:
-            raise ValueError('This value is not a plain Resource <{!s}>'.format(value))
+            raise ValueError(
+                "This value is not a plain Resource <{!s}>".format(value)
+            )
 
     resource = property(_get_resource, _set_resource)
 
@@ -156,7 +162,9 @@ class Handler:
             self._notifyhash(oldhash)
             self.reset_contents()
         else:
-            raise ValueError('This value is not a plain Provider <{!s}>'.format(value))
+            raise ValueError(
+                "This value is not a plain Provider <{!s}>".format(value)
+            )
 
     provider = property(_get_provider, _set_provider)
 
@@ -171,7 +179,9 @@ class Handler:
             self._container = value
             self._notifyhash(oldhash)
         else:
-            raise ValueError('This value is not a plain Container <{!s}>'.format(value))
+            raise ValueError(
+                "This value is not a plain Container <{!s}>".format(value)
+            )
 
     container = property(_get_container, _set_container)
 
@@ -206,11 +216,11 @@ class Handler:
     def simplified_hashkey(self):
         """Returns a tuple that can be used as a hashkey to quickly identify the handler."""
         if self.complete:
-            rkind = getattr(self.resource, 'kind', None)
-            rfile = getattr(self.container, 'filename', None)
+            rkind = getattr(self.resource, "kind", None)
+            rfile = getattr(self.container, "filename", None)
             return (rkind, rfile)
         else:
-            return ('incomplete', )
+            return ("incomplete",)
 
     @property
     def _cur_session(self):
@@ -228,7 +238,7 @@ class Handler:
         Update the stage upon request (e.g. the file has been fetched by another process).
         """
         self._stage.append(newstage)
-        if newstage in ('get', ):
+        if newstage in ("get",):
             self.container.updfill(True)
 
     def _updstage(self, newstage, insitu=False):
@@ -242,15 +252,25 @@ class Handler:
 
     def _notifyclear(self):
         """Notify that the hashkey has changed."""
-        self._observer.notify_upd(self, dict(clear=True, ))
+        self._observer.notify_upd(
+            self,
+            dict(
+                clear=True,
+            ),
+        )
 
     def _notifyhash(self, oldhash):
         """Notify that the hashkey has changed."""
-        self._observer.notify_upd(self, dict(oldhash=oldhash, ))
+        self._observer.notify_upd(
+            self,
+            dict(
+                oldhash=oldhash,
+            ),
+        )
 
     def is_expected(self):
         """Return a boolean value according to the last stage value (expected or not)."""
-        return self.stage.startswith('expect')
+        return self.stage.startswith("expect")
 
     @property
     def contents(self):
@@ -259,19 +279,27 @@ class Handler:
         is complete and the container filled.
         """
         if self._empty:
-            self.container.write('')
+            self.container.write("")
             self._empty = False
         if self.complete:
-            if self.container.filled or self.stage == 'put':
+            if self.container.filled or self.stage == "put":
                 if self._contents is None:
-                    self._contents = self.resource.contents_handler(datafmt=self.container.actualfmt)
+                    self._contents = self.resource.contents_handler(
+                        datafmt=self.container.actualfmt
+                    )
                     with self.container.iod_context():
                         self._contents.slurp(self.container)
                 return self._contents
             else:
-                logger.warning('Contents requested on an empty container [%s]', self.container)
+                logger.warning(
+                    "Contents requested on an empty container [%s]",
+                    self.container,
+                )
         else:
-            logger.warning('Contents requested for an uncomplete handler [%s]', self.container)
+            logger.warning(
+                "Contents requested for an uncomplete handler [%s]",
+                self.container,
+            )
             return None
 
     def reset_contents(self):
@@ -316,10 +344,12 @@ class Handler:
                 if fatal:
                     raise
                 else:
-                    return 'OOPS: {!s} (but fatal is False)'.format(e)
+                    return "OOPS: {!s} (but fatal is False)".format(e)
             return self._lasturl
         else:
-            logger.warning('Resource handler %s could not build location', self)
+            logger.warning(
+                "Resource handler %s could not build location", self
+            )
             return None
 
     def idcard(self, indent=2):
@@ -327,39 +357,45 @@ class Handler:
         Returns a multilines documentation string with a summary
         of the valuable information contained by this handler.
         """
-        tab = ' ' * indent
-        card = "\n".join((
-            '{0}Handler {1!r}',
-            '{0}{0}Complete  : {2}',
-            '{0}{0}Options   : {3}',
-            '{0}{0}Location  : {4}'
-        )).format(tab,
-                  self, self.complete, self.options, self.location())
+        tab = " " * indent
+        card = "\n".join(
+            (
+                "{0}Handler {1!r}",
+                "{0}{0}Complete  : {2}",
+                "{0}{0}Options   : {3}",
+                "{0}{0}Location  : {4}",
+            )
+        ).format(tab, self, self.complete, self.options, self.location())
         if self.hooks:
-            card += '\n{0}{0}Hooks     : {1}'.format(tab, ','.join(list(self.hooks.keys())))
-        d = IdCardAttrDumper(tag='idcarddumper')
+            card += "\n{0}{0}Hooks     : {1}".format(
+                tab, ",".join(list(self.hooks.keys()))
+            )
+        d = IdCardAttrDumper(tag="idcarddumper")
         d.reset()
         d.indent_first = 2 * len(tab)
-        for subobj in ('resource', 'provider', 'container'):
+        for subobj in ("resource", "provider", "container"):
             obj = getattr(self, subobj, None)
             if obj:
-                thisdoc = '{0}{0}{1:s} {2!r}'.format(tab,
-                                                     subobj.capitalize(), obj)
+                thisdoc = "{0}{0}{1:s} {2!r}".format(
+                    tab, subobj.capitalize(), obj
+                )
                 thisdoc += d.dump_fpattrs(obj)
             else:
-                thisdoc = '{0}{0}{1:s} undefined'.format(tab, subobj.capitalize())
+                thisdoc = "{0}{0}{1:s} undefined".format(
+                    tab, subobj.capitalize()
+                )
             card = card + "\n" + thisdoc
         return card
 
     def quickview(self, nb=0, indent=0):
         """Standard glance to objects."""
-        tab = '  ' * indent
-        print('{}{:02d}. {:s}'.format(tab, nb, repr(self)))
-        print('{}  Complete  : {!s}'.format(tab, self.complete))
-        for subobj in ('container', 'provider', 'resource'):
+        tab = "  " * indent
+        print("{}{:02d}. {:s}".format(tab, nb, repr(self)))
+        print("{}  Complete  : {!s}".format(tab, self.complete))
+        for subobj in ("container", "provider", "resource"):
             obj = getattr(self, subobj, None)
             if obj:
-                print('{}  {:10s}: {!s}'.format(tab, subobj.capitalize(), obj))
+                print("{}  {:10s}: {!s}".format(tab, subobj.capitalize(), obj))
 
     def wide_key_lookup(self, key, exports=False, fatal=True):
         """Return the *key* attribute if it exists in the provider or resource.
@@ -368,11 +404,11 @@ class Handler:
         is called upon the return value.
         """
         try:
-            if key == 'safeblock':
+            if key == "safeblock":
                 # In olive experiments, the block may contain an indication of
                 # the member's number. Usually we do not want to get that...
-                a_value = getattr(self.provider, 'block')
-                a_value = re.sub(r'(member|fc)_?\d+/', '', a_value)
+                a_value = getattr(self.provider, "block")
+                a_value = re.sub(r"(member|fc)_?\d+/", "", a_value)
             else:
                 a_value = getattr(self.provider, key)
         except AttributeError:
@@ -380,13 +416,17 @@ class Handler:
                 a_value = getattr(self.resource, key)
             except AttributeError:
                 if fatal:
-                    raise AttributeError('The {:s} attribute could not be found in {!r}'.format(key, self))
+                    raise AttributeError(
+                        "The {:s} attribute could not be found in {!r}".format(
+                            key, self
+                        )
+                    )
                 else:
                     a_value = None
         if exports:
-            if hasattr(a_value, 'footprint_export'):
+            if hasattr(a_value, "footprint_export"):
                 a_value = a_value.footprint_export()
-            elif hasattr(a_value, 'export_dict'):
+            elif hasattr(a_value, "export_dict"):
                 a_value = a_value.export_dict()
         return a_value
 
@@ -398,8 +438,8 @@ class Handler:
                 v = v.export_dict()
             except (AttributeError, TypeError):
                 pass
-            rhd['options'][k] = v
-        for subobj in ('resource', 'provider', 'container'):
+            rhd["options"][k] = v
+        for subobj in ("resource", "provider", "container"):
             obj = getattr(self, subobj, None)
             if obj is not None:
                 rhd[subobj] = obj.footprint_export()
@@ -419,11 +459,13 @@ class Handler:
     def store(self):
         if self.resource and self.provider:
             self._uridata = net.uriparse(self.location())
-            stopts = {k: v for k, v in self.options.items() if k.startswith('stor')}
+            stopts = {
+                k: v for k, v in self.options.items() if k.startswith("stor")
+            }
             return footprints.proxy.store(
-                scheme=self._uridata.pop('scheme'),
-                netloc=self._uridata.pop('netloc'),
-                **stopts
+                scheme=self._uridata.pop("scheme"),
+                netloc=self._uridata.pop("netloc"),
+                **stopts,
             )
         else:
             return None
@@ -434,46 +476,60 @@ class Handler:
         if self.resource and self.provider:
             store = self.store
             if store:
-                logger.debug('Check resource %s at %s from %s', self, self.lasturl, store)
-                rst = store.check(
-                    self.uridata,
-                    self.mkopts(extras)
+                logger.debug(
+                    "Check resource %s at %s from %s",
+                    self,
+                    self.lasturl,
+                    store,
                 )
+                rst = store.check(self.uridata, self.mkopts(extras))
                 if rst and self._mdcheck:
-                    logger.info('metadatacheck is on: we are forcing a real get()...')
+                    logger.info(
+                        "metadatacheck is on: we are forcing a real get()..."
+                    )
                     # We are using a temporary fake container
-                    mycontainer = footprints.proxy.container(shouldfly=True,
-                                                             actualfmt=self.container.actualfmt)
+                    mycontainer = footprints.proxy.container(
+                        shouldfly=True, actualfmt=self.container.actualfmt
+                    )
                     try:
                         tmp_options = self.mkopts(extras)
-                        tmp_options['obs_notify'] = False
+                        tmp_options["obs_notify"] = False
                         rst = store.get(
-                            self.uridata,
-                            mycontainer.iotarget(),
-                            tmp_options
+                            self.uridata, mycontainer.iotarget(), tmp_options
                         )
                         if rst:
                             if store.delayed:
-                                logger.warning("The resource is expected... let's say that's fine.")
+                                logger.warning(
+                                    "The resource is expected... let's say that's fine."
+                                )
                             else:
                                 # Create the contents manually and drop it when we are done.
-                                contents = self.resource.contents_handler(datafmt=mycontainer.actualfmt)
+                                contents = self.resource.contents_handler(
+                                    datafmt=mycontainer.actualfmt
+                                )
                                 contents.slurp(mycontainer)
-                                rst = contents.metadata_check(self.resource, delta=self._mddelta)
+                                rst = contents.metadata_check(
+                                    self.resource, delta=self._mddelta
+                                )
                     finally:
                         # Delete the temporary container
                         mycontainer.clear()
-                self.history.append(store.fullname(), 'check', rst)
-                if rst and self.stage == 'load':
+                self.history.append(store.fullname(), "check", rst)
+                if rst and self.stage == "load":
                     # Indicate that the resource was checked
-                    self._updstage('checked')
+                    self._updstage("checked")
                 if not rst:
                     # Always signal failures
-                    self._updstage('void')
+                    self._updstage("void")
             else:
-                logger.error('Could not find any store to check %s', self.lasturl)
+                logger.error(
+                    "Could not find any store to check %s", self.lasturl
+                )
         else:
-            logger.error('Could not check a rh without defined resource and provider %s', self)
+            logger.error(
+                "Could not check a rh without defined resource and provider %s",
+                self,
+            )
         return rst
 
     def locate(self, **extras):
@@ -482,16 +538,20 @@ class Handler:
         if self.resource and self.provider:
             store = self.store
             if store:
-                logger.debug('Locate resource %s at %s from %s', self, self.lasturl, store)
-                rst = store.locate(
-                    self.uridata,
-                    self.mkopts(extras)
+                logger.debug(
+                    "Locate resource %s at %s from %s",
+                    self,
+                    self.lasturl,
+                    store,
                 )
-                self.history.append(store.fullname(), 'locate', rst)
+                rst = store.locate(self.uridata, self.mkopts(extras))
+                self.history.append(store.fullname(), "locate", rst)
             else:
-                logger.error('Could not find any store to locate %s', self.lasturl)
+                logger.error(
+                    "Could not find any store to locate %s", self.lasturl
+                )
         else:
-            logger.error('Could not locate an incomplete rh %s', self)
+            logger.error("Could not locate an incomplete rh %s", self)
         return rst
 
     def prestage(self, **extras):
@@ -500,62 +560,73 @@ class Handler:
         if self.resource and self.provider:
             store = self.store
             if store:
-                logger.debug('Prestage resource %s at %s from %s', self, self.lasturl, store)
-                rst = store.prestage(
-                    self.uridata,
-                    self.mkopts(extras)
+                logger.debug(
+                    "Prestage resource %s at %s from %s",
+                    self,
+                    self.lasturl,
+                    store,
                 )
-                self.history.append(store.fullname(), 'prestage', rst)
+                rst = store.prestage(self.uridata, self.mkopts(extras))
+                self.history.append(store.fullname(), "prestage", rst)
             else:
-                logger.error('Could not find any store to prestage %s', self.lasturl)
+                logger.error(
+                    "Could not find any store to prestage %s", self.lasturl
+                )
         else:
-            logger.error('Could not prestage an incomplete rh %s', self)
+            logger.error("Could not prestage an incomplete rh %s", self)
         return rst
 
     def _generic_apply_hooks(self, action, **extras):
         """Apply the hooks after a get request (or verify that they were done)."""
         if self.hooks:
-            mytracker = extras.get('mytracker', None)
+            mytracker = extras.get("mytracker", None)
             if mytracker is None:
                 iotarget = self.container.iotarget()
                 mytracker = self._cur_context.localtracker[iotarget]
             for hook_name in sorted(self.hooks.keys()):
                 if mytracker.redundant_hook(action, hook_name):
-                    logger.info('Hook already executed <hook_name:%s>', hook_name)
+                    logger.info(
+                        "Hook already executed <hook_name:%s>", hook_name
+                    )
                 else:
-                    logger.info('Executing Hook <hook_name:%s>', hook_name)
+                    logger.info("Executing Hook <hook_name:%s>", hook_name)
                     hook_func, hook_args = self.hooks[hook_name]
                     hook_func(self._cur_session, self, *hook_args)
                     self._notifyhook(action, hook_name)
 
     def apply_get_hooks(self, **extras):
         """Apply the hooks after a get request (or verify that they were done)."""
-        self._generic_apply_hooks(action='get', **extras)
+        self._generic_apply_hooks(action="get", **extras)
 
     def apply_put_hooks(self, **extras):
         """Apply the hooks before a put request (or verify that they were done)."""
-        self._generic_apply_hooks(action='put', **extras)
+        self._generic_apply_hooks(action="put", **extras)
 
     def _postproc_get(self, store, rst, extras):
         self.container.updfill(rst)
         # Check metadata if sensible
         if self._mdcheck and rst and not store.delayed:
-            rst = self.contents.metadata_check(self.resource,
-                                               delta=self._mddelta)
+            rst = self.contents.metadata_check(
+                self.resource, delta=self._mddelta
+            )
             if not rst:
-                logger.info("We are now cleaning up the container and data contents.")
+                logger.info(
+                    "We are now cleaning up the container and data contents."
+                )
                 self.reset_contents()
                 self.clear()
         # For the record...
-        self.history.append(store.fullname(), 'get', rst)
+        self.history.append(store.fullname(), "get", rst)
         if rst:
             # This is an expected resource
             if store.delayed:
-                self._updstage('expected')
-                logger.info('Resource <%s> is expected', self.container.iotarget())
+                self._updstage("expected")
+                logger.info(
+                    "Resource <%s> is expected", self.container.iotarget()
+                )
             # This is a "real" resource
             else:
-                self._updstage('get')
+                self._updstage("get")
                 if self.hooks:
                     if not self.delayhooks:
                         self.apply_get_hooks(**extras)
@@ -563,7 +634,7 @@ class Handler:
                         logger.info("(get-)Hooks were delayed")
         else:
             # Always signal failures
-            self._updstage('void')
+            self._updstage("void")
         return rst
 
     def _actual_get(self, **extras):
@@ -575,7 +646,9 @@ class Handler:
         rst = False
         store = self.store
         if store:
-            logger.debug('Get resource %s at %s from %s', self, self.lasturl, store)
+            logger.debug(
+                "Get resource %s at %s from %s", self, self.lasturl, store
+            )
             st_options = self.mkopts(dict(rhandler=self.as_dict()), extras)
             # Actual get
             try:
@@ -590,7 +663,7 @@ class Handler:
             finally:
                 rst = self._postproc_get(store, rst, extras)
         else:
-            logger.error('Could not find any store to get %s', self.lasturl)
+            logger.error("Could not find any store to get %s", self.lasturl)
 
         # Reset the promise dictionary cache
         self._localpr_cache = None  # To cache the promise dictionary
@@ -608,11 +681,18 @@ class Handler:
         try:
             store = self.store
         except Exception as e:
-            logger.error("The Resource handler was unable to create a store object (%s).",
-                         str(e))
+            logger.error(
+                "The Resource handler was unable to create a store object (%s).",
+                str(e),
+            )
             store = None
         if store:
-            logger.debug('Early-Get resource %s at %s from %s', self, self.lasturl, store)
+            logger.debug(
+                "Early-Get resource %s at %s from %s",
+                self,
+                self.lasturl,
+                store,
+            )
             st_options = self.mkopts(dict(rhandler=self.as_dict()), extras)
             # Actual earlyget
             try:
@@ -622,11 +702,13 @@ class Handler:
                     st_options,
                 )
             except Exception as e:
-                logger.error("The store's earlyget method did not return (%s): it should never append!",
-                             str(e))
+                logger.error(
+                    "The store's earlyget method did not return (%s): it should never append!",
+                    str(e),
+                )
                 return None
         else:
-            logger.error('Could not find any store to get %s', self.lasturl)
+            logger.error("Could not find any store to get %s", self.lasturl)
             return None
 
     def _get_proxy(self, callback, alternate=False, **extras):
@@ -636,66 +718,98 @@ class Handler:
         """
         rst = False
         if self.complete:
-            if self.options.get('insitu', False):  # This a second pass (or third, forth, ...)
+            if self.options.get(
+                "insitu", False
+            ):  # This a second pass (or third, forth, ...)
                 cur_tracker = self._cur_context.localtracker
                 cur_seq = self._cur_context.sequence
                 iotarget = self.container.iotarget()
                 # The localpath is here and listed in the tracker
-                if self.container.exists() and cur_tracker.is_tracked_input(iotarget):
+                if self.container.exists() and cur_tracker.is_tracked_input(
+                    iotarget
+                ):
                     # Am I consistent with the ResourceHandler recorded in the tracker ?
-                    if cur_tracker[iotarget].match_rh('get', self):
+                    if cur_tracker[iotarget].match_rh("get", self):
                         rst = True
                         # There is the tricky usecase where we are dealing with an alternate
                         # that was already dealt with (yes, sometimes the nominal case and
                         # the alternate is the same !)
-                        if not (alternate and iotarget in [s.rh.container.iotarget()
-                                                           for s in cur_seq.effective_inputs()]):
+                        if not (
+                            alternate
+                            and iotarget
+                            in [
+                                s.rh.container.iotarget()
+                                for s in cur_seq.effective_inputs()
+                            ]
+                        ):
                             self.container.updfill(True)
-                            self._updstage('get', insitu=True)
+                            self._updstage("get", insitu=True)
                             logger.info(
-                                'The <%s> resource is already here and matches the RH description :-)',
-                                self.container.iotarget())
+                                "The <%s> resource is already here and matches the RH description :-)",
+                                self.container.iotarget(),
+                            )
                     else:
                         # This may happen if fatal=False and the local file was fetched
                         # by an alternate
                         if alternate:
                             if not self.container.is_virtual():
                                 lpath = self.container.localpath()
-                                for isec in self._cur_context.sequence.rinputs():
-                                    if (isec.stage in ('get' or 'expected') and
-                                            not isec.rh.container.is_virtual() and
-                                            isec.rh.container.localpath() == lpath):
+                                for (
+                                    isec
+                                ) in self._cur_context.sequence.rinputs():
+                                    if (
+                                        isec.stage in ("get" or "expected")
+                                        and not isec.rh.container.is_virtual()
+                                        and isec.rh.container.localpath()
+                                        == lpath
+                                    ):
                                         rst = True
                                         break
                                 if rst:
-                                    logger.info("Alternate is on and the local file exists.")
+                                    logger.info(
+                                        "Alternate is on and the local file exists."
+                                    )
                                 else:
-                                    logger.info("Alternate is on but the local file is not yet matched.")
-                                    self._updstage('void', insitu=True)
+                                    logger.info(
+                                        "Alternate is on but the local file is not yet matched."
+                                    )
+                                    self._updstage("void", insitu=True)
                             else:
-                                logger.info("Alternate is on. The local file exists. The container is virtual.")
+                                logger.info(
+                                    "Alternate is on. The local file exists. The container is virtual."
+                                )
                                 rst = True
                         else:
-                            logger.info("The resource is already here but doesn't match the RH description :-(")
-                            cur_tracker[iotarget].match_rh('get', self, verbose=True)
-                            self._updstage('void', insitu=True)
+                            logger.info(
+                                "The resource is already here but doesn't match the RH description :-("
+                            )
+                            cur_tracker[iotarget].match_rh(
+                                "get", self, verbose=True
+                            )
+                            self._updstage("void", insitu=True)
                 # Bloody hell, the localpath doesn't exist
                 else:
-                    rst = callback(**extras)  # This might be an expected resource...
+                    rst = callback(
+                        **extras
+                    )  # This might be an expected resource...
                     if rst:
-                        logger.info("The resource was successfully fetched :-)")
+                        logger.info(
+                            "The resource was successfully fetched :-)"
+                        )
                     else:
                         logger.info("Could not get the resource :-(")
             else:
                 if alternate and self.container.exists():
-                    logger.info('Alternate <%s> exists', alternate)
+                    logger.info("Alternate <%s> exists", alternate)
                     rst = True
                 else:
                     if self.container.exists():
-                        logger.warning('The resource is already here: that should not happen at this stage !')
+                        logger.warning(
+                            "The resource is already here: that should not happen at this stage !"
+                        )
                     rst = callback(**extras)
         else:
-            logger.error('Could not get an incomplete rh %s', self)
+            logger.error("Could not get an incomplete rh %s", self)
         return rst
 
     def get(self, alternate=False, **extras):
@@ -752,8 +866,10 @@ class Handler:
         """
         r_opts = extras.copy()
         self._latest_earlyget_opts = r_opts
-        self._latest_earlyget_opts['alternate'] = alternate
-        self._latest_earlyget_id = self._get_proxy(self._actual_earlyget, alternate=alternate, **extras)
+        self._latest_earlyget_opts["alternate"] = alternate
+        self._latest_earlyget_id = self._get_proxy(
+            self._actual_earlyget, alternate=alternate, **extras
+        )
         return self._latest_earlyget_id
 
     def finaliseget(self):
@@ -767,8 +883,13 @@ class Handler:
         :raises HandlerError: if :meth:`earlyget` is not called prior to this
                               method.
         """
-        if self._latest_earlyget_id is None and self._latest_earlyget_opts is None:
-            raise HandlerError('earlyget was not called yet. Calling finaliseget is not Allowed !')
+        if (
+            self._latest_earlyget_id is None
+            and self._latest_earlyget_opts is None
+        ):
+            raise HandlerError(
+                "earlyget was not called yet. Calling finaliseget is not Allowed !"
+            )
         try:
             if self._latest_earlyget_id is True:
                 # Nothing to be done...
@@ -776,20 +897,28 @@ class Handler:
             elif self._latest_earlyget_id is None:
                 # Delayed get not available... do the usual get !
                 e_opts = self._latest_earlyget_opts.copy()
-                e_opts['insitu'] = False
+                e_opts["insitu"] = False
                 return self._get_proxy(self._actual_get, **e_opts)
             else:
-                alternate = self._latest_earlyget_opts.get('alternate', False)
+                alternate = self._latest_earlyget_opts.get("alternate", False)
                 if alternate and self.container.exists():
                     # The container may have been filled be another finaliseget
-                    logger.info('Alternate <%s> exists', alternate)
+                    logger.info("Alternate <%s> exists", alternate)
                     rst = True
                 else:
                     rst = False
                     store = self.store
                     if store:
-                        logger.debug('Finalise-Get resource %s at %s from %s', self, self.lasturl, store)
-                        st_options = self.mkopts(dict(rhandler=self.as_dict()), self._latest_earlyget_opts)
+                        logger.debug(
+                            "Finalise-Get resource %s at %s from %s",
+                            self,
+                            self.lasturl,
+                            store,
+                        )
+                        st_options = self.mkopts(
+                            dict(rhandler=self.as_dict()),
+                            self._latest_earlyget_opts,
+                        )
                         # Actual get
                         rst = store.finaliseget(
                             self._latest_earlyget_id,
@@ -799,17 +928,25 @@ class Handler:
                         )
                         if rst is None:
                             # Delayed get failed... attempt the usual get
-                            logger.warning('Delayed get result was unclear ! Reverting to the usual get.')
+                            logger.warning(
+                                "Delayed get result was unclear ! Reverting to the usual get."
+                            )
                             e_opts = self._latest_earlyget_opts.copy()
-                            e_opts['insitu'] = False
+                            e_opts["insitu"] = False
                             return self._get_proxy(self._actual_get, **e_opts)
                         else:
-                            rst = self._postproc_get(store, rst, self._latest_earlyget_opts)
+                            rst = self._postproc_get(
+                                store, rst, self._latest_earlyget_opts
+                            )
                     else:
-                        logger.error('Could not find any store to get %s', self.lasturl)
+                        logger.error(
+                            "Could not find any store to get %s", self.lasturl
+                        )
 
                     # Reset the promise dictionary cache
-                    self._localpr_cache = None  # To cache the promise dictionary
+                    self._localpr_cache = (
+                        None  # To cache the promise dictionary
+                    )
 
                 return rst
         finally:
@@ -823,30 +960,44 @@ class Handler:
         """
         rst = False
         if self.complete:
-            if self.options.get('insitu', False):  # This a second pass (or third, forth, ...)
+            if self.options.get(
+                "insitu", False
+            ):  # This a second pass (or third, forth, ...)
                 cur_tracker = self._cur_context.localtracker
                 cur_seq = self._cur_context.sequence
                 iotarget = self.container.iotarget()
                 # The localpath is here and listed in the tracker
-                if (self.container.exists() and
-                        cur_tracker.is_tracked_input(iotarget)):
-                    if cur_tracker[iotarget].match_rh('get', self):
+                if self.container.exists() and cur_tracker.is_tracked_input(
+                    iotarget
+                ):
+                    if cur_tracker[iotarget].match_rh("get", self):
                         rst = True
                         # There is the tricky usecase where we are dealing with an alternate
                         # that was already dealt with (yes, sometimes the nominal case and
                         # the alternate is the same !)
-                        if not (alternate and iotarget in [s.rh.container.iotarget()
-                                                           for s in cur_seq.effective_inputs()]):
+                        if not (
+                            alternate
+                            and iotarget
+                            in [
+                                s.rh.container.iotarget()
+                                for s in cur_seq.effective_inputs()
+                            ]
+                        ):
                             self.container.updfill(True)
-                            self._updstage('get', insitu=True)
+                            self._updstage("get", insitu=True)
                     elif alternate:
                         # Alternate is on and the local file exists: check if
                         # the file has already been fetch previously in the sequence
-                        if iotarget in [s.rh.container.iotarget()
-                                        for s in cur_seq.effective_inputs()]:
+                        if iotarget in [
+                            s.rh.container.iotarget()
+                            for s in cur_seq.effective_inputs()
+                        ]:
                             rst = True
             else:
-                logger.error('This method should not be called with insitu=False (rh %s)', self)
+                logger.error(
+                    "This method should not be called with insitu=False (rh %s)",
+                    self,
+                )
         return rst
 
     def put(self, **extras):
@@ -864,40 +1015,60 @@ class Handler:
             store = self.store
             if store:
                 iotarget = self.container.iotarget()
-                logger.debug('Put resource %s as io %s at store %s', self, iotarget, store)
-                if iotarget is not None and (self.container.exists() or self.provider.expected):
+                logger.debug(
+                    "Put resource %s as io %s at store %s",
+                    self,
+                    iotarget,
+                    store,
+                )
+                if iotarget is not None and (
+                    self.container.exists() or self.provider.expected
+                ):
                     mytracker = self._cur_context.localtracker[iotarget]
                     # Execute the hooks only if the local file exists
                     if self.container.exists():
                         self.container.updfill(True)
                         if self.hooks:
                             if not self.delayhooks:
-                                self.apply_put_hooks(mytracker=mytracker, **extras)
+                                self.apply_put_hooks(
+                                    mytracker=mytracker, **extras
+                                )
                             else:
                                 logger.info("(put-)Hooks were delayed")
                     # Add a filter function to remove duplicated PUTs to the same uri
                     extras_ext = dict(extras)
-                    extras_ext['urifilter'] = functools.partial(mytracker.redundant_uri, 'put')
+                    extras_ext["urifilter"] = functools.partial(
+                        mytracker.redundant_uri, "put"
+                    )
                     # Actual put
-                    logger.debug('Put resource %s at %s from %s', self, self.lasturl, store)
+                    logger.debug(
+                        "Put resource %s at %s from %s",
+                        self,
+                        self.lasturl,
+                        store,
+                    )
                     rst = store.put(
                         iotarget,
                         self.uridata,
-                        self.mkopts(dict(rhandler=self.as_dict()), extras_ext)
+                        self.mkopts(dict(rhandler=self.as_dict()), extras_ext),
                     )
                     # For the record...
-                    self.history.append(store.fullname(), 'put', rst)
-                    self._updstage('put')
+                    self.history.append(store.fullname(), "put", rst)
+                    self._updstage("put")
                 elif self.ghost:
-                    self.history.append(store.fullname(), 'put', False)
-                    self._updstage('ghost')
+                    self.history.append(store.fullname(), "put", False)
+                    self._updstage("ghost")
                     rst = True
                 else:
-                    logger.error('Could not find any source to put [%s]', iotarget)
+                    logger.error(
+                        "Could not find any source to put [%s]", iotarget
+                    )
             else:
-                logger.error('Could not find any store to put [%s]', self.lasturl)
+                logger.error(
+                    "Could not find any store to put [%s]", self.lasturl
+                )
         else:
-            logger.error('Could not put an incomplete rh [%s]', self)
+            logger.error("Could not put an incomplete rh [%s]", self)
         return rst
 
     def delete(self, **extras):
@@ -906,46 +1077,65 @@ class Handler:
         if self.resource and self.provider:
             store = self.store
             if store:
-                logger.debug('Delete resource %s at %s from %s', self, self.lasturl, store)
+                logger.debug(
+                    "Delete resource %s at %s from %s",
+                    self,
+                    self.lasturl,
+                    store,
+                )
                 rst = store.delete(
                     self.uridata,
-                    self.mkopts(dict(rhandler=self.as_dict()), extras)
+                    self.mkopts(dict(rhandler=self.as_dict()), extras),
                 )
-                self.history.append(store.fullname(), 'delete', rst)
+                self.history.append(store.fullname(), "delete", rst)
             else:
-                logger.error('Could not find any store to delete %s', self.lasturl)
+                logger.error(
+                    "Could not find any store to delete %s", self.lasturl
+                )
         else:
-            logger.error('Could not delete a rh without defined resource and provider %s', self)
+            logger.error(
+                "Could not delete a rh without defined resource and provider %s",
+                self,
+            )
         return rst
 
     def clear(self):
         """Clear the local container contents."""
         rst = False
         if self.container:
-            logger.debug('Remove resource container %s', self.container)
+            logger.debug("Remove resource container %s", self.container)
             rst = self.container.clear()
-            self.history.append(self.container.actualpath(), 'clear', rst)
+            self.history.append(self.container.actualpath(), "clear", rst)
             self._notifyclear()
-            stage_clear_mapping = dict(expected='checked', get='checked')
+            stage_clear_mapping = dict(expected="checked", get="checked")
             if self.stage in stage_clear_mapping:
                 self._updstage(stage_clear_mapping[self.stage])
         return rst
 
-    def mkgetpr(self, pr_getter=None, tplfile=None, tplskip='@sync-skip.tpl',
-                tplfetch='@sync-fetch.tpl', py_exec=sys.executable, py_opts=''):
+    def mkgetpr(
+        self,
+        pr_getter=None,
+        tplfile=None,
+        tplskip="@sync-skip.tpl",
+        tplfetch="@sync-fetch.tpl",
+        py_exec=sys.executable,
+        py_opts="",
+    ):
         """Build a getter for the expected resource."""
         if tplfile is None:
             tplfile = tplfetch if self.is_expected() else tplskip
         if pr_getter is None:
-            pr_getter = self.container.localpath() + '.getpr'
+            pr_getter = self.container.localpath() + ".getpr"
         t = self._cur_session
         tpl = config.load_template(t, tplfile)
-        with open(pr_getter, 'w', encoding='utf-8') as fd:
-            fd.write(tpl.substitute(
-                python=py_exec,
-                pyopts=py_opts,
-                promise=self.container.localpath(),
-            ))
+        with open(pr_getter, "w", encoding="utf-8") as fd:
+            fd.write(
+                tpl.substitute(
+                    python=py_exec,
+                    pyopts=py_opts,
+                    promise=self.container.localpath(),
+                )
+            )
         t.sh.chmod(pr_getter, 0o555)
         return pr_getter
 
@@ -953,7 +1143,9 @@ class Handler:
     def _localpr_json(self):
         if self.is_expected():
             if self._localpr_cache is None:
-                self._localpr_cache = self._cur_session.sh.json_load(self.container.localpath())
+                self._localpr_cache = self._cur_session.sh.json_load(
+                    self.container.localpath()
+                )
             return self._localpr_cache
         else:
             return None
@@ -966,10 +1158,10 @@ class Handler:
         rc = True
         if self.is_expected():
             pr = self._localpr_json
-            itself = pr.get('itself')
+            itself = pr.get("itself")
             rc = not self._cur_session.sh.path.exists(itself)
             if rc and check_exists:
-                remote = pr.get('locate').split(';')[0]
+                remote = pr.get("locate").split(";")[0]
                 rc = self._cur_session.sh.path.exists(remote)
         return rc
 
@@ -981,28 +1173,39 @@ class Handler:
             nb = 0
             sh = self._cur_session.sh
             pr = self._localpr_json
-            itself = pr.get('itself')
+            itself = pr.get("itself")
             nbtries = int(timeout / sleep)
-            logger.info('Waiting %d x %d s. for expected resource <%s>', nbtries, sleep, local)
+            logger.info(
+                "Waiting %d x %d s. for expected resource <%s>",
+                nbtries,
+                sleep,
+                local,
+            )
             while sh.path.exists(itself):
                 sh.sleep(sleep)
                 nb += 1
                 if nb > nbtries:
-                    logger.error('Could not wait anymore <%d>', nb)
+                    logger.error("Could not wait anymore <%d>", nb)
                     rc = False
                     if fatal:
-                        logger.critical('Missing expected resource is fatal <%s>', local)
-                        raise HandlerError('Expected resource missing')
+                        logger.critical(
+                            "Missing expected resource is fatal <%s>", local
+                        )
+                        raise HandlerError("Expected resource missing")
                     break
             else:
-                remote = pr.get('locate').split(';')[0]
+                remote = pr.get("locate").split(";")[0]
                 if sh.path.exists(remote):
-                    logger.info('Keeping promise for remote resource <%s>', remote)
+                    logger.info(
+                        "Keeping promise for remote resource <%s>", remote
+                    )
                 else:
-                    logger.warning('Empty promise for remote resource <%s>', remote)
+                    logger.warning(
+                        "Empty promise for remote resource <%s>", remote
+                    )
                     rc = False
         else:
-            logger.info('Resource <%s> not expected', local)
+            logger.info("Resource <%s> not expected", local)
         return rc
 
     def save(self):
@@ -1013,9 +1216,9 @@ class Handler:
             if not self.container.is_virtual():
                 self.container.close()
         else:
-            logger.warning('Try to save undefined contents %s', self)
+            logger.warning("Try to save undefined contents %s", self)
         return rst
 
     def strlast(self):
         """String formatted log of the last action."""
-        return ' '.join([str(x) for x in self.history.last])
+        return " ".join([str(x) for x in self.history.last])

--- a/src/vortex/data/outflow.py
+++ b/src/vortex/data/outflow.py
@@ -17,13 +17,12 @@ __all__ = []
 
 
 class StaticResource(Resource):
-
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                info        = "The resource's kind.",
-                doc_zorder  = 90,
+        attr=dict(
+            kind=dict(
+                info="The resource's kind.",
+                doc_zorder=90,
             ),
         )
     )
@@ -36,19 +35,20 @@ class StaticGeoResource(StaticResource):
     _footprint = [
         hgeometry_deco,
         dict(
-            attr = dict(
-                clscontents = dict(
-                    default = FormatAdapter,
+            attr=dict(
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             )
-        )
+        ),
     ]
 
 
 class ModelResource(StaticResource):
-
     _abstract = True
-    _footprint = [model_deco, ]
+    _footprint = [
+        model_deco,
+    ]
 
 
 class ModelGeoResource(ModelResource):
@@ -58,10 +58,10 @@ class ModelGeoResource(ModelResource):
     _footprint = [
         hgeometry_deco,
         dict(
-            attr = dict(
-                clscontents = dict(
-                    default = FormatAdapter,
+            attr=dict(
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             )
-        )
+        ),
     ]

--- a/src/vortex/data/providers.py
+++ b/src/vortex/data/providers.py
@@ -21,15 +21,23 @@ from footprints.stdtypes import FPDict
 
 from vortex import sessions
 from vortex import config
-from vortex.syntax.stdattrs import xpid, legacy_xpid, free_xpid, opsuites, \
-    demosuites, scenario, member, block
+from vortex.syntax.stdattrs import (
+    xpid,
+    legacy_xpid,
+    free_xpid,
+    opsuites,
+    demosuites,
+    scenario,
+    member,
+    block,
+)
 from vortex.syntax.stdattrs import LegacyXPid, any_vortex_xpid
 from vortex.syntax.stdattrs import namespacefp, Namespace, FmtInt
 from vortex.tools import net, names
 from vortex.util.config import GenericConfigParser
 
 #: No automatic export
-__all__ = ['Provider']
+__all__ = ["Provider"]
 
 logger = loggers.getLogger(__name__)
 
@@ -38,48 +46,48 @@ class Provider(footprints.FootprintBase):
     """Abstract class for any Provider."""
 
     _abstract = True
-    _collector = ('provider',)
+    _collector = ("provider",)
     _footprint = dict(
-        info = 'Abstract root provider',
-        attr = dict(
-            vapp = dict(
-                info        = "The application's identifier.",
-                alias       = ('application',),
-                optional    = True,
-                default     = '[glove::vapp]',
-                doc_zorder  = -10
+        info="Abstract root provider",
+        attr=dict(
+            vapp=dict(
+                info="The application's identifier.",
+                alias=("application",),
+                optional=True,
+                default="[glove::vapp]",
+                doc_zorder=-10,
             ),
-            vconf = dict(
-                info        = "The configuration's identifier.",
-                alias       = ('configuration',),
-                optional    = True,
-                default     = '[glove::vconf]',
-                doc_zorder  = -10
+            vconf=dict(
+                info="The configuration's identifier.",
+                alias=("configuration",),
+                optional=True,
+                default="[glove::vconf]",
+                doc_zorder=-10,
             ),
-            username = dict(
-                info     = "The username that will be used whenever necessary.",
-                optional = True,
-                default  = None,
-                alias    = ('user', 'logname')
+            username=dict(
+                info="The username that will be used whenever necessary.",
+                optional=True,
+                default=None,
+                alias=("user", "logname"),
             ),
         ),
-        fastkeys = {'namespace'},
+        fastkeys={"namespace"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract provider init %s', self.__class__)
+        logger.debug("Abstract provider init %s", self.__class__)
         super().__init__(*args, **kw)
 
     def _str_more(self):
         """Additional information to print representation."""
         try:
-            return 'namespace=\'{:s}\''.format(self.namespace)
+            return "namespace='{:s}'".format(self.namespace)
         except AttributeError:
             return super()._str_more()
 
     @property
     def realkind(self):
-        return 'provider'
+        return "provider"
 
     def scheme(self, resource):
         """Abstract method."""
@@ -123,61 +131,67 @@ class Provider(footprints.FootprintBase):
         The different operations of the algorithm can be redefined by subclasses.
         """
         username = self.netuser_name(resource)
-        fullnetloc = ('{:s}@{:s}'.format(username, self.netloc(resource)) if username
-                      else self.netloc(resource))
+        fullnetloc = (
+            "{:s}@{:s}".format(username, self.netloc(resource))
+            if username
+            else self.netloc(resource)
+        )
         logger.debug(
-            'scheme %s netloc %s normpath %s urlquery %s',
+            "scheme %s netloc %s normpath %s urlquery %s",
             self.scheme(resource),
             fullnetloc,
-            os.path.normpath(self.pathname(resource) + '/' + self.basename(resource)),
-            self.urlquery(resource)
+            os.path.normpath(
+                self.pathname(resource) + "/" + self.basename(resource)
+            ),
+            self.urlquery(resource),
         )
 
-        return net.uriunparse((
-            self.scheme(resource),
-            fullnetloc,
-            os.path.normpath(self.pathname(resource) + '/' + self.basename(resource)),
-            None,
-            self.urlquery(resource),
-            None
-        ))
+        return net.uriunparse(
+            (
+                self.scheme(resource),
+                fullnetloc,
+                os.path.normpath(
+                    self.pathname(resource) + "/" + self.basename(resource)
+                ),
+                None,
+                self.urlquery(resource),
+                None,
+            )
+        )
 
 
 class Magic(Provider):
-
     _footprint = [
         xpid,
         dict(
-            info = 'Magic provider that always returns the same URI.',
-            attr = dict(
-                fake = dict(
-                    info     = "Enable this magic provider.",
-                    alias    = ('nowhere', 'noprovider'),
-                    type     = bool,
-                    optional = True,
-                    default  = True,
+            info="Magic provider that always returns the same URI.",
+            attr=dict(
+                fake=dict(
+                    info="Enable this magic provider.",
+                    alias=("nowhere", "noprovider"),
+                    type=bool,
+                    optional=True,
+                    default=True,
                 ),
-                magic = dict(
-                    info     = "The URI returned by this provider."
+                magic=dict(info="The URI returned by this provider."),
+                experiment=dict(
+                    optional=True,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
                 ),
-                experiment = dict(
-                    optional = True,
-                    doc_visibility  = footprints.doc.visibility.ADVANCED,
+                vapp=dict(
+                    doc_visibility=footprints.doc.visibility.GURU,
                 ),
-                vapp = dict(
-                    doc_visibility  = footprints.doc.visibility.GURU,
-                ),
-                vconf = dict(
-                    doc_visibility  = footprints.doc.visibility.GURU,
+                vconf=dict(
+                    doc_visibility=footprints.doc.visibility.GURU,
                 ),
             ),
-            fastkeys = {'magic'},
-        )
+            fastkeys={"magic"},
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'magic'
+        return "magic"
 
     def uri(self, resource):
         """URI is supposed to be the magic value !"""
@@ -185,47 +199,46 @@ class Magic(Provider):
 
 
 class Remote(Provider):
-
     _footprint = dict(
-        info = 'Provider that manipulates data given a real path',
-        attr = dict(
-            remote = dict(
-                info        = 'The path to the data.',
-                alias       = ('remfile', 'rempath'),
-                doc_zorder  = 50
+        info="Provider that manipulates data given a real path",
+        attr=dict(
+            remote=dict(
+                info="The path to the data.",
+                alias=("remfile", "rempath"),
+                doc_zorder=50,
             ),
-            hostname = dict(
-                info     = 'The hostname that holds the data.',
-                optional = True,
-                default  = 'localhost'
+            hostname=dict(
+                info="The hostname that holds the data.",
+                optional=True,
+                default="localhost",
             ),
-            tube = dict(
-                info     = "The protocol used to access the data.",
-                optional = True,
-                values   = ['scp', 'ftp', 'rcp', 'file', 'symlink'],
-                default  = 'file',
+            tube=dict(
+                info="The protocol used to access the data.",
+                optional=True,
+                values=["scp", "ftp", "rcp", "file", "symlink"],
+                default="file",
             ),
-            vapp = dict(
-                doc_visibility  = footprints.doc.visibility.GURU,
+            vapp=dict(
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-            vconf = dict(
-                doc_visibility  = footprints.doc.visibility.GURU,
+            vconf=dict(
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
         ),
-        fastkeys = {'remote'},
+        fastkeys={"remote"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Remote provider init %s', self.__class__)
+        logger.debug("Remote provider init %s", self.__class__)
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
-        return 'remote'
+        return "remote"
 
     def _str_more(self):
         """Additional information to print representation."""
-        return 'path=\'{:s}\''.format(self.remote)
+        return "path='{:s}'".format(self.remote)
 
     def scheme(self, resource):
         """The Remote scheme is its tube."""
@@ -245,10 +258,10 @@ class Remote(Provider):
 
     def urlquery(self, resource):
         """Check for relative path or not."""
-        if self.remote.startswith('/'):
+        if self.remote.startswith("/"):
             return None
         else:
-            return 'relative=1'
+            return "relative=1"
 
 
 def set_namespace_from_cache_settings(usecache, usearchive):
@@ -285,72 +298,81 @@ class Vortex(Provider):
         scenario,
         namespacefp,
         dict(
-            info = 'Vortex provider',
-            attr = dict(
-                experiment = dict(
-                    info = "Provider experiment id",
-                    type = str,
-                    optional = False,
-                    access = "rwx",
+            info="Vortex provider",
+            attr=dict(
+                experiment=dict(
+                    info="Provider experiment id",
+                    type=str,
+                    optional=False,
+                    access="rwx",
                 ),
-                member = dict(
-                    type    = FmtInt,
-                    args    = dict(fmt = '03'),
+                member=dict(
+                    type=FmtInt,
+                    args=dict(fmt="03"),
                 ),
-                namespace = dict(
-                    values   = [
-                        'vortex.cache.fr', 'vortex.archive.fr', 'vortex.multi.fr', 'vortex.stack.fr',
-                        'open.cache.fr', 'open.archive.fr', 'open.multi.fr', 'open.stack.fr',
+                namespace=dict(
+                    values=[
+                        "vortex.cache.fr",
+                        "vortex.archive.fr",
+                        "vortex.multi.fr",
+                        "vortex.stack.fr",
+                        "open.cache.fr",
+                        "open.archive.fr",
+                        "open.multi.fr",
+                        "open.stack.fr",
                     ],
-                    remap    = {
-                        'open.cache.fr': 'vortex.cache.fr',
-                        'open.archive.fr': 'vortex.archive.fr',
-                        'open.multi.fr': 'vortex.multi.fr',
-                        'open.stack.fr': 'vortex.stack.fr',
+                    remap={
+                        "open.cache.fr": "vortex.cache.fr",
+                        "open.archive.fr": "vortex.archive.fr",
+                        "open.multi.fr": "vortex.multi.fr",
+                        "open.stack.fr": "vortex.stack.fr",
                     },
-                    optional = True,
-                    default = None,
-                    access = "rwx",
+                    optional=True,
+                    default=None,
+                    access="rwx",
                 ),
-                cache = dict(
-                    info = "Whether or not to use the cache",
-                    type = bool,
-                    optional = True,
-                    default = None,
+                cache=dict(
+                    info="Whether or not to use the cache",
+                    type=bool,
+                    optional=True,
+                    default=None,
                 ),
-                archive = dict(
-                    info = "Whether or not to use the archive",
-                    type = bool,
-                    optional = True,
-                    default = None,
+                archive=dict(
+                    info="Whether or not to use the archive",
+                    type=bool,
+                    optional=True,
+                    default=None,
                 ),
-                namebuild = dict(
-                    info           = "The object responsible for building filenames.",
-                    optional       = True,
-                    doc_visibility = footprints.doc.visibility.ADVANCED,
+                namebuild=dict(
+                    info="The object responsible for building filenames.",
+                    optional=True,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
                 ),
-                expected = dict(
-                    info        = "Is the resource expected ?",
-                    alias       = ('promised',),
-                    type        = bool,
-                    optional    = True,
-                    default     = False,
-                    doc_zorder  = -5,
+                expected=dict(
+                    info="Is the resource expected ?",
+                    alias=("promised",),
+                    type=bool,
+                    optional=True,
+                    default=False,
+                    doc_zorder=-5,
                 ),
             ),
-            fastkeys = {'block', 'experiment'},
-        )
+            fastkeys={"block", "experiment"},
+        ),
     ]
 
     def __init__(self, *args, **kw):
-        logger.debug('Vortex experiment provider init %s', self.__class__)
+        logger.debug("Vortex experiment provider init %s", self.__class__)
         super().__init__(*args, **kw)
         if self.namebuild is not None:
             if self.namebuild not in self._CUSTOM_NAME_BUILDERS:
                 builder = fpx.vortexnamebuilder(name=self.namebuild)
                 if builder is None:
-                    raise ValueError("The << {:s} >> name builder does not exists."
-                                     .format(self.namebuild))
+                    raise ValueError(
+                        "The << {:s} >> name builder does not exists.".format(
+                            self.namebuild
+                        )
+                    )
                 self._CUSTOM_NAME_BUILDERS[self.namebuild] = builder
             self._namebuilder = self._CUSTOM_NAME_BUILDERS[self.namebuild]
         else:
@@ -368,23 +390,26 @@ class Vortex(Provider):
         # are specified, 'namespace' is ignored
         if self.namespace and (self.cache or self.archive):
             logger.warning(
-                f"Ignoring attribute \"namespace\" set to {self.namespace} "
+                f'Ignoring attribute "namespace" set to {self.namespace} '
                 "as attribute(s) cache and/or archive are specified"
             )
-        if self.namespace and ((self.cache is None) and (self.archive is None)):
+        if self.namespace and (
+            (self.cache is None) and (self.archive is None)
+        ):
             warnings.warn(
-                "Using attribute \"namespace\" is deprecated, use \"cache\""
-                "and/or \"archive\" instead.",
+                'Using attribute "namespace" is deprecated, use "cache"'
+                'and/or "archive" instead.',
                 category=DeprecationWarning,
             )
         else:
             self.namespace = set_namespace_from_cache_settings(
-                self.cache, self.archive,
-        )
+                self.cache,
+                self.archive,
+            )
             if not self.namespace:
                 raise ValueError(
-                    "Attributes \"cache\" and \"archive\" cannot be "
-                    "both specified as \"False\"."
+                    'Attributes "cache" and "archive" cannot be '
+                    'both specified as "False".'
                 )
 
     @property
@@ -393,7 +418,7 @@ class Vortex(Provider):
 
     @property
     def realkind(self):
-        return 'vortex'
+        return "vortex"
 
     def actual_experiment(self, resource):
         return self.experiment
@@ -401,13 +426,15 @@ class Vortex(Provider):
     def _str_more(self):
         """Additional information to print representation."""
         try:
-            return 'namespace=\'{:s}\' block=\'{:s}\''.format(self.namespace, self.block)
+            return "namespace='{:s}' block='{:s}'".format(
+                self.namespace, self.block
+            )
         except AttributeError:
             return super()._str_more()
 
     def scheme(self, resource):
         """Default: ``vortex``."""
-        return 'x' + self.realkind if self.expected else self.realkind
+        return "x" + self.realkind if self.expected else self.realkind
 
     def netloc(self, resource):
         """Returns the current ``namespace``."""
@@ -450,16 +477,23 @@ class Vortex(Provider):
         stackres, keepmember = resource.stackedstorage_resource()
         if stackres:
             stackpathinfo = self._pathname_info(stackres)
-            stackpathinfo['block'] = 'stacks'
+            stackpathinfo["block"] = "stacks"
             if not keepmember:
-                stackpathinfo['member'] = None
-            uqs['stackpath'] = [(self.namebuilder.pack_pathname(stackpathinfo) + '/' +
-                                 self.basename(stackres)), ]
-            uqs['stackfmt'] = [stackres.nativefmt, ]
+                stackpathinfo["member"] = None
+            uqs["stackpath"] = [
+                (
+                    self.namebuilder.pack_pathname(stackpathinfo)
+                    + "/"
+                    + self.basename(stackres)
+                ),
+            ]
+            uqs["stackfmt"] = [
+                stackres.nativefmt,
+            ]
         return urlparse.urlencode(sorted(uqs.items()), doseq=True)
 
 
 # Activate the footprint's fasttrack on the resources collector
-fcollect = footprints.collectors.get(tag='provider')
-fcollect.fasttrack = ('namespace', )
+fcollect = footprints.collectors.get(tag="provider")
+fcollect.fasttrack = ("namespace",)
 del fcollect

--- a/src/vortex/data/providers.py
+++ b/src/vortex/data/providers.py
@@ -6,35 +6,23 @@ Of course, the :class:`Vortex` abstract provider is a must see. It has three
 declinations depending on the experiment indentifier type.
 """
 
-import collections
-import operator
 import os.path
-import re
 from urllib import parse as urlparse
 import warnings
 
 from bronx.fancies import loggers
-from bronx.syntax.parsing import StringDecoder
 import footprints
 from footprints import proxy as fpx
-from footprints.stdtypes import FPDict
 
-from vortex import sessions
 from vortex import config
 from vortex.syntax.stdattrs import (
     xpid,
-    legacy_xpid,
-    free_xpid,
-    opsuites,
-    demosuites,
     scenario,
     member,
     block,
 )
-from vortex.syntax.stdattrs import LegacyXPid, any_vortex_xpid
-from vortex.syntax.stdattrs import namespacefp, Namespace, FmtInt
+from vortex.syntax.stdattrs import namespacefp, FmtInt
 from vortex.tools import net, names
-from vortex.util.config import GenericConfigParser
 
 #: No automatic export
 __all__ = ["Provider"]

--- a/src/vortex/data/resources.py
+++ b/src/vortex/data/resources.py
@@ -16,7 +16,9 @@ from vortex.syntax.stdattrs import nativefmt_deco, notinrepr, term_deco
 from .contents import DataContent, UnknownContent, FormatAdapter
 
 #: Export Resource and associated Catalog classes.
-__all__ = ['Resource', ]
+__all__ = [
+    "Resource",
+]
 
 logger = loggers.getLogger(__name__)
 
@@ -25,40 +27,40 @@ class Resource(footprints.FootprintBase):
     """Abstract class for any Resource."""
 
     _abstract = True
-    _collector = ('resource',)
+    _collector = ("resource",)
     _footprint = [
         nativefmt_deco,
         dict(
-            info = 'Abstract Resource',
-            attr = dict(
-                clscontents = dict(
-                    info            = "The class instantiated to read the container's content",
-                    type            = DataContent,
-                    isclass         = True,
-                    optional        = True,
-                    default         = UnknownContent,
-                    doc_visibility  = footprints.doc.visibility.ADVANCED,
+            info="Abstract Resource",
+            attr=dict(
+                clscontents=dict(
+                    info="The class instantiated to read the container's content",
+                    type=DataContent,
+                    isclass=True,
+                    optional=True,
+                    default=UnknownContent,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
                 )
             ),
-            fastkeys = {'kind', 'nativefmt'}
-        )
+            fastkeys={"kind", "nativefmt"},
+        ),
     ]
 
     def __init__(self, *args, **kw):
-        logger.debug('Resource init %s', self.__class__)
+        logger.debug("Resource init %s", self.__class__)
         super().__init__(*args, **kw)
         self._mailbox = LowerCaseDict()
 
     @property
     def realkind(self):
-        return 'resource'
+        return "resource"
 
     def _str_more(self):
         """Return a string representation of meaningful attributes for formatted output."""
         d = self.footprint_as_shallow_dict()
         for xdel in [x for x in notinrepr if x in d]:
             del d[xdel]
-        return ' '.join(['{:s}=\'{!s}\''.format(k, v) for k, v in d.items()])
+        return " ".join(["{:s}='{!s}'".format(k, v) for k, v in d.items()])
 
     @property
     def mailbox(self):
@@ -74,7 +76,9 @@ class Resource(footprints.FootprintBase):
 
     def pathinfo(self, provider):
         """Proxy to the appropriate method prefixed by provider name."""
-        actualpathinfo = getattr(self, provider + '_pathinfo', self.generic_pathinfo)
+        actualpathinfo = getattr(
+            self, provider + "_pathinfo", self.generic_pathinfo
+        )
         return actualpathinfo()
 
     def generic_basename(self):
@@ -83,7 +87,9 @@ class Resource(footprints.FootprintBase):
 
     def basename(self, provider):
         """Proxy to the appropriate method prefixed by provider name."""
-        actualbasename = getattr(self, provider + '_basename', self.generic_basename)
+        actualbasename = getattr(
+            self, provider + "_basename", self.generic_basename
+        )
         return actualbasename()
 
     def namebuilding_info(self):
@@ -91,7 +97,7 @@ class Resource(footprints.FootprintBase):
         Returns anonymous dict with suitable informations from vortex point of view.
         In real world, probably doomed to return an empty dict.
         """
-        return {'radical': self.realkind}
+        return {"radical": self.realkind}
 
     def vortex_urlquery(self):
         """Query to be binded to the resource's location in vortex space."""
@@ -99,7 +105,9 @@ class Resource(footprints.FootprintBase):
 
     def urlquery(self, provider):
         """Proxy to the appropriate method prefixed by provider name."""
-        actualurlquery = getattr(self, provider + '_urlquery', self.vortex_urlquery)
+        actualurlquery = getattr(
+            self, provider + "_urlquery", self.vortex_urlquery
+        )
         return actualurlquery()
 
     def gget_basename(self):
@@ -112,7 +120,7 @@ class Resource(footprints.FootprintBase):
 
     def genv_basename(self):
         """Just retrieve a potential gvar attribute."""
-        return getattr(self, 'gvar', '')
+        return getattr(self, "gvar", "")
 
     def uenv_basename(self):
         """Proxy to :meth:`genv_basename`."""
@@ -120,7 +128,7 @@ class Resource(footprints.FootprintBase):
 
     def gget_urlquery(self):
         """Duck typing: return an empty string by default."""
-        return ''
+        return ""
 
     def uget_urlquery(self):
         """Proxy to :meth:`gget_urlquery`."""
@@ -155,34 +163,32 @@ class Resource(footprints.FootprintBase):
 
 
 class Unknown(Resource):
-
     _footprint = [
         dict(
-            info = 'Unknown assumed NWP Resource (development only !)',
-            attr = dict(
-                unknown = dict(
-                    info = "Activate the unknown resource.",
-                    type = bool
+            info="Unknown assumed NWP Resource (development only !)",
+            attr=dict(
+                unknown=dict(info="Activate the unknown resource.", type=bool),
+                nickname=dict(
+                    info="The string that serves the purpose of Vortex's basename radical",
+                    optional=True,
+                    default="unknown",
                 ),
-                nickname = dict(
-                    info = "The string that serves the purpose of Vortex's basename radical",
-                    optional = True,
-                    default = 'unknown'
-                ),
-                clscontents = dict(
-                    default = FormatAdapter,
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             ),
-            fastkeys = {'unknown'},
+            fastkeys={"unknown"},
         )
     ]
 
     def namebuilding_info(self):
         """Keep the Unknown resource unknown."""
         bdict = super().namebuilding_info()
-        bdict.update(radical=self.nickname, )
-        if self.nativefmt in ('auto', 'autoconfig', 'foo', 'unknown'):
-            del bdict['fmt']
+        bdict.update(
+            radical=self.nickname,
+        )
+        if self.nativefmt in ("auto", "autoconfig", "foo", "unknown"):
+            del bdict["fmt"]
         return bdict
 
 
@@ -190,12 +196,12 @@ class UnknownWithTerm(Unknown):
     _footprint = [
         term_deco,
         dict(
-            info = 'Unknown assumed NWP Resource but with term (development only !)',
+            info="Unknown assumed NWP Resource but with term (development only !)",
         ),
     ]
 
 
 # Activate the footprint's fasttrack on the resources collector
-fcollect = footprints.collectors.get(tag='resource')
-fcollect.fasttrack = ('kind', )
+fcollect = footprints.collectors.get(tag="resource")
+fcollect.fasttrack = ("kind",)
 del fcollect

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -15,7 +15,12 @@ import footprints
 
 from vortex import sessions
 from vortex import config
-from vortex.data.abstractstores import Store, ArchiveStore, ConfigurableArchiveStore, CacheStore
+from vortex.data.abstractstores import (
+    Store,
+    ArchiveStore,
+    ConfigurableArchiveStore,
+    CacheStore,
+)
 from vortex.data.abstractstores import MultiStore, PromiseStore
 from vortex.data.abstractstores import ARCHIVE_GET_INTENT_DEFAULT
 from vortex.layout import dataflow
@@ -34,20 +39,20 @@ class MagicPlace(Store):
     """Somewhere, over the rainbow!"""
 
     _footprint = dict(
-        info = 'Evanescent physical store',
-        attr = dict(
-            scheme = dict(
-                values   = ['magic'],
+        info="Evanescent physical store",
+        attr=dict(
+            scheme=dict(
+                values=["magic"],
             ),
         ),
-        priority = dict(
-            level = footprints.priorities.top.DEFAULT  # @UndefinedVariable
-        )
+        priority=dict(
+            level=footprints.priorities.top.DEFAULT  # @UndefinedVariable
+        ),
     )
 
     @property
     def realkind(self):
-        return 'magicstore'
+        return "magicstore"
 
     def has_fast_check(self):
         """A void check is very fast !"""
@@ -59,7 +64,7 @@ class MagicPlace(Store):
 
     def magiclocate(self, remote, options):
         """Void - Empty string returned."""
-        return ''
+        return ""
 
     def magicget(self, remote, local, options):
         """Void - Always True."""
@@ -108,23 +113,23 @@ class FunctionStore(Store):
     """
 
     _footprint = dict(
-        info = 'Dummy store that calls a function',
-        attr = dict(
-            scheme = dict(
-                values   = ['function'],
+        info="Dummy store that calls a function",
+        attr=dict(
+            scheme=dict(
+                values=["function"],
             ),
-            netloc = dict(
-                values   = [''],
-            )
+            netloc=dict(
+                values=[""],
+            ),
         ),
-        priority = dict(
-            level = footprints.priorities.top.DEFAULT  # @UndefinedVariable
-        )
+        priority=dict(
+            level=footprints.priorities.top.DEFAULT  # @UndefinedVariable
+        ),
     )
 
     @property
     def realkind(self):
-        return 'functionstore'
+        return "functionstore"
 
     def has_fast_check(self):
         """A void check is very fast !"""
@@ -136,20 +141,21 @@ class FunctionStore(Store):
 
     def functionlocate(self, remote, options):
         """The name of the function that will be called."""
-        cleanname = remote['path'][1:]
-        if cleanname.endswith('/'):
+        cleanname = remote["path"][1:]
+        if cleanname.endswith("/"):
             cleanname = cleanname[:-1]
         return cleanname
 
     def functionget(self, remote, local, options):
         """Calls the appropriate function and writes the result."""
         # Find the appropriate function
-        cbfunc = self.system.import_function(self.functionlocate(remote,
-                                                                 options))
+        cbfunc = self.system.import_function(
+            self.functionlocate(remote, options)
+        )
         # ... and call it
         opts = dict()
         opts.update(options)
-        opts.update(remote['query'])
+        opts.update(remote["query"])
         try:
             fres = cbfunc(opts)
         except FunctionStoreCallbackError as e:
@@ -157,15 +163,15 @@ class FunctionStore(Store):
             logger.error("Here is the exception: %s", str(e))
             fres = None
         if fres is not None:
-            if 'intent' in options and options['intent'] == dataflow.intent.IN:
-                logger.info('Ignore intent <in> for function input.')
+            if "intent" in options and options["intent"] == dataflow.intent.IN:
+                logger.info("Ignore intent <in> for function input.")
             # Handle StringIO objects, by changing them to ByteIOs...
             if isinstance(fres, io.StringIO):
                 s_fres = fres
                 s_fres.seek(0)
                 fres = io.BytesIO()
                 for l in s_fres:
-                    fres.write(l.encode(encoding='utf-8'))
+                    fres.write(l.encode(encoding="utf-8"))
                 fres.seek(0)
             # NB: fres should be a file like object (BytesIO will do the trick)
             return self.system.cp(fres, local)
@@ -187,30 +193,30 @@ class Finder(Store):
     """The most usual store: your current filesystem!"""
 
     _footprint = dict(
-        info = 'Miscellaneous file access',
-        attr = dict(
-            scheme = dict(
-                values  = ['file', 'ftp', 'symlink', 'rcp', 'scp'],
+        info="Miscellaneous file access",
+        attr=dict(
+            scheme=dict(
+                values=["file", "ftp", "symlink", "rcp", "scp"],
             ),
-            netloc = dict(
-                outcast = ['oper.inline.fr'],
+            netloc=dict(
+                outcast=["oper.inline.fr"],
             ),
-            storehash = dict(
-                values = hashalgo_avail_list,
+            storehash=dict(
+                values=hashalgo_avail_list,
             ),
         ),
-        priority = dict(
-            level = footprints.priorities.top.DEFAULT  # @UndefinedVariable
-        )
+        priority=dict(
+            level=footprints.priorities.top.DEFAULT  # @UndefinedVariable
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Finder store init %s', self.__class__)
+        logger.debug("Finder store init %s", self.__class__)
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
-        return 'finder'
+        return "finder"
 
     def hostname(self):
         """Returns the current :attr:`netloc`."""
@@ -218,21 +224,28 @@ class Finder(Store):
 
     def fullpath(self, remote):
         """Return actual path unless explicitly defined as relative path."""
-        if remote['query'].get('relative', False):
-            return remote['path'].lstrip('/')
+        if remote["query"].get("relative", False):
+            return remote["path"].lstrip("/")
         else:
-            return remote['path']
+            return remote["path"]
 
     def _localtarfix(self, local):
-        if (isinstance(local, str) and self.system.path.isfile(local) and
-                self.system.is_tarfile(local)):
-            destdir = self.system.path.dirname(self.system.path.realpath(local))
+        if (
+            isinstance(local, str)
+            and self.system.path.isfile(local)
+            and self.system.is_tarfile(local)
+        ):
+            destdir = self.system.path.dirname(
+                self.system.path.realpath(local)
+            )
             try:
                 self.system.smartuntar(local, destdir)
             except ExecutionError:
                 if not self.system.is_tarname(local):
-                    logger.warning("An automatic untar was attempted but it failed. " +
-                                   "Maybe the system's is_tarfile got it wrong ?")
+                    logger.warning(
+                        "An automatic untar was attempted but it failed. "
+                        + "Maybe the system's is_tarfile got it wrong ?"
+                    )
                 else:
                     raise
 
@@ -251,10 +264,12 @@ class Finder(Store):
     def fileget(self, remote, local, options):
         """Delegates to ``system`` the copy of ``remote`` to ``local``."""
         rpath = self.fullpath(remote)
-        logger.info('fileget on %s (to: %s)', rpath, local)
-        if 'intent' in options and options['intent'] == dataflow.intent.IN:
-            logger.info('Ignore intent <in> for remote input %s', rpath)
-        rc = self.system.cp(rpath, local, fmt=options.get('fmt'), intent=dataflow.intent.INOUT)
+        logger.info("fileget on %s (to: %s)", rpath, local)
+        if "intent" in options and options["intent"] == dataflow.intent.IN:
+            logger.info("Ignore intent <in> for remote input %s", rpath)
+        rc = self.system.cp(
+            rpath, local, fmt=options.get("fmt"), intent=dataflow.intent.INOUT
+        )
         rc = rc and self._hash_get_check(self.fileget, remote, local, options)
         if rc:
             self._localtarfix(local)
@@ -263,8 +278,8 @@ class Finder(Store):
     def fileput(self, local, remote, options):
         """Delegates to ``system`` the copy of ``local`` to ``remote``."""
         rpath = self.fullpath(remote)
-        logger.info('fileput to %s (from: %s)', rpath, local)
-        rc = self.system.cp(local, rpath, fmt=options.get('fmt'))
+        logger.info("fileput to %s (from: %s)", rpath, local)
+        rc = self.system.cp(local, rpath, fmt=options.get("fmt"))
         return rc and self._hash_put(self.fileput, local, remote, options)
 
     def filedelete(self, remote, options):
@@ -272,10 +287,13 @@ class Finder(Store):
         rc = None
         if self.filecheck(remote, options):
             rpath = self.fullpath(remote)
-            logger.info('filedelete on %s', rpath)
-            rc = self.system.remove(rpath, fmt=options.get('fmt'))
+            logger.info("filedelete on %s", rpath)
+            rc = self.system.remove(rpath, fmt=options.get("fmt"))
         else:
-            logger.error('Try to remove a non-existing resource <%s>', self.fullpath(remote))
+            logger.error(
+                "Try to remove a non-existing resource <%s>",
+                self.fullpath(remote),
+            )
         return rc
 
     symlinkcheck = filecheck
@@ -283,34 +301,40 @@ class Finder(Store):
 
     def symlinkget(self, remote, local, options):
         rpath = self.fullpath(remote)
-        if 'intent' in options and options['intent'] == dataflow.intent.INOUT:
-            logger.error('It is unsafe to have a symlink with intent=inout: %s', rpath)
+        if "intent" in options and options["intent"] == dataflow.intent.INOUT:
+            logger.error(
+                "It is unsafe to have a symlink with intent=inout: %s", rpath
+            )
             return False
         rc = self.system.remove(local)
         self.system.symlink(rpath, local)
         return rc and self.system.path.exists(local)
 
     def symlinkput(self, local, remote, options):
-        logger.error("The Finder store with scheme:symlink is not able to perform Puts.")
+        logger.error(
+            "The Finder store with scheme:symlink is not able to perform Puts."
+        )
         return False
 
     def symlinkdelete(self, remote, options):
-        logger.error("The Finder store with scheme:symlink is not able to perform Deletes.")
+        logger.error(
+            "The Finder store with scheme:symlink is not able to perform Deletes."
+        )
         return False
 
     def _ftpinfos(self, remote, **kwargs):
         args = kwargs.copy()
-        args['hostname'] = self.hostname()
-        args['logname'] = remote['username']
+        args["hostname"] = self.hostname()
+        args["logname"] = remote["username"]
         port = self.hostname().netport
         if port is not None:
-            args['port'] = port
+            args["port"] = port
         return args
 
     def ftpcheck(self, remote, options):
         """Delegates to ``system.ftp`` a distant check."""
         rc = None
-        ftp = self.system.ftp(** self._ftpinfos(remote))
+        ftp = self.system.ftp(**self._ftpinfos(remote))
         if ftp:
             try:
                 rc = ftp.size(self.fullpath(remote))
@@ -324,7 +348,7 @@ class Finder(Store):
 
     def ftplocate(self, remote, options):
         """Delegates to ``system`` qualified name creation."""
-        ftp = self.system.ftp(** self._ftpinfos(remote, delayed=True))
+        ftp = self.system.ftp(**self._ftpinfos(remote, delayed=True))
         if ftp:
             rloc = ftp.netpath(self.fullpath(remote))
             ftp.close()
@@ -335,13 +359,15 @@ class Finder(Store):
     def ftpget(self, remote, local, options):
         """Delegates to ``system`` the file transfer of ``remote`` to ``local``."""
         rpath = self.fullpath(remote)
-        logger.info('ftpget on ftp://%s/%s (to: %s)', self.hostname(), rpath, local)
+        logger.info(
+            "ftpget on ftp://%s/%s (to: %s)", self.hostname(), rpath, local
+        )
         rc = self.system.smartftget(
             rpath,
             local,
-            fmt=options.get('fmt'),
+            fmt=options.get("fmt"),
             # ftp control
-            ** self._ftpinfos(remote)
+            **self._ftpinfos(remote),
         )
         rc = rc and self._hash_get_check(self.ftpget, remote, local, options)
         if rc:
@@ -352,14 +378,16 @@ class Finder(Store):
         """Delegates to ``system`` the file transfer of ``local`` to ``remote``."""
         rpath = self.fullpath(remote)
         put_opts = dict()
-        put_opts['fmt'] = options.get('fmt')
-        put_opts['sync'] = options.get('enforcesync', False)
-        logger.info('ftpput to ftp://%s/%s (from: %s)', self.hostname(), rpath, local)
+        put_opts["fmt"] = options.get("fmt")
+        put_opts["sync"] = options.get("enforcesync", False)
+        logger.info(
+            "ftpput to ftp://%s/%s (from: %s)", self.hostname(), rpath, local
+        )
         rc = self.system.smartftput(
             local,
             rpath,
             # ftp control
-            ** self._ftpinfos(remote, ** put_opts)
+            **self._ftpinfos(remote, **put_opts),
         )
         return rc and self._hash_put(self.ftpput, local, remote, options)
 
@@ -368,7 +396,9 @@ class Finder(Store):
         rc = None
         actualpath = self.fullpath(remote)
         if self.ftpcheck(remote, options):
-            logger.info('ftpdelete on ftp://%s/%s', self.hostname(), actualpath)
+            logger.info(
+                "ftpdelete on ftp://%s/%s", self.hostname(), actualpath
+            )
             ftp = self.system.ftp(**self._ftpinfos(remote))
             if ftp:
                 try:
@@ -376,14 +406,16 @@ class Finder(Store):
                 finally:
                     ftp.close()
         else:
-            logger.error('Try to remove a non-existing resource <%s>', actualpath)
+            logger.error(
+                "Try to remove a non-existing resource <%s>", actualpath
+            )
         return rc
 
 
 class _VortexStackedStorageMixin:
     """Mixin class that adds utility functions to work with stacked data."""
 
-    _STACKED_RE = re.compile('stacked-')
+    _STACKED_RE = re.compile("stacked-")
 
     @property
     def stackedstore(self):
@@ -391,25 +423,31 @@ class _VortexStackedStorageMixin:
         return self._STACKED_RE.search(self.netloc)
 
     def _stacked_remainder(self, remote, stackpath):
-        path_remainder = remote['path'].strip('/').split('/')
-        for a_spath in stackpath.split('/'):
+        path_remainder = remote["path"].strip("/").split("/")
+        for a_spath in stackpath.split("/"):
             if path_remainder and path_remainder[0] == a_spath:
                 del path_remainder[0]
             else:
                 break
-        return '/'.join(path_remainder)
+        return "/".join(path_remainder)
 
     def _stacked_xremote(self, remote):
         """The path to **remote** with its stack."""
         if self.stackedstore:
             remote = remote.copy()
-            remote['query'] = remote['query'].copy()
-            stackpath = remote['query'].pop('stackpath', (None, ))[0]
-            stackfmt = remote['query'].pop('stackfmt', (None, ))[0]
+            remote["query"] = remote["query"].copy()
+            stackpath = remote["query"].pop("stackpath", (None,))[0]
+            stackfmt = remote["query"].pop("stackfmt", (None,))[0]
             if stackpath is None or stackfmt is None:
-                raise ValueError('"stackpath" and "stackfmt" are not available in the query.')
+                raise ValueError(
+                    '"stackpath" and "stackfmt" are not available in the query.'
+                )
             else:
-                remote['path'] = stackpath + '/' + self._stacked_remainder(remote, stackpath)
+                remote["path"] = (
+                    stackpath
+                    + "/"
+                    + self._stacked_remainder(remote, stackpath)
+                )
         return remote
 
     def _stacked_xegglocate(self, remote):
@@ -423,14 +461,16 @@ class _VortexStackedStorageMixin:
 
         """
         remote = remote.copy()
-        remote['query'] = remote['query'].copy()
-        stackpath = remote['query'].pop('stackpath', (None, ))[0].strip('/')
-        stackfmt = remote['query'].pop('stackfmt', (None, ))[0]
+        remote["query"] = remote["query"].copy()
+        stackpath = remote["query"].pop("stackpath", (None,))[0].strip("/")
+        stackfmt = remote["query"].pop("stackfmt", (None,))[0]
         if stackpath is None or stackfmt is None:
-            raise ValueError('"stackpath" and "stackfmt" are not available in the query.')
+            raise ValueError(
+                '"stackpath" and "stackfmt" are not available in the query.'
+            )
         else:
             resource_remainder = self._stacked_remainder(remote, stackpath)
-            remote['path'] = '/' + stackpath
+            remote["path"] = "/" + stackpath
         return remote, stackfmt, resource_remainder
 
 
@@ -438,11 +478,13 @@ _vortex_readonly_store = footprints.Footprint(
     info="Abstract store' readonly=True attribute",
     attr=dict(
         readonly=dict(
-            values=[True, ],
+            values=[
+                True,
+            ],
             optional=True,
-            default=True
+            default=True,
         )
-    )
+    ),
 )
 
 
@@ -451,25 +493,24 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
 
     _abstract = True
     _footprint = dict(
-        info = 'VORTEX archive access',
-        attr = dict(
-            scheme = dict(
-                values   = ['vortex'],
+        info="VORTEX archive access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            netloc = dict(
+            netloc=dict(),
+            storehead=dict(
+                optional=True,
+                default="vortex",
+                outcast=["xp"],
             ),
-            storehead = dict(
-                optional = True,
-                default  = 'vortex',
-                outcast  = ['xp'],
-            ),
-        )
+        ),
     )
 
-    _STACKS_AUTOREFILL_CRIT = 'stacked-archive-smart'
+    _STACKS_AUTOREFILL_CRIT = "stacked-archive-smart"
 
     def __init__(self, *args, **kw):
-        logger.debug('Vortex archive store init %s', self.__class__)
+        logger.debug("Vortex archive store init %s", self.__class__)
         super().__init__(*args, **kw)
 
     def remap_read(self, remote, options):
@@ -478,10 +519,12 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
 
     def remap_list(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""
-        if len(remote['path'].split('/')) >= 4:
+        if len(remote["path"].split("/")) >= 4:
             return self.remap_read(remote, options)
         else:
-            logger.critical('The << %s >> path is not listable.', remote['path'])
+            logger.critical(
+                "The << %s >> path is not listable.", remote["path"]
+            )
             return None
 
     remap_write = remap_read
@@ -490,7 +533,7 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
     def stacks_autorefill(self):
         """Where to refill a stack retrieved from the archive."""
         if self._STACKS_AUTOREFILL_CRIT in self.netloc:
-            return self.netloc.replace(self._STACKS_AUTOREFILL_CRIT, 'cache')
+            return self.netloc.replace(self._STACKS_AUTOREFILL_CRIT, "cache")
         else:
             return None
 
@@ -500,24 +543,34 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         rundir = sessions.current().context.rundir
         if not rundir:
             rundir = self.system.pwd()
-        rundir = self.system.path.join(rundir, 'vortex_stacks_xeggs')
-        target = self.system.path.join(rundir, * remote['path'].strip('/').split('/'))
+        rundir = self.system.path.join(rundir, "vortex_stacks_xeggs")
+        target = self.system.path.join(
+            rundir, *remote["path"].strip("/").split("/")
+        )
         targetopts = dict(fmt=remotefmt, intent=dataflow.intent.IN)
         if self.system.path.exists(target):
-            logger.info("Stack previously retrieved (in %s). Using it.", target)
+            logger.info(
+                "Stack previously retrieved (in %s). Using it.", target
+            )
             rc = True
         else:
             if result_id:
-                rc = self._vortexfinaliseget(result_id, remote, target, targetopts)
+                rc = self._vortexfinaliseget(
+                    result_id, remote, target, targetopts
+                )
             else:
                 rc = self._vortexget(remote, target, targetopts)
         if rc and self.stacks_autorefill:
-            rstore = footprints.proxy.store(scheme=self.scheme, netloc=self.stacks_autorefill)
+            rstore = footprints.proxy.store(
+                scheme=self.scheme, netloc=self.stacks_autorefill
+            )
             logger.info("Refilling the stack egg to [%s]", rstore)
             try:
                 rstore.put(target, remote.copy(), targetopts)
             except (ExecutionError, OSError) as e:
-                logger.error("An ExecutionError happened during the refill: %s", str(e))
+                logger.error(
+                    "An ExecutionError happened during the refill: %s", str(e)
+                )
                 logger.error("This error is ignored... but that's ugly !")
         return rc, target, remainder
 
@@ -526,11 +579,15 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         if self.stackedstore:
             s_remote, s_remotefmt, _ = self._stacked_xegglocate(remote)
             options = options.copy()
-            options['fmt'] = s_remotefmt
+            options["fmt"] = s_remotefmt
             rc = self._vortexcheck(s_remote, options)
             if rc:
-                rc, target, remainder = self._vortex_stacked_egg_retrieve(remote)
-                rc = rc and self.system.path.exists(self.system.path.join(target, remainder))
+                rc, target, remainder = self._vortex_stacked_egg_retrieve(
+                    remote
+                )
+                rc = rc and self.system.path.exists(
+                    self.system.path.join(target, remainder)
+                )
             return rc
         else:
             return self._vortexcheck(remote, options)
@@ -545,7 +602,7 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         if self.stackedstore:
             remote, s_remotefmt, _ = self._stacked_xegglocate(remote)
             options = options.copy()
-            options['fmt'] = s_remotefmt
+            options["fmt"] = s_remotefmt
         return self._vortexlocate(remote, options)
 
     def _vortexlocate(self, remote, options):
@@ -573,7 +630,7 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         if self.stackedstore:
             remote, s_remotefmt, _ = self._stacked_xegglocate(remote)
             options = options.copy()
-            options['fmt'] = s_remotefmt
+            options["fmt"] = s_remotefmt
         return self._vortexprestageinfo(remote, options)
 
     def _vortexprestageinfo(self, remote, options):
@@ -585,10 +642,12 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         """Vortex' archive get sequence."""
         if self.stackedstore:
             rc, target, remainder = self._vortex_stacked_egg_retrieve(remote)
-            rc = rc and self.system.cp(self.system.path.join(target, remainder), local,
-                                       fmt=options.get('fmt'),
-                                       intent=options.get('intent',
-                                                          ARCHIVE_GET_INTENT_DEFAULT))
+            rc = rc and self.system.cp(
+                self.system.path.join(target, remainder),
+                local,
+                fmt=options.get("fmt"),
+                intent=options.get("intent", ARCHIVE_GET_INTENT_DEFAULT),
+            )
             return rc
         else:
             return self._vortexget(remote, local, options)
@@ -603,7 +662,7 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         if self.stackedstore:
             s_remote, s_remotefmt, _ = self._stacked_xegglocate(remote)
             targetopts = dict(fmt=s_remotefmt, intent=dataflow.intent.IN)
-            return self._vortexearlyget(s_remote, 'somelocalfile', targetopts)
+            return self._vortexearlyget(s_remote, "somelocalfile", targetopts)
         else:
             return self._vortexearlyget(remote, local, options)
 
@@ -615,11 +674,15 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
     def vortexfinaliseget(self, result_id, remote, local, options):
         """Vortex' archive finaliseget sequence."""
         if self.stackedstore:
-            rc, target, remainder = self._vortex_stacked_egg_retrieve(remote, result_id=result_id)
-            rc = rc and self.system.cp(self.system.path.join(target, remainder), local,
-                                       fmt=options.get('fmt'),
-                                       intent=options.get('intent',
-                                                          ARCHIVE_GET_INTENT_DEFAULT))
+            rc, target, remainder = self._vortex_stacked_egg_retrieve(
+                remote, result_id=result_id
+            )
+            rc = rc and self.system.cp(
+                self.system.path.join(target, remainder),
+                local,
+                fmt=options.get("fmt"),
+                intent=options.get("intent", ARCHIVE_GET_INTENT_DEFAULT),
+            )
             return rc
         else:
             return self._vortexfinaliseget(result_id, remote, local, options)
@@ -655,30 +718,31 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
     """
 
     _footprint = dict(
-        info = 'VORTEX archive access for casual experiments',
-        attr = dict(
-            netloc = dict(
-                values   = ['vortex.archive-legacy.fr'],
+        info="VORTEX archive access for casual experiments",
+        attr=dict(
+            netloc=dict(
+                values=["vortex.archive-legacy.fr"],
             ),
-        )
+        ),
     )
 
     @property
     def _actual_mappingroot(self):
         """Read the get entry point form configuration."""
         return config.from_config(
-            section="storage", key="rootdir",
+            section="storage",
+            key="rootdir",
         )
 
     def remap_read(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""
         remote = copy.copy(remote)
-        xpath = remote['path'].split('/')
+        xpath = remote["path"].split("/")
         actual_mappingroot = self._actual_mappingroot
         if not self.storeroot and actual_mappingroot:
-            remote['root'] = actual_mappingroot
+            remote["root"] = actual_mappingroot
             xpath[3:4] = list(xpath[3])
-        remote['path'] = self.system.path.join(*xpath)
+        remote["path"] = self.system.path.join(*xpath)
         return remote
 
 
@@ -693,17 +757,21 @@ class VortexStdStackedArchiveStore(VortexStdBaseArchiveStore):
     _footprint = [
         _vortex_readonly_store,
         dict(
-            attr = dict(
-                netloc = dict(
-                    values   = ['vortex.stacked-archive-legacy.fr',
-                                'vortex.stacked-archive-smart.fr'],
+            attr=dict(
+                netloc=dict(
+                    values=[
+                        "vortex.stacked-archive-legacy.fr",
+                        "vortex.stacked-archive-smart.fr",
+                    ],
                 ),
             )
-        )
+        ),
     ]
 
 
-class VortexFreeStdBaseArchiveStore(_VortexBaseArchiveStore, ConfigurableArchiveStore):
+class VortexFreeStdBaseArchiveStore(
+    _VortexBaseArchiveStore, ConfigurableArchiveStore
+):
     """Archive for casual VORTEX experiments: Support for Free XPIDs.
 
     This 'archive-legacy' store looks into the resource 'main' location not
@@ -711,27 +779,27 @@ class VortexFreeStdBaseArchiveStore(_VortexBaseArchiveStore, ConfigurableArchive
     """
 
     #: Path to the vortex-free Store configuration file
-    _store_global_config = '@store-vortex-free.ini'
-    _datastore_id = 'store-vortex-free-conf'
+    _store_global_config = "@store-vortex-free.ini"
+    _datastore_id = "store-vortex-free-conf"
 
     _footprint = dict(
-        info = 'VORTEX archive access for casual experiments',
-        attr = dict(
-            netloc = dict(
-                values   = ['vortex-free.archive-legacy.fr'],
+        info="VORTEX archive access for casual experiments",
+        attr=dict(
+            netloc=dict(
+                values=["vortex-free.archive-legacy.fr"],
             ),
-        )
+        ),
     )
 
     def remap_read(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""
         remote = copy.copy(remote)
-        xpath = remote['path'].strip('/').split('/')
+        xpath = remote["path"].strip("/").split("/")
         f_xpid = FreeXPid(xpath[2])
         xpath[2] = f_xpid.id
-        if 'root' not in remote:
-            remote['root'] = self._actual_storeroot(f_xpid)
-        remote['path'] = self.system.path.join(*xpath)
+        if "root" not in remote:
+            remote["root"] = self._actual_storeroot(f_xpid)
+        remote["path"] = self.system.path.join(*xpath)
         return remote
 
     remap_write = remap_read
@@ -748,13 +816,16 @@ class VortexFreeStdStackedArchiveStore(VortexFreeStdBaseArchiveStore):
     _footprint = [
         _vortex_readonly_store,
         dict(
-            attr = dict(
-                netloc = dict(
-                    values   = ['vortex-free.stacked-archive-legacy.fr',
-                                'vortex-free.stacked-archive-smart.fr'],
+            attr=dict(
+                netloc=dict(
+                    values=[
+                        "vortex-free.stacked-archive-legacy.fr",
+                        "vortex-free.stacked-archive-smart.fr",
+                    ],
                 ),
             )
-        )]
+        ),
+    ]
 
 
 class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
@@ -765,39 +836,37 @@ class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
     """
 
     _footprint = dict(
-        info = 'VORTEX archive access for op experiments',
-        attr = dict(
-            netloc = dict(
-                values   = ['vsop.archive-legacy.fr'],
+        info="VORTEX archive access for op experiments",
+        attr=dict(
+            netloc=dict(
+                values=["vsop.archive-legacy.fr"],
             ),
-            storetrue = dict(
-                default = DelayedEnvValue('op_archive', True),
+            storetrue=dict(
+                default=DelayedEnvValue("op_archive", True),
             ),
-        )
+        ),
     )
 
     @property
     def _actual_storeroot(self):
-        return (
-            self.storeroot or
-            config.from_config(
-                section="storage", key="op_rootdir",
-            )
+        return self.storeroot or config.from_config(
+            section="storage",
+            key="op_rootdir",
         )
 
     def remap_read(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""
         remote = copy.copy(remote)
-        xpath = remote['path'].split('/')
-        remote['root'] = self._actual_storeroot
-        if len(xpath) >= 5 and re.match(r'^\d{8}T\d{2,4}', xpath[4]):
+        xpath = remote["path"].split("/")
+        remote["root"] = self._actual_storeroot
+        if len(xpath) >= 5 and re.match(r"^\d{8}T\d{2,4}", xpath[4]):
             # If a date is detected
             vxdate = list(xpath[4])
-            vxdate.insert(4, '/')
-            vxdate.insert(7, '/')
-            vxdate.insert(10, '/')
-            xpath[4] = ''.join(vxdate)
-        remote['path'] = self.system.path.join(*xpath)
+            vxdate.insert(4, "/")
+            vxdate.insert(7, "/")
+            vxdate.insert(10, "/")
+            xpath[4] = "".join(vxdate)
+        remote["path"] = self.system.path.join(*xpath)
         return remote
 
     remap_write = remap_read
@@ -814,13 +883,16 @@ class VortexOpStackedArchiveStore(VortexOpBaseArchiveStore):
     _footprint = [
         _vortex_readonly_store,
         dict(
-            attr = dict(
-                netloc = dict(
-                    values   = ['vsop.stacked-archive-legacy.fr',
-                                'vsop.stacked-archive-smart.fr'],
+            attr=dict(
+                netloc=dict(
+                    values=[
+                        "vsop.stacked-archive-legacy.fr",
+                        "vsop.stacked-archive-smart.fr",
+                    ],
                 ),
             )
-        )]
+        ),
+    ]
 
 
 class VortexArchiveStore(MultiStore):
@@ -835,42 +907,58 @@ class VortexArchiveStore(MultiStore):
     """
 
     _footprint = dict(
-        info = 'VORTEX archive access',
-        attr = dict(
-            scheme = dict(
-                values  = ['vortex'],
+        info="VORTEX archive access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            netloc = dict(
-                values  = ['vortex.archive.fr', 'vortex-free.archive.fr', 'vsop.archive.fr'],
+            netloc=dict(
+                values=[
+                    "vortex.archive.fr",
+                    "vortex-free.archive.fr",
+                    "vsop.archive.fr",
+                ],
             ),
-            refillstore = dict(
-                default = False,
+            refillstore=dict(
+                default=False,
             ),
-            storehead = dict(
-                optional = True,
+            storehead=dict(
+                optional=True,
             ),
-            storesync = dict(
-                alias    = ('archsync', 'synchro'),
-                type     = bool,
-                optional = True,
+            storesync=dict(
+                alias=("archsync", "synchro"),
+                type=bool,
+                optional=True,
             ),
-        )
+        ),
     )
 
     def filtered_readable_openedstores(self, remote):
         """Only use the stacked store if sensible."""
-        ostores = [self.openedstores[0], ]
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if not sto.stackedstore or 'stackpath' in remote['query']
-                        ])
+        ostores = [
+            self.openedstores[0],
+        ]
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if not sto.stackedstore or "stackpath" in remote["query"]
+            ]
+        )
         return ostores
 
     def alternates_netloc(self):
         """Return netlocs describing both base and stacked archives."""
-        netloc_m = re.match(r'(?P<base>v.*)\.archive\.(?P<country>\w+)', self.netloc)
+        netloc_m = re.match(
+            r"(?P<base>v.*)\.archive\.(?P<country>\w+)", self.netloc
+        )
         return [
-            '{base:s}.archive-legacy.{country:s}'.format(** netloc_m.groupdict()),
-            '{base:s}.stacked-archive-legacy.{country:s}'.format(** netloc_m.groupdict()),
+            "{base:s}.archive-legacy.{country:s}".format(
+                **netloc_m.groupdict()
+            ),
+            "{base:s}.stacked-archive-legacy.{country:s}".format(
+                **netloc_m.groupdict()
+            ),
         ]
 
     def alternates_fpextras(self):
@@ -883,26 +971,28 @@ class _VortexCacheBaseStore(CacheStore, _VortexStackedStorageMixin):
 
     _abstract = True
     _footprint = dict(
-        info = 'VORTEX cache access',
-        attr = dict(
-            scheme = dict(
-                values  = ['vortex'],
+        info="VORTEX cache access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            headdir = dict(
-                default = "",
-                outcast = ['xp', ],
+            headdir=dict(
+                default="",
+                outcast=[
+                    "xp",
+                ],
             ),
-            rtouch = dict(
-                default = True,
+            rtouch=dict(
+                default=True,
             ),
-            rtouchskip = dict(
-                default = 3,
+            rtouchskip=dict(
+                default=3,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Vortex cache store init %s', self.__class__)
+        logger.debug("Vortex cache store init %s", self.__class__)
         del self.cache
         super().__init__(*args, **kw)
 
@@ -939,16 +1029,19 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
     """Some kind of MTOOL cache for VORTEX experiments."""
 
     _footprint = dict(
-        info = 'VORTEX MTOOL like Cache access',
-        attr = dict(
-            netloc = dict(
-                values  = ['{:s}.{:s}cache-mt.fr'.format(v, s)
-                           for v in ('vortex', 'vortex-free', 'vsop') for s in ('', 'stacked-')]
+        info="VORTEX MTOOL like Cache access",
+        attr=dict(
+            netloc=dict(
+                values=[
+                    "{:s}.{:s}cache-mt.fr".format(v, s)
+                    for v in ("vortex", "vortex-free", "vsop")
+                    for s in ("", "stacked-")
+                ]
             ),
-            strategy = dict(
-                default = 'mtool',
+            strategy=dict(
+                default="mtool",
             ),
-        )
+        ),
     )
 
 
@@ -957,21 +1050,21 @@ class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
     """The DSI/OP VORTEX cache where researchers can get the freshest data."""
 
     _footprint = dict(
-        info = 'VORTEX Mtool cache access',
-        attr = dict(
-            netloc = dict(
-                values  = [
-                    'vsop.{:s}cache-op2r.fr'.format(s)
-                    for s in ('', 'stacked-')
+        info="VORTEX Mtool cache access",
+        attr=dict(
+            netloc=dict(
+                values=[
+                    "vsop.{:s}cache-op2r.fr".format(s)
+                    for s in ("", "stacked-")
                 ],
             ),
-            strategy = dict(
-                default = 'op2r',
+            strategy=dict(
+                default="op2r",
             ),
-            readonly = dict(
-                default = True,
-            )
-        )
+            readonly=dict(
+                default=True,
+            ),
+        ),
     )
 
     @property
@@ -985,33 +1078,49 @@ class _AbstractVortexCacheMultiStore(MultiStore):
 
     _abstract = True
     _footprint = dict(
-        info = 'VORTEX cache access',
-        attr = dict(
-            scheme = dict(
-                values  = ['vortex'],
+        info="VORTEX cache access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            refillstore = dict(
-                default = False,
-            )
-        )
+            refillstore=dict(
+                default=False,
+            ),
+        ),
     )
 
     def filtered_readable_openedstores(self, remote):
         """Deals with stacked stores that are not always active."""
-        ostores = [self.openedstores[0], ]
+        ostores = [
+            self.openedstores[0],
+        ]
         # TODO is the call to cache.allow_reads still required without
         # marketplace stores?
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if ((not sto.stackedstore or 'stackpath' in remote['query']) and
-                            sto.cache.allow_reads(remote['path']))
-                        ])
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if (
+                    (not sto.stackedstore or "stackpath" in remote["query"])
+                    and sto.cache.allow_reads(remote["path"])
+                )
+            ]
+        )
         return ostores
 
     def filtered_writeable_openedstores(self, remote):
         """never writes into stack stores."""
-        ostores = [self.openedstores[0], ]
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if not sto.stackedstore and sto.cache.allow_writes(remote['path'])])
+        ostores = [
+            self.openedstores[0],
+        ]
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if not sto.stackedstore
+                and sto.cache.allow_writes(remote["path"])
+            ]
+        )
         return ostores
 
 
@@ -1019,18 +1128,27 @@ class VortexCacheStore(_AbstractVortexCacheMultiStore):
     """The go to store for data cached by VORTEX R&D experiments."""
 
     _footprint = dict(
-        attr = dict(
-            netloc = dict(
-                values  = ['vortex.cache.fr', 'vortex-free.cache.fr', ],
+        attr=dict(
+            netloc=dict(
+                values=[
+                    "vortex.cache.fr",
+                    "vortex-free.cache.fr",
+                ],
             ),
         )
     )
 
     def alternates_netloc(self):
         """For Non-Op users, Op caches may be accessed in read-only mode."""
-        netloc_m = re.match(r'(?P<base>vortex.*)\.cache\.(?P<country>\w+)', self.netloc)
-        mt_netloc = '{base:s}.cache-mt.{country:s}'.format(** netloc_m.groupdict())
-        s_mt_netloc = '{base:s}.stacked-cache-mt.{country:s}'.format(** netloc_m.groupdict())
+        netloc_m = re.match(
+            r"(?P<base>vortex.*)\.cache\.(?P<country>\w+)", self.netloc
+        )
+        mt_netloc = "{base:s}.cache-mt.{country:s}".format(
+            **netloc_m.groupdict()
+        )
+        s_mt_netloc = "{base:s}.stacked-cache-mt.{country:s}".format(
+            **netloc_m.groupdict()
+        )
         return [mt_netloc, s_mt_netloc]
 
 
@@ -1042,35 +1160,36 @@ class VortexVsopCacheStore(_AbstractVortexCacheMultiStore):
     """
 
     _footprint = dict(
-        info = 'VORTEX vsop magic cache access',
-        attr = dict(
-            netloc = dict(
-                values  = ['vsop.cache.fr', ],
+        info="VORTEX vsop magic cache access",
+        attr=dict(
+            netloc=dict(
+                values=[
+                    "vsop.cache.fr",
+                ],
             ),
-            glovekind = dict(
-                optional = True,
-                default = '[glove::realkind]',
+            glovekind=dict(
+                optional=True,
+                default="[glove::realkind]",
             ),
-        )
+        ),
     )
 
     def alternates_netloc(self):
         """For Non-Op users, Op caches may be accessed in read-only mode."""
         todo = [
-            'vsop.cache-mt.fr',
-            'vsop.stacked-cache-mt.fr',
+            "vsop.cache-mt.fr",
+            "vsop.stacked-cache-mt.fr",
         ]
 
         # Only set up op2r cache if the associated filepath
         # is configured
-        if (
-                (self.glovekind != 'opuser') and
-                config.is_defined(
-                    section="data-tree", key="op_rootdir",
-                )
+        if (self.glovekind != "opuser") and config.is_defined(
+            section="data-tree",
+            key="op_rootdir",
         ):
             todo += [
-                'vsop.cache-op2r.fr', 'vsop.stacked-cache-op2r.fr',
+                "vsop.cache-op2r.fr",
+                "vsop.stacked-cache-op2r.fr",
             ]
         return todo
 
@@ -1080,30 +1199,44 @@ class _AbstractVortexStackMultiStore(MultiStore):
 
     _abstract = True
     _footprint = dict(
-        info = 'VORTEX stack access',
-        attr = dict(
-            scheme = dict(
-                values  = ['vortex'],
+        info="VORTEX stack access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            refillstore = dict(
-                default = False,
-            )
-        )
+            refillstore=dict(
+                default=False,
+            ),
+        ),
     )
 
     # TODO is this still needed without marketplace stores?
     def filtered_readable_openedstores(self, remote):
         """Deals with marketplace stores that are not always active."""
-        ostores = [self.openedstores[0], ]
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if sto.cache.allow_reads(remote['path'])])
+        ostores = [
+            self.openedstores[0],
+        ]
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if sto.cache.allow_reads(remote["path"])
+            ]
+        )
         return ostores
 
     def filtered_writeable_openedstores(self, remote):
         """Deals with marketplace stores that are not always active."""
-        ostores = [self.openedstores[0], ]
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if sto.cache.allow_writes(remote['path'])])
+        ostores = [
+            self.openedstores[0],
+        ]
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if sto.cache.allow_writes(remote["path"])
+            ]
+        )
         return ostores
 
 
@@ -1111,18 +1244,22 @@ class VortexStackStore(_AbstractVortexStackMultiStore):
     """Store intended to read and write data into VORTEX R&D stacks."""
 
     _footprint = dict(
-        info = 'VORTEX stack access',
-        attr = dict(
-            netloc = dict(
-                values  = ['vortex.stack.fr', 'vortex-free.stack.fr'],
+        info="VORTEX stack access",
+        attr=dict(
+            netloc=dict(
+                values=["vortex.stack.fr", "vortex-free.stack.fr"],
             ),
-        )
+        ),
     )
 
     def alternates_netloc(self):
         """Go through the various stacked stores."""
-        netloc_m = re.match(r'(?P<base>vortex.*)\.stack\.(?P<country>\w+)', self.netloc)
-        s_mt_netloc = '{base:s}.stacked-cache-mt.{country:s}'.format(** netloc_m.groupdict())
+        netloc_m = re.match(
+            r"(?P<base>vortex.*)\.stack\.(?P<country>\w+)", self.netloc
+        )
+        s_mt_netloc = "{base:s}.stacked-cache-mt.{country:s}".format(
+            **netloc_m.groupdict()
+        )
         return [s_mt_netloc]
 
 
@@ -1130,22 +1267,24 @@ class VortexVsopStackStore(_AbstractVortexStackMultiStore):
     """Store intended to read and write data into VORTEX R&D stacks."""
 
     _footprint = dict(
-        info = 'VORTEX stack access',
-        attr = dict(
-            netloc = dict(
-                values  = ['vsop.stack.fr'],
+        info="VORTEX stack access",
+        attr=dict(
+            netloc=dict(
+                values=["vsop.stack.fr"],
             ),
-            glovekind = dict(
-                optional = True,
-                default = '[glove::realkind]',
+            glovekind=dict(
+                optional=True,
+                default="[glove::realkind]",
             ),
-        )
+        ),
     )
 
     def alternates_netloc(self):
         """For Non-Op users, Op caches may be accessed in read-only mode."""
-        todo = ['vsop.stacked-cache-mt.fr', ]
-        if self.glovekind != 'opuser':
+        todo = [
+            "vsop.stacked-cache-mt.fr",
+        ]
+        if self.glovekind != "opuser":
             todo.append("vsop.stacked-cache-op2r.fr")
         return todo
 
@@ -1157,24 +1296,30 @@ class VortexStoreLegacy(MultiStore):
     """
 
     _footprint = dict(
-        info='VORTEX multi access',
+        info="VORTEX multi access",
         attr=dict(
             scheme=dict(
-                values=['vortex'],
+                values=["vortex"],
             ),
             netloc=dict(
-                values=['vortex.multi-legacy.fr', 'vortex-free.multi-legacy.fr', 'vsop.multi-legacy.fr'],
+                values=[
+                    "vortex.multi-legacy.fr",
+                    "vortex-free.multi-legacy.fr",
+                    "vsop.multi-legacy.fr",
+                ],
             ),
             refillstore=dict(
                 default=True,
-            )
-        )
+            ),
+        ),
     )
 
     def alternates_netloc(self):
         """Tuple of alternates domains names, e.g. ``cache`` and ``archive``."""
-        return [self.netloc.firstname + d for d in ('.cache.fr',
-                                                    '.archive-legacy.fr')]
+        return [
+            self.netloc.firstname + d
+            for d in (".cache.fr", ".archive-legacy.fr")
+        ]
 
 
 class VortexStore(MultiStore):
@@ -1184,64 +1329,81 @@ class VortexStore(MultiStore):
     """
 
     _footprint = dict(
-        info = 'VORTEX multi access',
-        attr = dict(
-            scheme = dict(
-                values  = ['vortex'],
+        info="VORTEX multi access",
+        attr=dict(
+            scheme=dict(
+                values=["vortex"],
             ),
-            netloc = dict(
-                values  = ['vortex.multi.fr', 'vortex-free.multi.fr', 'vsop.multi.fr'],
+            netloc=dict(
+                values=[
+                    "vortex.multi.fr",
+                    "vortex-free.multi.fr",
+                    "vsop.multi.fr",
+                ],
             ),
-            refillstore = dict(
-                default = False
-            )
-        )
+            refillstore=dict(default=False),
+        ),
     )
 
     def filtered_readable_openedstores(self, remote):
         """Deals with stacked stores that are not always active."""
-        ostores = [self.openedstores[0], ]
-        ostores.extend([sto for sto in self.openedstores[1:]
-                        if not sto.stackedstore or 'stackpath' in remote['query']
-                        ])
+        ostores = [
+            self.openedstores[0],
+        ]
+        ostores.extend(
+            [
+                sto
+                for sto in self.openedstores[1:]
+                if not sto.stackedstore or "stackpath" in remote["query"]
+            ]
+        )
         return ostores
 
     def alternates_netloc(self):
         """Tuple of alternates domains names, e.g. ``cache`` and ``archive``."""
-        return [self.netloc.firstname + d for d in ('.multi-legacy.fr',
-                                                    '.stacked-archive-smart.fr',)]
+        return [
+            self.netloc.firstname + d
+            for d in (
+                ".multi-legacy.fr",
+                ".stacked-archive-smart.fr",
+            )
+        ]
 
 
 class PromiseCacheStore(VortexCacheMtStore):
     """Some kind of vortex cache for EXPECTED resources."""
 
     _footprint = dict(
-        info = 'EXPECTED cache access',
-        attr = dict(
-            netloc = dict(
-                values  = ['promise.cache.fr'],
+        info="EXPECTED cache access",
+        attr=dict(
+            netloc=dict(
+                values=["promise.cache.fr"],
             ),
-            headdir = dict(
-                default = 'promise',
-                outcast = ['xp', 'vortex'],
+            headdir=dict(
+                default="promise",
+                outcast=["xp", "vortex"],
             ),
-        )
+        ),
     )
 
     @staticmethod
     def _add_default_options(options):
         options_upd = options.copy()
-        options_upd['fmt'] = 'ascii'  # Promises are always JSON files
-        options_upd['intent'] = 'in'  # Promises are always read-only
+        options_upd["fmt"] = "ascii"  # Promises are always JSON files
+        options_upd["intent"] = "in"  # Promises are always read-only
         return options_upd
 
     def vortexget(self, remote, local, options):
         """Proxy to :meth:`incacheget`."""
-        return super().vortexget(remote, local, self._add_default_options(options))
+        return super().vortexget(
+            remote, local, self._add_default_options(options)
+        )
 
     def vortexput(self, local, remote, options):
         """Proxy to :meth:`incacheput`."""
-        return super().vortexput(local, remote, self._add_default_options(options))
+        return super().vortexput(
+            local, remote, self._add_default_options(options)
+        )
 
     def vortexdelete(self, remote, options):
         """Proxy to :meth:`incachedelete`."""
@@ -1252,20 +1414,24 @@ class VortexPromiseStore(PromiseStore):
     """Combine a Promise Store for expected resources and any VORTEX Store."""
 
     _footprint = dict(
-        info = 'VORTEX promise store',
-        attr = dict(
-            scheme = dict(
-                values  = ['xvortex'],
+        info="VORTEX promise store",
+        attr=dict(
+            scheme=dict(
+                values=["xvortex"],
             ),
             netloc=dict(
-                outcast = ['vortex-demo.cache.fr', 'vortex-demo.multi.fr',
-                           'vortex.testcache.fr', 'vortex.testmulti.fr'],
+                outcast=[
+                    "vortex-demo.cache.fr",
+                    "vortex-demo.multi.fr",
+                    "vortex.testcache.fr",
+                    "vortex.testmulti.fr",
+                ],
             ),
-        )
+        ),
     )
 
 
 # Activate the footprint's fasttrack on the stores collector
-fcollect = footprints.collectors.get(tag='store')
-fcollect.fasttrack = ('netloc', 'scheme')
+fcollect = footprints.collectors.get(tag="store")
+fcollect.fasttrack = ("netloc", "scheme")
 del fcollect

--- a/src/vortex/gloves.py
+++ b/src/vortex/gloves.py
@@ -18,45 +18,45 @@ class Glove(footprints.FootprintBase):
     """Base class for GLObal Versatile Environment."""
 
     _abstract = True
-    _collector = ('glove',)
+    _collector = ("glove",)
     _footprint = dict(
-        info = 'Abstract glove',
-        attr = dict(
-            email = dict(
-                alias    = ['address'],
-                optional = True,
-                default  = Environment(active=False)['email'],
-                access   = 'rwx',
+        info="Abstract glove",
+        attr=dict(
+            email=dict(
+                alias=["address"],
+                optional=True,
+                default=Environment(active=False)["email"],
+                access="rwx",
             ),
-            vapp = dict(
-                optional = True,
-                default  = 'play',
-                access   = 'rwx',
+            vapp=dict(
+                optional=True,
+                default="play",
+                access="rwx",
             ),
-            vconf = dict(
-                optional = True,
-                default  = 'sandbox',
-                access   = 'rwx',
+            vconf=dict(
+                optional=True,
+                default="sandbox",
+                access="rwx",
             ),
-            tag = dict(
-                optional = True,
-                default  = 'default',
+            tag=dict(
+                optional=True,
+                default="default",
             ),
-            user = dict(
-                alias    = ('logname', 'username'),
-                optional = True,
-                default  = Environment(active=False)['logname']
+            user=dict(
+                alias=("logname", "username"),
+                optional=True,
+                default=Environment(active=False)["logname"],
             ),
-            profile = dict(
-                alias    = ('kind', 'membership'),
-                values   = ['oper', 'dble', 'test', 'research', 'tourist'],
-                remap    = dict(tourist = 'research')
-            )
-        )
+            profile=dict(
+                alias=("kind", "membership"),
+                values=["oper", "dble", "test", "research", "tourist"],
+                remap=dict(tourist="research"),
+            ),
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Glove abstract %s init', self.__class__)
+        logger.debug("Glove abstract %s init", self.__class__)
         super().__init__(*args, **kw)
         self._rmdepthmin = 3
         self._siteroot = None
@@ -70,32 +70,32 @@ class Glove(footprints.FootprintBase):
     @property
     def realkind(self):
         """Returns the litteral string identity of the current glove."""
-        return 'glove'
+        return "glove"
 
     @property
     def configrc(self):
         """Returns the path of the default directory where ``.ini`` files are stored."""
-        return Environment(active=False).HOME + '/.vortexrc'
+        return Environment(active=False).HOME + "/.vortexrc"
 
     @property
     def siteroot(self):
         """Returns the path of the vortex install directory."""
         if not self._siteroot:
-            self._siteroot = '/'.join(__file__.split('/')[0:-3])
+            self._siteroot = "/".join(__file__.split("/")[0:-3])
         return self._siteroot
 
     @property
     def siteconf(self):
         """Returns the path of the default directory where ``.ini`` files are stored."""
         if not self._siteconf:
-            self._siteconf = '/'.join((self.siteroot, 'conf'))
+            self._siteconf = "/".join((self.siteroot, "conf"))
         return self._siteconf
 
     @property
     def sitedoc(self):
         """Returns the path of the default directory where ``.ini`` files are stored."""
         if not self._sitedoc:
-            self._sitedoc = '/'.join((self.siteroot, 'sphinx'))
+            self._sitedoc = "/".join((self.siteroot, "sphinx"))
         return self._sitedoc
 
     @property
@@ -103,8 +103,8 @@ class Glove(footprints.FootprintBase):
         """Returns the path of the default directory where ``.ini`` files are stored."""
         if not self._sitesrc:
             self._sitesrc = (
-                '/'.join((self.siteroot, 'site')),
-                '/'.join((self.siteroot, 'src'))
+                "/".join((self.siteroot, "site")),
+                "/".join((self.siteroot, "src")),
             )
         return self._sitesrc
 
@@ -120,8 +120,9 @@ class Glove(footprints.FootprintBase):
         """Refresh actual email with current username and provided ``domain``."""
         if domain is None:
             from vortex import sessions
+
             domain = sessions.system().getfqdn()
-        return '@'.join((self.user, domain))
+        return "@".join((self.user, domain))
 
     @property
     def xmail(self):
@@ -156,14 +157,16 @@ class Glove(footprints.FootprintBase):
             if self._ftduser:
                 return self._ftduser
             else:
-                return Environment.current().get('VORTEX_ARCHIVE_USER',
-                                                 self.user if defaults_to_user else None)
+                return Environment.current().get(
+                    "VORTEX_ARCHIVE_USER",
+                    self.user if defaults_to_user else None,
+                )
 
     def _get_default_fthost(self):
         if self._ftdhost:
             return self._ftdhost
         else:
-            return Environment.current().get('VORTEX_ARCHIVE_HOST', None)
+            return Environment.current().get("VORTEX_ARCHIVE_HOST", None)
 
     def _set_default_fthost(self, value):
         self._ftdhost = value
@@ -171,31 +174,57 @@ class Glove(footprints.FootprintBase):
     def _del_default_fthost(self):
         self._ftdhost = None
 
-    default_fthost = property(_get_default_fthost, _set_default_fthost, _del_default_fthost)
+    default_fthost = property(
+        _get_default_fthost, _set_default_fthost, _del_default_fthost
+    )
 
-    def describeftsettings(self, indent='+ '):
+    def describeftsettings(self, indent="+ "):
         """Returns a printable description of default file transfert usernames."""
         card = "\n".join(
-            ['{0}{3:48s} = {4:s}', ] +
-            ['{0}{1:48s} = {2:s}', ] +
-            (['{0}Host specific FT users:', ] if self._ftusers else []) +
-            ['{0}' + '  {:46s} = {:s}'.format(k, v) for k, v in self._ftusers.items() if v]
-        ).format(indent,
-                 'Default FT User', str(self._ftduser),
-                 'Default FT Host', str(self._ftdhost))
+            [
+                "{0}{3:48s} = {4:s}",
+            ]
+            + [
+                "{0}{1:48s} = {2:s}",
+            ]
+            + (
+                [
+                    "{0}Host specific FT users:",
+                ]
+                if self._ftusers
+                else []
+            )
+            + [
+                "{0}" + "  {:46s} = {:s}".format(k, v)
+                for k, v in self._ftusers.items()
+                if v
+            ]
+        ).format(
+            indent,
+            "Default FT User",
+            str(self._ftduser),
+            "Default FT Host",
+            str(self._ftdhost),
+        )
         return card
 
-    def idcard(self, indent='+ '):
+    def idcard(self, indent="+ "):
         """Returns a printable description of the current glove."""
-        card = "\n".join((
-            '{0}User     = {1:s}',
-            '{0}Profile  = {2!s}',
-            '{0}Vapp     = {3:s}',
-            '{0}Vconf    = {4:s}',
-            '{0}Configrc = {5:s}'
-        )).format(
+        card = "\n".join(
+            (
+                "{0}User     = {1:s}",
+                "{0}Profile  = {2!s}",
+                "{0}Vapp     = {3:s}",
+                "{0}Vconf    = {4:s}",
+                "{0}Configrc = {5:s}",
+            )
+        ).format(
             indent,
-            self.user, self.profile, self.vapp, self.vconf, self.configrc
+            self.user,
+            self.profile,
+            self.vapp,
+            self.vconf,
+            self.configrc,
         )
         return card
 
@@ -211,19 +240,19 @@ class ResearchGlove(Glove):
 
     _explicit = False
     _footprint = dict(
-        info = 'Research glove',
-        attr = dict(
-            profile = dict(
-                optional = True,
-                values   = ['research', 'tourist'],
-                default  = 'research',
+        info="Research glove",
+        attr=dict(
+            profile=dict(
+                optional=True,
+                values=["research", "tourist"],
+                default="research",
             )
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'research'
+        return "research"
 
 
 class OperGlove(Glove):
@@ -236,40 +265,38 @@ class OperGlove(Glove):
     """
 
     _footprint = dict(
-        info = 'Operational glove',
-        attr = dict(
-            user = dict(
-                values   = ['mxpt001']
+        info="Operational glove",
+        attr=dict(
+            user=dict(values=["mxpt001"]),
+            profile=dict(
+                optional=False,
+                values=["oper", "dble", "test", "miroir"],
             ),
-            profile = dict(
-                optional = False,
-                values   = ['oper', 'dble', 'test', 'miroir'],
-            )
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'opuser'
+        return "opuser"
 
 
 class UnitTestGlove(ResearchGlove):
     """A very special glove for unit-tests."""
 
     _footprint = dict(
-        info = 'Unit-Test Glove',
-        attr = dict(
-            profile = dict(
-                optional = False,
-                values   = ['utest'],
+        info="Unit-Test Glove",
+        attr=dict(
+            profile=dict(
+                optional=False,
+                values=["utest"],
             ),
-            test_configrc = dict(
-                optional = False,
+            test_configrc=dict(
+                optional=False,
             ),
-            test_siteroot = dict(
-                optional = False,
+            test_siteroot=dict(
+                optional=False,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):

--- a/src/vortex/layout/__init__.py
+++ b/src/vortex/layout/__init__.py
@@ -24,4 +24,4 @@ It also provides modules that allows to create "standard" VORTEX's jobs:
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'Package that helps organising a VORTEX session.'
+__tocinfoline__ = "Package that helps organising a VORTEX session."

--- a/src/vortex/layout/appconf.py
+++ b/src/vortex/layout/appconf.py
@@ -37,8 +37,10 @@ class ConfigSet(collections.abc.MutableMapping):
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
-        self.__dict__['_internal'] = dict()
-        self.__dict__['_confdecoder'] = AppConfigStringDecoder(substitution_cb=self._internal.get)
+        self.__dict__["_internal"] = dict()
+        self.__dict__["_confdecoder"] = AppConfigStringDecoder(
+            substitution_cb=self._internal.get
+        )
 
     @staticmethod
     def _remap_key(key):
@@ -54,25 +56,34 @@ class ConfigSet(collections.abc.MutableMapping):
     def __setitem__(self, key, value):
         if value is not None and isinstance(value, str):
             # Support for old style dictionaries (compatibility)
-            if (key.endswith('_map') and not re.match(r'^dict\(.*\)$', value) and
-                    not re.match(r'^\w+\(dict\(.*\)\)$', value)):
+            if (
+                key.endswith("_map")
+                and not re.match(r"^dict\(.*\)$", value)
+                and not re.match(r"^\w+\(dict\(.*\)\)$", value)
+            ):
                 key = key[:-4]
-                if re.match(r'^\w+\(.*\)$', value):
-                    value = re.sub(r'^(\w+)\((.*)\)$', r'\1(dict(\2))', value)
+                if re.match(r"^\w+\(.*\)$", value):
+                    value = re.sub(r"^(\w+)\((.*)\)$", r"\1(dict(\2))", value)
                 else:
-                    value = 'dict(' + value + ')'
+                    value = "dict(" + value + ")"
             # Support for geometries (compatibility)
-            if (('geometry' in key or 'geometries' in key) and
-                    (not re.match(r'^geometry\(.*\)$', value, flags=re.IGNORECASE))):
-                value = 'geometry(' + value + ')'
+            if ("geometry" in key or "geometries" in key) and (
+                not re.match(r"^geometry\(.*\)$", value, flags=re.IGNORECASE)
+            ):
+                value = "geometry(" + value + ")"
             # Support for oldstyle range (compatibility)
-            if (key.endswith('_range') and not re.match(r'^rangex\(.*\)$', value) and
-                    not re.match(r'^\w+\(rangex\(.*\)\)$', value)):
+            if (
+                key.endswith("_range")
+                and not re.match(r"^rangex\(.*\)$", value)
+                and not re.match(r"^\w+\(rangex\(.*\)\)$", value)
+            ):
                 key = key[:-6]
-                if re.match(r'^\w+\(.*\)$', value):
-                    value = re.sub(r'^(\w+)\((.*)\)$', r'\1(rangex(\2))', value)
+                if re.match(r"^\w+\(.*\)$", value):
+                    value = re.sub(
+                        r"^(\w+)\((.*)\)$", r"\1(rangex(\2))", value
+                    )
                 else:
-                    value = 'rangex(' + value + ')'
+                    value = "rangex(" + value + ")"
         self._internal[self._remap_key(key)] = value
 
     def __delitem__(self, key):
@@ -92,7 +103,7 @@ class ConfigSet(collections.abc.MutableMapping):
         if key in self:
             return self[key]
         else:
-            raise AttributeError('No such parameter <' + key + '>')
+            raise AttributeError("No such parameter <" + key + ">")
 
     def __setattr__(self, attr, value):
         self[attr] = value
@@ -101,7 +112,7 @@ class ConfigSet(collections.abc.MutableMapping):
         if key in self:
             del self[key]
         else:
-            raise AttributeError('No such parameter <' + key + '>')
+            raise AttributeError("No such parameter <" + key + ">")
 
     def copy(self):
         newobj = self.__class__()

--- a/src/vortex/layout/contexts.py
+++ b/src/vortex/layout/contexts.py
@@ -18,10 +18,10 @@ __all__ = []
 
 logger = loggers.getLogger(__name__)
 
-_RHANDLERS_OBSBOARD = 'Resources-Handlers'
-_STORES_OBSBOARD = 'Stores-Activity'
+_RHANDLERS_OBSBOARD = "Resources-Handlers"
+_STORES_OBSBOARD = "Stores-Activity"
 
-_PRESTAGE_REQ_ACTION = 'prestage_req'
+_PRESTAGE_REQ_ACTION = "prestage_req"
 
 
 # Module Interface
@@ -105,14 +105,14 @@ class ContextObserverRecorder(observer.Observer):
 
     def updobsitem(self, item, info):
         if (self._binded_context is not None) and self._binded_context.active:
-            logger.debug('Recording upd item %s', item)
-            if info['observerboard'] == _RHANDLERS_OBSBOARD:
+            logger.debug("Recording upd item %s", item)
+            if info["observerboard"] == _RHANDLERS_OBSBOARD:
                 processed_item = item.as_dict()
                 self._stages_recorder.append((processed_item, info))
                 self._tracker_recorder.update_rh(item, info)
-            elif info['observerboard'] == _STORES_OBSBOARD:
+            elif info["observerboard"] == _STORES_OBSBOARD:
                 self._tracker_recorder.update_store(item, info)
-                if info['action'] == _PRESTAGE_REQ_ACTION:
+                if info["action"] == _PRESTAGE_REQ_ACTION:
                     self._prestaging_recorder.append(info)
 
     def replay_in(self, context):
@@ -122,24 +122,33 @@ class ContextObserverRecorder(observer.Observer):
         """
         # First the stages of the sequence
         if self._stages_recorder:
-            logger.info('The recorder is replaying stages for context <%s>', context.tag)
-            for (pr_item, info) in self._stages_recorder:
+            logger.info(
+                "The recorder is replaying stages for context <%s>",
+                context.tag,
+            )
+            for pr_item, info in self._stages_recorder:
                 rh_stack = set()
                 for section in context.sequence.fastsearch(pr_item):
                     if section.rh.as_dict() == pr_item:
                         context.sequence.section_updstage(section, info)
                         rh_stack.add(section.rh)
                 for rh in rh_stack:
-                    rh.external_stage_update(info.get('stage'))
+                    rh.external_stage_update(info.get("stage"))
         # Then the localtracker
         if self._tracker_recorder is not None:
-            logger.info('The recorder is updating the LocalTracker for context <%s>', context.tag)
+            logger.info(
+                "The recorder is updating the LocalTracker for context <%s>",
+                context.tag,
+            )
             context.localtracker.append(self._tracker_recorder)
         # Finally the prestaging requests
         if self._prestaging_recorder:
-            logger.info('The recorder is replaying prestaging requests for context <%s>', context.tag)
+            logger.info(
+                "The recorder is replaying prestaging requests for context <%s>",
+                context.tag,
+            )
             for info in self._prestaging_recorder:
-                context.prestaging_hub(** info)
+                context.prestaging_hub(**info)
 
 
 class DiffHistory(PrivateHistory):
@@ -147,11 +156,17 @@ class DiffHistory(PrivateHistory):
 
     def append_record(self, rc, localcontainer, remotehandler):
         """Adds a new diff record in the current DiffHistory."""
-        rcmap = {True: 'PASS', False: 'FAIL'}
-        containerstr = (str(localcontainer) if localcontainer.is_virtual()
-                        else localcontainer.localpath())
-        self.append('{:s}: {:s} (Ref: {!s})'.format(rcmap[bool(rc)], containerstr,
-                                                    remotehandler.provider))
+        rcmap = {True: "PASS", False: "FAIL"}
+        containerstr = (
+            str(localcontainer)
+            if localcontainer.is_virtual()
+            else localcontainer.localpath()
+        )
+        self.append(
+            "{:s}: {:s} (Ref: {!s})".format(
+                rcmap[bool(rc)], containerstr, remotehandler.provider
+            )
+        )
 
     def datastore_inplace_overwrite(self, other):
         """Used by a DataStore object to refill a DiffHistory."""
@@ -163,23 +178,26 @@ class DiffHistory(PrivateHistory):
 class Context(getbytag.GetByTag, observer.Observer):
     """Physical layout of a session or task, etc."""
 
-    _tag_default = 'ctx'
+    _tag_default = "ctx"
 
-    def __init__(self, path=None, topenv=None, sequence=None, localtracker=None):
+    def __init__(
+        self, path=None, topenv=None, sequence=None, localtracker=None
+    ):
         """Initiate a new execution context."""
-        logger.debug('Context initialisation %s', self)
+        logger.debug("Context initialisation %s", self)
         if path is None:
-            logger.critical('Try to define a new context without virtual path')
-            raise ValueError('No virtual path given to new context.')
+            logger.critical("Try to define a new context without virtual path")
+            raise ValueError("No virtual path given to new context.")
         if topenv is None:
-            logger.critical('Try to define a new context without a topenv.')
-            raise ValueError('No top environment given to new context.')
-        self._env = Environment(env=topenv, verbose=topenv.verbose(),
-                                contextlock=self)
-        self._path = path + '/' + self.tag
+            logger.critical("Try to define a new context without a topenv.")
+            raise ValueError("No top environment given to new context.")
+        self._env = Environment(
+            env=topenv, verbose=topenv.verbose(), contextlock=self
+        )
+        self._path = path + "/" + self.tag
         self._session = None
         self._rundir = None
-        self._stamp = '-'.join(('vortex', 'stamp', self.tag, str(id(self))))
+        self._stamp = "-".join(("vortex", "stamp", self.tag, str(id(self))))
         self._fstore = dict()
         self._fstamps = set()
         self._wkdir = None
@@ -196,22 +214,30 @@ class Context(getbytag.GetByTag, observer.Observer):
             self._localtracker = localtracker
         else:
             # Create the localtracker within the Session's datastore
-            if self.session.datastore.check('context_localtracker', dict(path=self.path)):
-                self._localtracker = self.session.datastore.get('context_localtracker',
-                                                                dict(path=self.path))
+            if self.session.datastore.check(
+                "context_localtracker", dict(path=self.path)
+            ):
+                self._localtracker = self.session.datastore.get(
+                    "context_localtracker", dict(path=self.path)
+                )
             else:
-                self._localtracker = self.session.datastore.insert('context_localtracker',
-                                                                   dict(path=self.path),
-                                                                   dataflow.LocalTracker())
+                self._localtracker = self.session.datastore.insert(
+                    "context_localtracker",
+                    dict(path=self.path),
+                    dataflow.LocalTracker(),
+                )
 
         # Create the localtracker within the Session's datastore
-        if self.session.datastore.check('context_diffhistory', dict(path=self.path)):
-            self._dhistory = self.session.datastore.get('context_diffhistory',
-                                                        dict(path=self.path))
+        if self.session.datastore.check(
+            "context_diffhistory", dict(path=self.path)
+        ):
+            self._dhistory = self.session.datastore.get(
+                "context_diffhistory", dict(path=self.path)
+            )
         else:
-            self._dhistory = self.session.datastore.insert('context_diffhistory',
-                                                           dict(path=self.path),
-                                                           DiffHistory())
+            self._dhistory = self.session.datastore.insert(
+                "context_diffhistory", dict(path=self.path), DiffHistory()
+            )
 
         observer.get(tag=_RHANDLERS_OBSBOARD).register(self)
         observer.get(tag=_STORES_OBSBOARD).register(self)
@@ -223,7 +249,9 @@ class Context(getbytag.GetByTag, observer.Observer):
 
     def _enforce_active(self):
         if not self.active:
-            raise RuntimeError("It's not allowed to call this method on an inactive Context.")
+            raise RuntimeError(
+                "It's not allowed to call this method on an inactive Context."
+            )
 
     def newobsitem(self, item, info):
         """
@@ -231,9 +259,14 @@ class Context(getbytag.GetByTag, observer.Observer):
         Register a new section in void active context with the resource handler ``item``.
         """
         if self.active:
-            logger.debug('Notified %s new item of class %s and id %s', self, item.__class__, id(item))
-            if self._record and info['observerboard'] == _RHANDLERS_OBSBOARD:
-                self._sequence.section(rh=item, stage='load')
+            logger.debug(
+                "Notified %s new item of class %s and id %s",
+                self,
+                item.__class__,
+                id(item),
+            )
+            if self._record and info["observerboard"] == _RHANDLERS_OBSBOARD:
+                self._sequence.section(rh=item, stage="load")
 
     def updobsitem(self, item, info):
         """
@@ -241,21 +274,21 @@ class Context(getbytag.GetByTag, observer.Observer):
         Track the new stage of the section containing the resource handler ``item``.
         """
         if self.active:
-            logger.debug('Notified %s upd item %s', self, item)
-            if info['observerboard'] == _RHANDLERS_OBSBOARD:
-                if 'stage' in info:
+            logger.debug("Notified %s upd item %s", self, item)
+            if info["observerboard"] == _RHANDLERS_OBSBOARD:
+                if "stage" in info:
                     # Update the sequence
                     for section in self._sequence.fastsearch(item):
                         if section.rh is item:
                             self._sequence.section_updstage(section, info)
-                if ('stage' in info) or ('clear' in info):
+                if ("stage" in info) or ("clear" in info):
                     # Update the local tracker
                     self._localtracker.update_rh(item, info)
-            elif info['observerboard'] == _STORES_OBSBOARD:
+            elif info["observerboard"] == _STORES_OBSBOARD:
                 # Update the local tracker
                 self._localtracker.update_store(item, info)
-                if info['action'] == _PRESTAGE_REQ_ACTION:
-                    self.prestaging_hub.record(** info)
+                if info["action"] == _PRESTAGE_REQ_ACTION:
+                    self.prestaging_hub.record(**info)
 
     def get_recorder(self):
         """Return a :obj:`ContextObserverRecorder` object recording the changes in this Context."""
@@ -275,7 +308,9 @@ class Context(getbytag.GetByTag, observer.Observer):
         # It's not possible to activate a Context that lies outside the current
         # session
         if not self.session.active:
-            raise RuntimeError("It's not allowed to switch to a Context that belongs to an inactive session")
+            raise RuntimeError(
+                "It's not allowed to switch to a Context that belongs to an inactive session"
+            )
 
     def focus_gain_hook(self):
         super().focus_gain_hook()
@@ -297,7 +332,7 @@ class Context(getbytag.GetByTag, observer.Observer):
             obj.catch_focus()
             return obj
         else:
-            logger.error('Try to switch to an undefined context: %s', tag)
+            logger.error("Try to switch to an undefined context: %s", tag)
             return None
 
     def activate(self):
@@ -314,7 +349,10 @@ class Context(getbytag.GetByTag, observer.Observer):
         """Return the session bound to the current virtual context path."""
         if self._session is None:
             from vortex import sessions
-            self._session = sessions.get(tag=[x for x in self.path.split('/') if x][0])
+
+            self._session = sessions.get(
+                tag=[x for x in self.path.split("/") if x][0]
+            )
         return self._session
 
     def _get_rundir(self):
@@ -324,12 +362,20 @@ class Context(getbytag.GetByTag, observer.Observer):
     def _set_rundir(self, path):
         """Set a new rundir."""
         if self._rundir:
-            logger.warning('Context <%s> is changing its working directory <%s>', self.tag, self._rundir)
+            logger.warning(
+                "Context <%s> is changing its working directory <%s>",
+                self.tag,
+                self._rundir,
+            )
         if self.system.path.isdir(path):
             self._rundir = path
-            logger.info('Context <%s> set rundir <%s>', self.tag, self._rundir)
+            logger.info("Context <%s> set rundir <%s>", self.tag, self._rundir)
         else:
-            logger.error('Try to change context <%s> to invalid path <%s>', self.tag, path)
+            logger.error(
+                "Try to change context <%s> to invalid path <%s>",
+                self.tag,
+                path,
+            )
 
     rundir = property(_get_rundir, _set_rundir)
 
@@ -337,7 +383,7 @@ class Context(getbytag.GetByTag, observer.Observer):
         """Change directory to the one associated to that context."""
         self._enforce_active()
         if self.rundir is None:
-            subpath = self.path.replace(self.session.path, '', 1)
+            subpath = self.path.replace(self.session.path, "", 1)
             self._rundir = self.session.rundir + subpath
         self.system.cd(self.rundir, create=True)
         self._wkdir = self.rundir
@@ -357,9 +403,11 @@ class Context(getbytag.GetByTag, observer.Observer):
         see :class:`vortex.tools.prestaging` for more details.
         """
         if self._prestaging_hub is None:
-            self._prestaging_hub = vortex.tools.prestaging.get_hub(tag='contextbound_{:s}'.format(self.tag),
-                                                                   sh=self.system,
-                                                                   email=self.session.glove.email)
+            self._prestaging_hub = vortex.tools.prestaging.get_hub(
+                tag="contextbound_{:s}".format(self.tag),
+                sh=self.system,
+                email=self.session.glove.email,
+            )
         return self._prestaging_hub
 
     @property
@@ -369,8 +417,9 @@ class Context(getbytag.GetByTag, observer.Observer):
         see :class:`vortex.tools.delayedactions` for more details.
         """
         if self._delayedactions_hub is None:
-            self._delayedactions_hub = PrivateDelayedActionsHub(sh=self.system,
-                                                                contextrundir=self.rundir)
+            self._delayedactions_hub = PrivateDelayedActionsHub(
+                sh=self.system, contextrundir=self.rundir
+            )
         return self._delayedactions_hub
 
     @property
@@ -395,8 +444,12 @@ class Context(getbytag.GetByTag, observer.Observer):
     @property
     def subcontexts(self):
         """The current contexts virtually included in the current one."""
-        rootpath = self.path + '/'
-        return [x for x in self.__class__.tag_values() if x.path.startswith(rootpath)]
+        rootpath = self.path + "/"
+        return [
+            x
+            for x in self.__class__.tag_values()
+            if x.path.startswith(rootpath)
+        ]
 
     def newcontext(self, name, focus=False):
         """
@@ -405,17 +458,19 @@ class Context(getbytag.GetByTag, observer.Observer):
         as well as the default ``focus``.
         """
         if name in self.__class__.tag_keys():
-            raise RuntimeError("A context with tag={!s} already exists.".format(name))
+            raise RuntimeError(
+                "A context with tag={!s} already exists.".format(name)
+            )
         newctx = self.__class__(tag=name, topenv=self.env, path=self.path)
         if focus:
             self.__class__.set_focus(newctx)
         return newctx
 
-    def stamp(self, tag='default'):
+    def stamp(self, tag="default"):
         """Return a stamp name that could be used for any generic purpose."""
-        return self._stamp + '.' + str(tag)
+        return self._stamp + "." + str(tag)
 
-    def fstrack_stamp(self, tag='default'):
+    def fstrack_stamp(self, tag="default"):
         """Set a stamp to track changes on the filesystem."""
         self._enforce_active()
         stamp = self.stamp(tag)
@@ -423,7 +478,7 @@ class Context(getbytag.GetByTag, observer.Observer):
         self.system.touch(stamp)
         self._fstore[stamp] = set(self.system.ffind())
 
-    def fstrack_check(self, tag='default'):
+    def fstrack_check(self, tag="default"):
         """
         Return a anonymous dictionary with for the each key, the list of entries
         in the file system that are concerned since the last associated ``tag`` stamp.
@@ -432,14 +487,18 @@ class Context(getbytag.GetByTag, observer.Observer):
         self._enforce_active()
         stamp = self.stamp(tag)
         if not self.system.path.exists(stamp):
-            logger.warning('Missing stamp %s', stamp)
+            logger.warning("Missing stamp %s", stamp)
             return None
         ffinded = set(self.system.ffind())
         bkuptrace = self.system.trace
         self.system.trace = False
         fscheck = Tracker(self._fstore[stamp], ffinded)
         stroot = self.system.stat(stamp)
-        fscheck.updated = [f for f in fscheck.unchanged if self.system.stat(f).st_mtime > stroot.st_mtime]
+        fscheck.updated = [
+            f
+            for f in fscheck.unchanged
+            if self.system.stat(f).st_mtime > stroot.st_mtime
+        ]
         self.system.trace = bkuptrace
         return fscheck
 
@@ -456,35 +515,42 @@ class Context(getbytag.GetByTag, observer.Observer):
         """Activate automatic recording of section while loading resource handlers."""
         self._record = True
 
-    def clear_promises(self, netloc='promise.cache.fr', scheme='vortex', storeoptions=None):
+    def clear_promises(
+        self, netloc="promise.cache.fr", scheme="vortex", storeoptions=None
+    ):
         """Remove all promises that have been made in this context.
 
         :param netloc: Netloc of the promise's cache store to clean up
         :param scheme: Scheme of the promise's cache store to clean up
         :param storeoptions: Option dictionary passed to the store (may be None)
         """
-        self.system.header('Clear promises for {}://{} in context {}'.format(scheme, netloc, self.path))
+        self.system.header(
+            "Clear promises for {}://{} in context {}".format(
+                scheme, netloc, self.path
+            )
+        )
         skeleton = dict(scheme=scheme, netloc=netloc)
-        promises = self.localtracker.grep_uri('put', skeleton)
+        promises = self.localtracker.grep_uri("put", skeleton)
         if promises:
-            logger.info('Some promises are left pending...')
+            logger.info("Some promises are left pending...")
             if storeoptions is None:
                 storeoptions = dict()
-            store = footprints.proxy.store(scheme=scheme, netloc=netloc,
-                                           **storeoptions)
+            store = footprints.proxy.store(
+                scheme=scheme, netloc=netloc, **storeoptions
+            )
             for promise in [pr.copy() for pr in promises]:
-                del promise['scheme']
-                del promise['netloc']
+                del promise["scheme"]
+                del promise["netloc"]
                 store.delete(promise)
         else:
-            logger.info('No promises were left pending.')
+            logger.info("No promises were left pending.")
 
     def clear_stamps(self):
         """Remove local context stamps."""
         if self._fstore:
             fstamps = list(self._fstamps)
             self.system.rmall(*fstamps)
-            logger.info('Removing context stamps %s', fstamps)
+            logger.info("Removing context stamps %s", fstamps)
             self._fstore = dict()
             self._fstamps = set()
 
@@ -503,7 +569,7 @@ class Context(getbytag.GetByTag, observer.Observer):
         try:
             self.clear()
         except TypeError:
-            logger.error('Could not clear local context <%s>', self.tag)
+            logger.error("Could not clear local context <%s>", self.tag)
         # Nullify some variable to help during garbage collection
         self._prestaging_hub = None
         if self._delayedactions_hub:

--- a/src/vortex/layout/jobs.py
+++ b/src/vortex/layout/jobs.py
@@ -432,7 +432,7 @@ def mkjob(t, **kw):
         # Using ast ensures that a valid python script was generated
         try:
             ast.parse(pycode, "compile.mkjob.log", "exec")
-        except SyntaxError as e:
+        except SyntaxError:
             logger.error(
                 "Error while attempting to parse the following script:\n%s",
                 pycode,

--- a/src/vortex/layout/jobs.py
+++ b/src/vortex/layout/jobs.py
@@ -24,7 +24,11 @@ from vortex.layout.appconf import ConfigSet
 from vortex.tools.actions import actiond as ad
 from vortex.tools.actions import FlowSchedulerGateway
 from vortex.tools.systems import istruedef
-from vortex.util.config import GenericConfigParser, ExtendedReadOnlyConfigParser, AppConfigStringDecoder
+from vortex.util.config import (
+    GenericConfigParser,
+    ExtendedReadOnlyConfigParser,
+    AppConfigStringDecoder,
+)
 from vortex.util.config import load_template
 
 #: Export nothing
@@ -33,13 +37,19 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-_RE_VORTEXDATE = re.compile(r'_(?P<date>\d{8})T(?P<hh>\d{2})(?P<mm>\d{2})(?P<cutoff>[AP])',
-                            re.IGNORECASE)
-_RE_OPTIME = re.compile(r'_t?(?P<hh>\d{2})(?:[:h-]?(?P<mm>\d{2})?)', re.IGNORECASE)
-_RE_MEMBER = re.compile(r'_mb(?P<member>\d+)', re.IGNORECASE)
+_RE_VORTEXDATE = re.compile(
+    r"_(?P<date>\d{8})T(?P<hh>\d{2})(?P<mm>\d{2})(?P<cutoff>[AP])",
+    re.IGNORECASE,
+)
+_RE_OPTIME = re.compile(
+    r"_t?(?P<hh>\d{2})(?:[:h-]?(?P<mm>\d{2})?)", re.IGNORECASE
+)
+_RE_MEMBER = re.compile(r"_mb(?P<member>\d+)", re.IGNORECASE)
 
 
-_JobBasicConf = collections.namedtuple('_JobBasicConf', ['appbase', 'xpid', 'vapp', 'vconf'])
+_JobBasicConf = collections.namedtuple(
+    "_JobBasicConf", ["appbase", "xpid", "vapp", "vconf"]
+)
 
 
 def _guess_vapp_vconf_xpid(t, path=None):
@@ -49,91 +59,113 @@ def _guess_vapp_vconf_xpid(t, path=None):
     """
     if path is None:
         path = t.sh.pwd()
-    lpath = path.split('/')
-    if lpath[-1] in ('demo', 'gco', 'genv', 'jobs', 'logs', 'src', 'tasks', 'vortex'):
+    lpath = path.split("/")
+    if lpath[-1] in (
+        "demo",
+        "gco",
+        "genv",
+        "jobs",
+        "logs",
+        "src",
+        "tasks",
+        "vortex",
+    ):
         lpath.pop()
-    if re.match('jobs_[^' + t.sh.path.sep + ']+', lpath[-1]):
+    if re.match("jobs_[^" + t.sh.path.sep + "]+", lpath[-1]):
         lpath.pop()
-    return _JobBasicConf('/'.join(lpath), *lpath[-3:])
+    return _JobBasicConf("/".join(lpath), *lpath[-3:])
 
 
-def _mkjob_opts_detect_1(t, ** opts):
+def _mkjob_opts_detect_1(t, **opts):
     """Detect options that does not depend on the configuration file."""
     tr_opts = dict()
     auto_opts = dict()
 
     # Things guessed from the directory name
     opset = _guess_vapp_vconf_xpid(t)
-    appbase = opts.pop('appbase', opset.appbase)
-    target_appbase = opts.get('target_appbase', opset.appbase)
-    xpid = opts.get('xpid', opset.xpid)
-    vapp = opts.pop('vapp', opset.vapp)
-    vconf = opts.pop('vconf', opset.vconf)
+    appbase = opts.pop("appbase", opset.appbase)
+    target_appbase = opts.get("target_appbase", opset.appbase)
+    xpid = opts.get("xpid", opset.xpid)
+    vapp = opts.pop("vapp", opset.vapp)
+    vconf = opts.pop("vconf", opset.vconf)
 
-    taskconf = opts.pop('taskconf', None)
+    taskconf = opts.pop("taskconf", None)
     if taskconf:
-        jobconf = '{:s}/conf/{:s}_{:s}_{:s}.ini'.format(appbase, vapp, vconf, taskconf)
-        taskconf = '_' + taskconf
+        jobconf = "{:s}/conf/{:s}_{:s}_{:s}.ini".format(
+            appbase, vapp, vconf, taskconf
+        )
+        taskconf = "_" + taskconf
     else:
-        jobconf = '{:s}/conf/{:s}_{:s}.ini'.format(appbase, vapp, vconf)
-        taskconf = ''
+        jobconf = "{:s}/conf/{:s}_{:s}.ini".format(appbase, vapp, vconf)
+        taskconf = ""
 
     # Other pre-calculated stuff
-    tr_opts['appbase'] = appbase
-    tr_opts['target_appbase'] = target_appbase
-    tr_opts['xpid'] = xpid
-    tr_opts['vapp'] = vapp
-    tr_opts['vconf'] = vconf
-    tr_opts['jobconf'] = jobconf
-    tr_opts['taskconf'] = taskconf
+    tr_opts["appbase"] = appbase
+    tr_opts["target_appbase"] = target_appbase
+    tr_opts["xpid"] = xpid
+    tr_opts["vapp"] = vapp
+    tr_opts["vconf"] = vconf
+    tr_opts["jobconf"] = jobconf
+    tr_opts["taskconf"] = taskconf
 
     return tr_opts, auto_opts, opts
 
 
-def _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_opts, ** opts):
+def _mkjob_opts_detect_2(
+    t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_opts, **opts
+):
     """Detect options that depend on the configuration file."""
 
     # Fix the task's name
-    name = re.sub(r'\.py$', '', opts.pop('name', 'autojob'))
+    name = re.sub(r"\.py$", "", opts.pop("name", "autojob"))
 
     # Try to find default rundate/runtime according to the jobname
-    runtime = opts.pop('runtime', None)
-    rundate = opts.pop('rundate', None)
-    cutoff = opts.pop('cutoff', None)
+    runtime = opts.pop("runtime", None)
+    rundate = opts.pop("rundate", None)
+    cutoff = opts.pop("cutoff", None)
     if runtime is None and rundate is None:
         vtxdate = _RE_VORTEXDATE.search(name)
         if vtxdate:
-            rundate = date.Date(vtxdate.group('date') +
-                                vtxdate.group('hh') + vtxdate.group('mm'))
-            runtime = date.Time('{:s}:{:s}'.format(vtxdate.group('hh'),
-                                                   vtxdate.group('mm')))
+            rundate = date.Date(
+                vtxdate.group("date")
+                + vtxdate.group("hh")
+                + vtxdate.group("mm")
+            )
+            runtime = date.Time(
+                "{:s}:{:s}".format(vtxdate.group("hh"), vtxdate.group("mm"))
+            )
             if cutoff is None:
-                cutoff = dict(A='assim', P='production').get(vtxdate.group('cutoff'))
-            name = _RE_VORTEXDATE.sub('', name)
+                cutoff = dict(A="assim", P="production").get(
+                    vtxdate.group("cutoff")
+                )
+            name = _RE_VORTEXDATE.sub("", name)
         else:
             optime = _RE_OPTIME.search(name)
             if optime:
-                runtime = date.Time('{:s}:{:s}'.format(optime.group('hh'), optime.group('mm')))
-                name = _RE_OPTIME.sub('', name)
+                runtime = date.Time(
+                    "{:s}:{:s}".format(optime.group("hh"), optime.group("mm"))
+                )
+                name = _RE_OPTIME.sub("", name)
 
     # Try to find default member number according to the jobname
-    member = opts.pop('member', None)
+    member = opts.pop("member", None)
     if member is None:
         mblookup = _RE_MEMBER.search(name)
         if mblookup:
-            member = int(mblookup.group('member'))
-            name = _RE_MEMBER.sub('', name)
+            member = int(mblookup.group("member"))
+            name = _RE_MEMBER.sub("", name)
 
     # Get the job's configuration
     p_jobconf = jobconf.get(name, None)
     if p_jobconf is None:
-        logger.warning('No job configuration for job name=%s', name)
-        logger.info('The job configuration build from the [DEFAULT] section... This may be a bad idea !')
+        logger.warning("No job configuration for job name=%s", name)
+        logger.info(
+            "The job configuration build from the [DEFAULT] section... This may be a bad idea !"
+        )
         p_jobconf = jobconf_defaults
 
     # The mkjob profile and associated conf
-    profile = opts.pop('profile',
-                       p_jobconf.get('profile_mkjob', 'test'))
+    profile = opts.pop("profile", p_jobconf.get("profile_mkjob", "test"))
 
     # Find the appropriate config given the template
     p_tplconf = tplconf.get(profile, None)
@@ -151,17 +183,19 @@ def _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_op
         Function that look up in command line options, then in job's conf,
         then in template's conf.
         """
-        return opts.pop(what, p_jobconf.get(what, p_tplconf.get(what, default)))
+        return opts.pop(
+            what, p_jobconf.get(what, p_tplconf.get(what, default))
+        )
 
     # A last chance for these super-stars : they may be set in job's conf...
     if rundate is None:
-        rundate = p_jobconf.get('rundate', None)
+        rundate = p_jobconf.get("rundate", None)
     if runtime is None:
-        runtime = p_jobconf.get('runtime', None)
+        runtime = p_jobconf.get("runtime", None)
     if cutoff is None:
-        cutoff = p_jobconf.get('cutoff', None)
+        cutoff = p_jobconf.get("cutoff", None)
     if member is None:
-        member = p_jobconf.get('member', None)
+        member = p_jobconf.get("member", None)
 
     if member is not None:
         try:
@@ -171,7 +205,7 @@ def _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_op
 
     # Special treatment for xpid and target_appbase (they may be in jobconf but
     # command line value remain the preferred value)
-    for stuff in ('xpid', 'target_appbase'):
+    for stuff in ("xpid", "target_appbase"):
         if stuff not in opts:
             if stuff in p_jobconf:
                 tr_opts[stuff] = p_jobconf[stuff]
@@ -179,95 +213,111 @@ def _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_op
             del opts[stuff]
 
     # Switch verbosity from boolean to plain string
-    verb = opts_plus_job_plus_tpl('verbose', True)
+    verb = opts_plus_job_plus_tpl("verbose", True)
     if isinstance(verb, bool):
-        verb = 'verbose' if verb else 'noverbose'
+        verb = "verbose" if verb else "noverbose"
 
     # Adapt the partition name if refill is on
-    refill = opts_plus_job_plus_tpl('refill', False)
+    refill = opts_plus_job_plus_tpl("refill", False)
     if not isinstance(refill, bool):
         refill = bool(istruedef.match(refill))
-    warmstart = opts_plus_job_plus_tpl('warmstart', False)
+    warmstart = opts_plus_job_plus_tpl("warmstart", False)
     if not isinstance(warmstart, bool):
         warmstart = bool(istruedef.match(warmstart))
-    partition = opts_plus_job_plus_tpl('partition', None)
+    partition = opts_plus_job_plus_tpl("partition", None)
     if refill or warmstart:
-        partition = opts_plus_job_plus_tpl('refill_partition', None)
+        partition = opts_plus_job_plus_tpl("refill_partition", None)
 
     # SuiteBg
-    suitebg = opts_plus_job_plus_tpl('suitebg', None)
+    suitebg = opts_plus_job_plus_tpl("suitebg", None)
 
     # Rundates
-    rundates = opts_plus_job_plus_tpl('rundates', None)
+    rundates = opts_plus_job_plus_tpl("rundates", None)
 
     # Lists...
-    for explist in ('loadedmods', 'loadedaddons', 'loadedjaplugins',
-                    'ldlibs', 'extrapythonpath'):
+    for explist in (
+        "loadedmods",
+        "loadedaddons",
+        "loadedjaplugins",
+        "ldlibs",
+        "extrapythonpath",
+    ):
         val = opts_plus_job_plus_tpl(explist, None)
         if val:
-            tr_opts[explist] = ','.join(["'{:s}'".format(x)
-                                         for x in re.split(r'\s*,\s*', val)
-                                         if len(x)])
+            tr_opts[explist] = ",".join(
+                [
+                    "'{:s}'".format(x)
+                    for x in re.split(r"\s*,\s*", val)
+                    if len(x)
+                ]
+            )
             if tr_opts[explist]:
-                tr_opts[explist] += ','  # Always ends with a ,
+                tr_opts[explist] += ","  # Always ends with a ,
 
     # A lot of basic stuffs...
-    tr_opts['create'] = opts.pop('create', date.at_second().iso8601())
-    tr_opts['mkuser'] = opts.pop('mkuser', t.glove.user)
-    tr_opts['mkhost'] = opts.pop('mkhost', t.sh.hostname)
-    tr_opts['mkopts'] = opts.pop('mkopts')
-    tr_opts['pwd'] = opts.pop('pwd', t.sh.getcwd())
-    tr_opts['home'] = opts_plus_job('home', t.env.HOME)
+    tr_opts["create"] = opts.pop("create", date.at_second().iso8601())
+    tr_opts["mkuser"] = opts.pop("mkuser", t.glove.user)
+    tr_opts["mkhost"] = opts.pop("mkhost", t.sh.hostname)
+    tr_opts["mkopts"] = opts.pop("mkopts")
+    tr_opts["pwd"] = opts.pop("pwd", t.sh.getcwd())
+    tr_opts["home"] = opts_plus_job("home", t.env.HOME)
 
-    tr_opts['python_mkjob'] = t.sh.which('python')
-    tr_opts['python'] = opts_plus_job_plus_tpl('python', tr_opts['python_mkjob'])
-    tr_opts['pyopts'] = opts_plus_job_plus_tpl('pyopts', '-u')
+    tr_opts["python_mkjob"] = t.sh.which("python")
+    tr_opts["python"] = opts_plus_job_plus_tpl(
+        "python", tr_opts["python_mkjob"]
+    )
+    tr_opts["pyopts"] = opts_plus_job_plus_tpl("pyopts", "-u")
 
-    tr_opts['task'] = opts_plus_job_plus_tpl('task', 'void')
+    tr_opts["task"] = opts_plus_job_plus_tpl("task", "void")
 
     # Other pre-calculated stuff
-    tr_opts['verbose'] = verb
-    tr_opts['name'] = name
-    tr_opts['file'] = opts.pop('file', name + '.py')
+    tr_opts["verbose"] = verb
+    tr_opts["name"] = name
+    tr_opts["file"] = opts.pop("file", name + ".py")
     if rundate is None:
-        tr_opts['rundate'] = None
+        tr_opts["rundate"] = None
     else:
         try:
             rundate = date.Date(rundate).ymdh
         except (ValueError, TypeError):
             pass
-        tr_opts['rundate'] = "'" + str(rundate) + "'"  # Ugly, but that's history
+        tr_opts["rundate"] = (
+            "'" + str(rundate) + "'"
+        )  # Ugly, but that's history
     if runtime is None:
-        tr_opts['runtime'] = None
+        tr_opts["runtime"] = None
     else:
         try:
             runtime = date.Time(runtime)
         except (ValueError, TypeError):
             pass
-        tr_opts['runtime'] = "'" + str(runtime) + "'"  # Ugly, but that's history
+        tr_opts["runtime"] = (
+            "'" + str(runtime) + "'"
+        )  # Ugly, but that's history
     if cutoff is not None:
-        tr_opts['cutoff'] = cutoff
-    tr_opts['member'] = member
-    auto_opts['member'] = member
+        tr_opts["cutoff"] = cutoff
+    tr_opts["member"] = member
+    auto_opts["member"] = member
     if suitebg is None:
-        tr_opts['suitebg'] = suitebg
+        tr_opts["suitebg"] = suitebg
     else:
-        tr_opts['suitebg'] = "'" + suitebg + "'"  # Ugly, but that's history
-    auto_opts['suitebg'] = suitebg
-    tr_opts['refill'] = refill
-    tr_opts['warmstart'] = warmstart
+        tr_opts["suitebg"] = "'" + suitebg + "'"  # Ugly, but that's history
+    auto_opts["suitebg"] = suitebg
+    tr_opts["refill"] = refill
+    tr_opts["warmstart"] = warmstart
     if partition is not None:
-        tr_opts['partition'] = partition
+        tr_opts["partition"] = partition
     if rundates:
-        tr_opts['rundates'] = rundates
-        auto_opts['rundates'] = rundates
+        tr_opts["rundates"] = rundates
+        auto_opts["rundates"] = rundates
     else:
-        tr_opts['rundates'] = ''
+        tr_opts["rundates"] = ""
 
     # The list of auto command-line options to ignore
-    auto_options_filter_opts = opts.pop('auto_options_filter', ())
-    auto_options_filter = (opts_plus_job_plus_tpl('auto_options_filter', '').split(',') +
-                           list(auto_options_filter_opts))
+    auto_options_filter_opts = opts.pop("auto_options_filter", ())
+    auto_options_filter = opts_plus_job_plus_tpl(
+        "auto_options_filter", ""
+    ).split(",") + list(auto_options_filter_opts)
     # All the remaining stuff...
     for k, v in opts.items():
         tr_opts.setdefault(k, v)
@@ -282,9 +332,9 @@ def _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_defaults, tr_opts, auto_op
 
 def _mkjob_type_translate(k, v):
     """Dump values as strings for auto_options export..."""
-    if 'dates' in k:
+    if "dates" in k:
         return "bronx.stdtypes.date.daterangex('{:s}')".format(v)
-    elif 'date' in k:
+    elif "date" in k:
         return "bronx.stdtypes.date.Date('{:s}')".format(v)
     else:
         if isinstance(v, str):
@@ -294,14 +344,18 @@ def _mkjob_type_translate(k, v):
 
 
 def _mkjob_opts_autoexport(auto_opts):
-    return ',\n'.join(['    ' + k + '=' + _mkjob_type_translate(k, v)
-                       for k, v in sorted(auto_opts.items())])
+    return ",\n".join(
+        [
+            "    " + k + "=" + _mkjob_type_translate(k, v)
+            for k, v in sorted(auto_opts.items())
+        ]
+    )
 
 
 def mkjob(t, **kw):
     """Build a complete job file according to a template and some parameters."""
     opts = dict(
-        inifile='@job-default.ini',
+        inifile="@job-default.ini",
         wrap=False,
     )
     opts.update(kw)
@@ -311,63 +365,78 @@ def mkjob(t, **kw):
 
     # Read the configuration files
     try:
-        iniparser = ExtendedReadOnlyConfigParser(inifile=opts['inifile'])
+        iniparser = ExtendedReadOnlyConfigParser(inifile=opts["inifile"])
         tplconf = iniparser.as_dict()
     except Exception as pb:
-        emsg = 'Could not read the << {:s} >> config file: {!s}'.format(opts['inifile'], pb)
+        emsg = "Could not read the << {:s} >> config file: {!s}".format(
+            opts["inifile"], pb
+        )
         logger.critical(emsg)
         raise ValueError(emsg)
 
-    if t.sh.path.exists(tr_opts['jobconf']):
-        t.sh.header('Reading ' + tr_opts['jobconf'])
+    if t.sh.path.exists(tr_opts["jobconf"]):
+        t.sh.header("Reading " + tr_opts["jobconf"])
         try:
-            jobparser = ExtendedReadOnlyConfigParser(inifile=tr_opts['jobconf'])
+            jobparser = ExtendedReadOnlyConfigParser(
+                inifile=tr_opts["jobconf"]
+            )
             jobconf = jobparser.as_dict()
             jobconf_default = jobparser.defaults()
         except Exception as pb:
-            emsg = 'Could not read the << {:s} >> config file: {!s}'.format(tr_opts['jobconf'], pb)
+            emsg = "Could not read the << {:s} >> config file: {!s}".format(
+                tr_opts["jobconf"], pb
+            )
             logger.critical(emsg)
             raise ValueError(emsg)
     else:
-        emsg = 'Could not find the << {:s} >> config file.'.format(tr_opts['jobconf'])
+        emsg = "Could not find the << {:s} >> config file.".format(
+            tr_opts["jobconf"]
+        )
         logger.error(emsg)
         raise ValueError(emsg)
 
     # Detect most of the options that depend on the configuration file
-    tr_opts, auto_opts = _mkjob_opts_detect_2(t, tplconf, jobconf, jobconf_default,
-                                              tr_opts, auto_opts, ** r_kw)
+    tr_opts, auto_opts = _mkjob_opts_detect_2(
+        t, tplconf, jobconf, jobconf_default, tr_opts, auto_opts, **r_kw
+    )
 
     # Dump auto_exported options
-    tr_opts['auto_options'] = _mkjob_opts_autoexport(auto_opts)
+    tr_opts["auto_options"] = _mkjob_opts_autoexport(auto_opts)
 
     # Generate the job
-    corejob = load_template(t,
-                            tr_opts['template'],
-                            encoding="script",
-                            default_templating='twopasslegacy')
-    tr_opts['tplfile'] = corejob.srcfile
+    corejob = load_template(
+        t,
+        tr_opts["template"],
+        encoding="script",
+        default_templating="twopasslegacy",
+    )
+    tr_opts["tplfile"] = corejob.srcfile
 
     # Variable starting with j2_ are dealt with using the AppConfigStringDecoder.
     # It allows fancier things when jinja2 templates are used
-    j2_activated = corejob.KIND == 'jinja2'
+    j2_activated = corejob.KIND == "jinja2"
     if j2_activated:
         csd = AppConfigStringDecoder(substitution_cb=lambda k: tr_opts[k])
-        for k in [k for k in tr_opts.keys() if k.startswith('j2_')]:
+        for k in [k for k in tr_opts.keys() if k.startswith("j2_")]:
             tr_opts[k] = csd(tr_opts[k])
 
-    pycode = corejob(** tr_opts)
+    pycode = corejob(**tr_opts)
 
-    if opts['wrap']:
+    if opts["wrap"]:
+
         def autojob():
-            eval(compile(pycode, 'compile.mkjob.log', 'exec'))
+            eval(compile(pycode, "compile.mkjob.log", "exec"))
+
         objcode = autojob
     else:
         # Using ast ensures that a valid python script was generated
         try:
-            ast.parse(pycode, 'compile.mkjob.log', 'exec')
+            ast.parse(pycode, "compile.mkjob.log", "exec")
         except SyntaxError as e:
-            logger.error("Error while attempting to parse the following script:\n%s",
-                         pycode)
+            logger.error(
+                "Error while attempting to parse the following script:\n%s",
+                pycode,
+            )
             raise
         objcode = pycode
 
@@ -381,6 +450,7 @@ def _extendable(func):
     The added behaviour is to look into the plugins list and call appropriate
     methods upon them.
     """
+
     def new_me(self, *kargs, **kw):
         # Call the original function, save the result
         res = func(self, *kargs, **kw)
@@ -389,7 +459,7 @@ def _extendable(func):
         if not (dargs and isinstance(dargs[0], vortex.sessions.Ticket)):
             dargs.insert(0, vortex.sessions.current())
         # The method we are looking for
-        plugable_n = 'plugable_' + func.__name__.lstrip('_')
+        plugable_n = "plugable_" + func.__name__.lstrip("_")
         # Go through the plugins and look for available methods
         for p in [p for p in self.plugins if hasattr(p, plugable_n)]:
             # If the previous result was a session, use it...
@@ -404,49 +474,48 @@ def _extendable(func):
                 dargs[0] = res
             res = tg_callback(self, *dargs, **kw)
         return res
+
     return new_me
 
 
 class JobAssistant(footprints.FootprintBase):
     """Class in charge of setting various session and environment settings for a Vortex job."""
 
-    _collector = ('jobassistant',)
+    _collector = ("jobassistant",)
     _footprint = dict(
-        info = 'Abstract JobAssistant',
-        attr = dict(
-            kind = dict(
-                values = ['generic', 'minimal']
+        info="Abstract JobAssistant",
+        attr=dict(
+            kind=dict(values=["generic", "minimal"]),
+            modules=dict(
+                info="A set of Python modules/packages to be imported.",
+                type=FPSet,
+                optional=True,
+                default=FPSet(()),
             ),
-            modules = dict(
-                info = 'A set of Python modules/packages to be imported.',
-                type = FPSet,
-                optional = True,
-                default = FPSet(()),
+            addons=dict(
+                info="A set of Vortex shell addons to load in the main System object",
+                type=FPSet,
+                optional=True,
+                default=FPSet(()),
             ),
-            addons = dict(
-                info = 'A set of Vortex shell addons to load in the main System object',
-                type = FPSet,
-                optional = True,
-                default = FPSet(()),
+            ldlibs=dict(
+                info="A set of paths to prepend to the LD_LIBRARY_PATH variable.",
+                type=FPSet,
+                optional=True,
+                default=FPSet(()),
             ),
-            ldlibs = dict(
-                info = 'A set of paths to prepend to the LD_LIBRARY_PATH variable.',
-                type = FPSet,
-                optional = True,
-                default = FPSet(()),
+            special_prefix=dict(
+                info="The prefix of environment variable with a special meaning.",
+                optional=True,
+                default="op_",
             ),
-            special_prefix = dict(
-                info = 'The prefix of environment variable with a special meaning.',
-                optional = True,
-                default = 'op_',
-            )
         ),
     )
 
-    _P_SESSION_INFO_FMT = '+ {0:14s} = {1!s}'
-    _P_ENVVAR_FMT = '+ {0:s} = {1!s}'
-    _P_MODULES_FMT = '+ {0:s}'
-    _P_ADDON_FMT = '+ Add-on {0:10s} = {1!r}'
+    _P_SESSION_INFO_FMT = "+ {0:14s} = {1!s}"
+    _P_ENVVAR_FMT = "+ {0:s} = {1!s}"
+    _P_MODULES_FMT = "+ {0:s}"
+    _P_ADDON_FMT = "+ Add-on {0:10s} = {1!r}"
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -464,39 +533,47 @@ class JobAssistant(footprints.FootprintBase):
         return self._plugins
 
     def add_plugin(self, kind, **kwargs):
-        self._plugins.append(fpx.jobassistant_plugin(kind=kind, masterja=self,
-                                                     **kwargs))
+        self._plugins.append(
+            fpx.jobassistant_plugin(kind=kind, masterja=self, **kwargs)
+        )
 
     @property
     def conf(self):
         if self._conf is None:
-            raise RuntimeError('It is too soon to access the JobAssisant configuration')
+            raise RuntimeError(
+                "It is too soon to access the JobAssisant configuration"
+            )
         return self._conf
 
     @property
     def special_variables(self):
         if self._special_variables is None:
-            raise RuntimeError('It is too soon to access the JobAssisant special variables')
+            raise RuntimeError(
+                "It is too soon to access the JobAssisant special variables"
+            )
         return self._special_variables
 
     def __getattr__(self, name):
         """Search the plugins for unknown methods."""
-        if not (name.startswith('_') or name.startswith('plugable')):
+        if not (name.startswith("_") or name.startswith("plugable")):
             for plugin in self.plugins:
                 if hasattr(plugin, name):
                     return getattr(plugin, name)
-        raise AttributeError('Attribute not found.')
+        raise AttributeError("Attribute not found.")
 
     @_extendable
     def _init_special_variables(self, prefix=None, **kw):
         """Print some of the environment variables."""
         prefix = prefix or self.special_prefix
         # Suffixed variables
-        specials = kw.get('actual', dict())
-        self._special_variables = {k[len(prefix):].lower(): v
-                                   for k, v in specials.items() if k.startswith(prefix)}
+        specials = kw.get("actual", dict())
+        self._special_variables = {
+            k[len(prefix) :].lower(): v
+            for k, v in specials.items()
+            if k.startswith(prefix)
+        }
         # Auto variables
-        auto = kw.get('auto_options', dict())
+        auto = kw.get("auto_options", dict())
         for k, v in auto.items():
             self._special_variables.setdefault(k.lower(), v)
 
@@ -506,19 +583,19 @@ class JobAssistant(footprints.FootprintBase):
 
     def _init_conf(self, **kw):
         """Read the application's configuration file."""
-        jobname = self._kw_and_specials_get('jobname', None)
-        iniconf = self._kw_and_specials_get('iniconf', None)
-        iniencoding = self._kw_and_specials_get('inienconding', None)
+        jobname = self._kw_and_specials_get("jobname", None)
+        iniconf = self._kw_and_specials_get("iniconf", None)
+        iniencoding = self._kw_and_specials_get("inienconding", None)
         self._conf = ConfigSet()
         if iniconf:
             try:
                 iniparser = GenericConfigParser(iniconf, encoding=iniencoding)
             except Exception:
-                logger.critical('Could not read config %s', iniconf)
+                logger.critical("Could not read config %s", iniconf)
                 raise
             thisconf = iniparser.as_dict(merged=False)
             # Conf defaults
-            self._conf.update(thisconf.get('defaults', dict()))
+            self._conf.update(thisconf.get("defaults", dict()))
             if jobname is not None:
                 # Job specific conf
                 self._conf.update(thisconf.get(jobname, dict()))
@@ -535,22 +612,22 @@ class JobAssistant(footprints.FootprintBase):
 
         locprint = functools.partial(self._printfmt, self._P_SESSION_INFO_FMT)
 
-        t.sh.header('Toolbox description')
+        t.sh.header("Toolbox description")
 
-        locprint('Root directory', t.glove.siteroot)
-        locprint('Path directory', t.glove.sitesrc)
-        locprint('Conf directory', t.glove.siteconf)
+        locprint("Root directory", t.glove.siteroot)
+        locprint("Path directory", t.glove.sitesrc)
+        locprint("Conf directory", t.glove.siteconf)
 
-        t.sh.header('Session & Target description')
+        t.sh.header("Session & Target description")
 
-        locprint('Session Ticket', t)
-        locprint('Session Glove', t.glove)
-        locprint('Session System', t.sh)
-        locprint('Session Env', t.env)
+        locprint("Session Ticket", t)
+        locprint("Session Glove", t.glove)
+        locprint("Session System", t.sh)
+        locprint("Session Env", t.env)
         tg = t.sh.default_target
-        locprint('Target name', tg.hostname)
-        locprint('Target system', tg.sysname)
-        locprint('Target inifile', tg.inifile)
+        locprint("Target name", tg.hostname)
+        locprint("Target system", tg.sysname)
+        locprint("Target inifile", tg.inifile)
 
     @_extendable
     def _print_toolbox_settings(self, t):
@@ -558,16 +635,23 @@ class JobAssistant(footprints.FootprintBase):
         vortex.toolbox.show_toolbox_settings()
 
     @classmethod
-    def print_somevariables(cls, t, prefix=''):
+    def print_somevariables(cls, t, prefix=""):
         """Print some of the environment variables."""
         prefix = prefix.upper()
         filtered = sorted([x for x in t.env.keys() if x.startswith(prefix)])
         if filtered:
-            t.sh.highlight('{:s} environment variables'.format(prefix if prefix else 'All'))
+            t.sh.highlight(
+                "{:s} environment variables".format(
+                    prefix if prefix else "All"
+                )
+            )
             maxlen = max([len(x) for x in filtered])
             for var_name in filtered:
-                cls._printfmt(cls._P_ENVVAR_FMT,
-                              var_name.ljust(maxlen), t.env.native(var_name))
+                cls._printfmt(
+                    cls._P_ENVVAR_FMT,
+                    var_name.ljust(maxlen),
+                    t.env.native(var_name),
+                )
         return len(filtered)
 
     @_extendable
@@ -575,15 +659,19 @@ class JobAssistant(footprints.FootprintBase):
         """Print some of the environment variables."""
         prefix = prefix or self.special_prefix
         if self.special_variables:
-            filtered = {prefix + k: v for k, v in self.special_variables.items()}
-            self._printfmt('Copying actual {:s} variables to the environment', prefix)
+            filtered = {
+                prefix + k: v for k, v in self.special_variables.items()
+            }
+            self._printfmt(
+                "Copying actual {:s} variables to the environment", prefix
+            )
             t.env.update(filtered)
             self.print_somevariables(t, prefix=prefix)
 
     @_extendable
     def _modules_preload(self, t):
         """Import all the modules listed in the footprint."""
-        t.sh.header('External imports')
+        t.sh.header("External imports")
         for module in sorted(self.modules):
             importlib.import_module(module)
             self._printfmt(self._P_MODULES_FMT, module)
@@ -591,7 +679,7 @@ class JobAssistant(footprints.FootprintBase):
     @_extendable
     def _addons_preload(self, t):
         """Load shell addons."""
-        t.sh.header('Add-ons to the shell')
+        t.sh.header("Add-ons to the shell")
         for addon in self.addons:
             shadd = footprints.proxy.addon(kind=addon, shell=t.sh)
             self._printfmt(self._P_ADDON_FMT, addon.upper(), shadd)
@@ -601,18 +689,18 @@ class JobAssistant(footprints.FootprintBase):
         """Set usual settings for the system shell."""
         t.sh.header("Session and system basic setup")
         self._printfmt('+ Setting "stack" and "memlock" limits to unlimited.')
-        t.sh.setulimit('stack')
-        t.sh.setulimit('memlock')
+        t.sh.setulimit("stack")
+        t.sh.setulimit("memlock")
         for ldlib in self.ldlibs:
             self._printfmt('+ Prepending "{}" to the LD_LIBRARY_PATH.', ldlib)
-            t.env.setgenericpath('LD_LIBRARY_PATH', ldlib, pos=0)
+            t.env.setgenericpath("LD_LIBRARY_PATH", ldlib, pos=0)
 
     @_extendable
     def _early_session_setup(self, t, **kw):
         """Create a now session, set important things, ..."""
         t.sh.header("Session's early setup")
-        t.glove.vapp = self._kw_and_specials_get('vapp', None)
-        t.glove.vconf = self._kw_and_specials_get('vconf', None)
+        t.glove.vapp = self._kw_and_specials_get("vapp", None)
+        t.glove.vconf = self._kw_and_specials_get("vconf", None)
         # Ensure that the script's path is an absolute path
         sys.argv[0] = t.sh.path.abspath(sys.argv[0])
         return t
@@ -623,34 +711,54 @@ class JobAssistant(footprints.FootprintBase):
         t.sh.header("Session's final setup")
         # Handle session's datastore for subjobs
         if self.subjob_tag is not None:
-            t.datastore.pickle_load(subjobs._DSTORE_IN.format(self.subjob_fsid))
-            self._printfmt('+ The datastore was read from disk: ' + subjobs._DSTORE_IN,
-                           self.subjob_fsid)
+            t.datastore.pickle_load(
+                subjobs._DSTORE_IN.format(self.subjob_fsid)
+            )
+            self._printfmt(
+                "+ The datastore was read from disk: " + subjobs._DSTORE_IN,
+                self.subjob_fsid,
+            )
         # Possibly setup the default user names for file-transfers
-        ftuser = self.conf.get('ftuser', None)
+        ftuser = self.conf.get("ftuser", None)
         if ftuser is not None:
             if isinstance(ftuser, dict):
                 for dest, d_ftuser in ftuser.items():
-                    if not (isinstance(dest, str) and isinstance(d_ftuser, str)):
-                        logger.error('Improper ftuser configuration (Destination=%s, Logname=%s)',
-                                     dest, d_ftuser)
+                    if not (
+                        isinstance(dest, str) and isinstance(d_ftuser, str)
+                    ):
+                        logger.error(
+                            "Improper ftuser configuration (Destination=%s, Logname=%s)",
+                            dest,
+                            d_ftuser,
+                        )
                         continue
-                    if dest.lower() == 'default':
-                        self._printfmt('+ Setting the default file-transfer user to: {:s}', d_ftuser)
+                    if dest.lower() == "default":
+                        self._printfmt(
+                            "+ Setting the default file-transfer user to: {:s}",
+                            d_ftuser,
+                        )
                         t.glove.setftuser(d_ftuser)
                     else:
-                        self._printfmt('+ Setting the {:s} file-transfer user to: {:s}', dest, d_ftuser)
+                        self._printfmt(
+                            "+ Setting the {:s} file-transfer user to: {:s}",
+                            dest,
+                            d_ftuser,
+                        )
                         t.glove.setftuser(d_ftuser, dest)
             elif isinstance(ftuser, str):
-                self._printfmt('+ Setting the default file-transfer user to: {:s}', ftuser)
+                self._printfmt(
+                    "+ Setting the default file-transfer user to: {:s}", ftuser
+                )
                 t.glove.setftuser(ftuser)
             else:
-                logger.error('Improper ftuser value %s', ftuser)
+                logger.error("Improper ftuser value %s", ftuser)
         # Possibly setup the default hostname for file-transfers
-        fthost = self.conf.get('fthost', None)
+        fthost = self.conf.get("fthost", None)
         if fthost is not None:
             t.glove.default_fthost = fthost
-            self._printfmt('+ Setting the default file-transfer hostname to: {:s}', fthost)
+            self._printfmt(
+                "+ Setting the default file-transfer hostname to: {:s}", fthost
+            )
 
     @_extendable
     def _env_setup(self, t, **kw):
@@ -662,7 +770,7 @@ class JobAssistant(footprints.FootprintBase):
     @_extendable
     def _toolbox_setup(self, t, **kw):
         """Toolbox default setup."""
-        t.sh.header('Toolbox module settings')
+        t.sh.header("Toolbox module settings")
         vortex.toolbox.active_verbose = True
         vortex.toolbox.active_now = True
         vortex.toolbox.active_clear = True
@@ -670,7 +778,7 @@ class JobAssistant(footprints.FootprintBase):
     @_extendable
     def _actions_setup(self, t, **kw):
         """Setup the action dispatcher."""
-        t.sh.header('Actions setup')
+        t.sh.header("Actions setup")
 
     @_extendable
     def _job_final_init(self, t, **kw):
@@ -678,8 +786,8 @@ class JobAssistant(footprints.FootprintBase):
         t.sh.header("Job's final init")
 
     def _subjob_detect(self, t):
-        if 'VORTEX_SUBJOB_ACTIVATED' in t.env:
-            tag, fsid = t.env['VORTEX_SUBJOB_ACTIVATED'].split(':', 1)
+        if "VORTEX_SUBJOB_ACTIVATED" in t.env:
+            tag, fsid = t.env["VORTEX_SUBJOB_ACTIVATED"].split(":", 1)
             self.subjob_tag = tag
             self.subjob_fsid = fsid
 
@@ -702,15 +810,19 @@ class JobAssistant(footprints.FootprintBase):
         self._env_setup(t, **kw)  # Setup the session's Environment object
         self._modules_preload(t)  # Load a few modules
         self._addons_preload(t)  # Active some shell addons
-        self._extra_session_setup(t, **kw)  # Some extra configuration on the session
+        self._extra_session_setup(
+            t, **kw
+        )  # Some extra configuration on the session
         self._toolbox_setup(t, **kw)  # Setup toolbox settings
-        self._print_toolbox_settings(t)  # Print a summary of the toolbox settings
+        self._print_toolbox_settings(
+            t
+        )  # Print a summary of the toolbox settings
         self._actions_setup(t, **kw)  # Setup the actionDispatcher
         # Begin signal handling
         t.sh.signal_intercept_on()
         # A last word ?
         self._job_final_init(t, **kw)
-        self._printfmt('')
+        self._printfmt("")
         return t, t.env, t.sh
 
     @_extendable
@@ -722,16 +834,23 @@ class JobAssistant(footprints.FootprintBase):
     def register_cycle(self, cycle):
         """A callback to register GCO cycles."""
         from vortex.nwp.syntax.stdattrs import GgetId
+
         try:
             cycle = GgetId(cycle)
         except ValueError:
-            self._printfmt('** Cycle << {!s} >> will auto-register whenever necessary **', cycle)
+            self._printfmt(
+                "** Cycle << {!s} >> will auto-register whenever necessary **",
+                cycle,
+            )
             return
         from vortex_gco.tools import genv
+
         if cycle in genv.cycles():
-            self._printfmt('** Cycle << {!s} >> already registered **', cycle)
+            self._printfmt("** Cycle << {!s} >> already registered **", cycle)
         else:
-            self._printfmt('\n** Cycle << {!s} >> is to be registered **', cycle)
+            self._printfmt(
+                "\n** Cycle << {!s} >> is to be registered **", cycle
+            )
             genv.autofill(cycle)
             print(genv.as_rawstr(cycle=cycle))
 
@@ -748,13 +867,15 @@ class JobAssistant(footprints.FootprintBase):
         :param Exception latest_error: The latest caught exception.
         """
         t = vortex.ticket()
-        t.sh.subtitle('Handling exception')
-        (exc_type, exc_value, exc_traceback) = sys.exc_info()  # @UnusedVariable
-        self._printfmt('Exception type: {!s}', exc_type)
-        self._printfmt('Exception info: {!s}', latest_error)
-        t.sh.header('Traceback Error / BEGIN')
+        t.sh.subtitle("Handling exception")
+        (exc_type, exc_value, exc_traceback) = (
+            sys.exc_info()
+        )  # @UnusedVariable
+        self._printfmt("Exception type: {!s}", exc_type)
+        self._printfmt("Exception info: {!s}", latest_error)
+        t.sh.header("Traceback Error / BEGIN")
         print("\n".join(traceback.format_tb(exc_traceback)))
-        t.sh.header('Traceback Error / END')
+        t.sh.header("Traceback Error / END")
 
     @_extendable
     def rescue(self):
@@ -769,9 +890,14 @@ class JobAssistant(footprints.FootprintBase):
         t = vortex.ticket()
         t.sh.subtitle("Executing JobAssistant's finalise actions")
         if self.subjob_tag is not None:
-            t.datastore.pickle_dump(subjobs._DSTORE_OUT.format(self.subjob_fsid, self.subjob_tag))
-            self._printfmt('+ The datastore was written to disk: ' + subjobs._DSTORE_OUT,
-                           self.subjob_fsid, self.subjob_tag)
+            t.datastore.pickle_dump(
+                subjobs._DSTORE_OUT.format(self.subjob_fsid, self.subjob_tag)
+            )
+            self._printfmt(
+                "+ The datastore was written to disk: " + subjobs._DSTORE_OUT,
+                self.subjob_fsid,
+                self.subjob_tag,
+            )
 
     def close(self):
         """This must be the last called method whenever a job finishes."""
@@ -780,23 +906,22 @@ class JobAssistant(footprints.FootprintBase):
         t.sh.signal_intercept_off()
         t.exit()
         if self.unix_exit_code:
-            self._printfmt('Something went wrong :-(')
+            self._printfmt("Something went wrong :-(")
             exit(self.unix_exit_code)
         if self.subjob_tag:
-            self._printfmt('Subjob fast exit :-)')
+            self._printfmt("Subjob fast exit :-)")
             exit(0)
 
 
 class JobAssistantPlugin(footprints.FootprintBase):
-
     _conflicts = []
     _abstract = True
-    _collector = ('jobassistant_plugin',)
+    _collector = ("jobassistant_plugin",)
     _footprint = dict(
-        info = 'Abstract JobAssistant Plugin',
-        attr = dict(
-            kind = dict(),
-            masterja = dict(
+        info="Abstract JobAssistant Plugin",
+        attr=dict(
+            kind=dict(),
+            masterja=dict(
                 type=JobAssistant,
             ),
         ),
@@ -807,7 +932,11 @@ class JobAssistantPlugin(footprints.FootprintBase):
         # Check for potential conflicts
         for conflicting in self._conflicts:
             if conflicting in [p.kind for p in self.masterja.plugins]:
-                raise RuntimeError('"{:s}" conflicts with "{:s}"'.format(self.kind, conflicting))
+                raise RuntimeError(
+                    '"{:s}" conflicts with "{:s}"'.format(
+                        self.kind, conflicting
+                    )
+                )
 
     @staticmethod
     def _printfmt(fmt, *kargs, **kwargs):
@@ -815,45 +944,47 @@ class JobAssistantPlugin(footprints.FootprintBase):
 
 
 class JobAssistantTmpdirPlugin(JobAssistantPlugin):
-
-    _conflicts = ['mtool', 'autodir']
+    _conflicts = ["mtool", "autodir"]
     _footprint = dict(
-        info = 'JobAssistant TMPDIR Plugin',
-        attr = dict(
-            kind = dict(
-                values = ['tmpdir', ]
+        info="JobAssistant TMPDIR Plugin",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "tmpdir",
+                ]
             ),
         ),
     )
 
     def plugable_extra_session_setup(self, t, **kw):
         """Set the rundir according to the TMPDIR variable."""
-        myrundir = kw.get('rundir', None) or t.env.TMPDIR
+        myrundir = kw.get("rundir", None) or t.env.TMPDIR
         if myrundir:
-            t.rundir = kw.get('rundir', myrundir)
-            self._printfmt('+ Current rundir < {:s} >', t.rundir)
+            t.rundir = kw.get("rundir", myrundir)
+            self._printfmt("+ Current rundir < {:s} >", t.rundir)
 
 
 class JobAssistantAutodirPlugin(JobAssistantPlugin):
-
-    _conflicts = ['mtool', 'tmpdir']
+    _conflicts = ["mtool", "tmpdir"]
     _footprint = dict(
-        info = 'JobAssistant Automatic Directory Plugin',
-        attr = dict(
-            kind = dict(
-                values = ['autodir', ]
+        info="JobAssistant Automatic Directory Plugin",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "autodir",
+                ]
             ),
-            appbase = dict(
+            appbase=dict(
                 info="The directory where the application lies.",
             ),
-            jobname = dict(
+            jobname=dict(
                 info="The current job name.",
             ),
-            cleanup = dict(
-                info = "Remove the workind directory when the job is done.",
-                type = bool,
-                optional = True,
-                default = True,
+            cleanup=dict(
+                info="Remove the workind directory when the job is done.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
         ),
     )
@@ -863,18 +994,21 @@ class JobAssistantAutodirPlugin(JobAssistantPlugin):
         self._joblabel = None
 
     def _autodir_tmpdir(self, t):
-        tmpbase = t.sh.path.join(self.appbase, 'run', 'tmp')
+        tmpbase = t.sh.path.join(self.appbase, "run", "tmp")
         if self._joblabel is None:
             with t.sh.cdcontext(tmpbase, create=True):
-                self._joblabel = t.sh.path.basename(tempfile.mkdtemp(
-                    prefix='{:s}_{:s}_'.format(self.jobname,
-                                               date.now().strftime('%Y%m%d_%H%M%S')),
-                    dir='.'
-                ))
+                self._joblabel = t.sh.path.basename(
+                    tempfile.mkdtemp(
+                        prefix="{:s}_{:s}_".format(
+                            self.jobname, date.now().strftime("%Y%m%d_%H%M%S")
+                        ),
+                        dir=".",
+                    )
+                )
         return t.sh.path.join(tmpbase, self._joblabel)
 
     def _autodir_abort(self, t):
-        abortbase = t.sh.path.join(self.appbase, 'run', 'abort')
+        abortbase = t.sh.path.join(self.appbase, "run", "abort")
         if self._joblabel is None:
             self._autodir_tmpdir(t)
         abortdir = t.sh.path.join(abortbase, self._joblabel)
@@ -884,12 +1018,12 @@ class JobAssistantAutodirPlugin(JobAssistantPlugin):
     def plugable_extra_session_setup(self, t, **kw):
         """Set the rundir according to the TMPDIR variable."""
         t.rundir = self._autodir_tmpdir(t)
-        self._printfmt('+ Current rundir < {:s} >', t.rundir)
+        self._printfmt("+ Current rundir < {:s} >", t.rundir)
 
     def plugable_finalise(self, t):
         """Should be called when a job finishes successfully"""
         if self.cleanup:
-            self._printfmt('+ Removing the rundir < {:s} >', t.rundir)
+            self._printfmt("+ Removing the rundir < {:s} >", t.rundir)
             t.sh.cd(t.env.HOME)
             t.sh.rm(self._autodir_tmpdir(t))
 
@@ -901,41 +1035,44 @@ class JobAssistantAutodirPlugin(JobAssistantPlugin):
 
 
 class JobAssistantMtoolPlugin(JobAssistantPlugin):
-
-    _conflicts = ['tmpdir', 'autodir']
+    _conflicts = ["tmpdir", "autodir"]
 
     _footprint = dict(
-        info = 'JobAssistant MTOOL Plugin',
-        attr = dict(
-            kind = dict(
-                values = ['mtool', ]
+        info="JobAssistant MTOOL Plugin",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "mtool",
+                ]
             ),
-            step = dict(
+            step=dict(
                 info="The number of the current MTOOL step.",
                 type=int,
             ),
             stepid=dict(
                 info="The name (id) of the current MTOOL step.",
             ),
-            lastid = dict(
+            lastid=dict(
                 info="The name (id) of the last effective MTOOL step.",
                 optional=True,
             ),
-            mtoolid = dict(
+            mtoolid=dict(
                 info="The MTOOL's job number",
                 type=int,
                 optional=True,
-            )
+            ),
         ),
     )
 
     @property
     def mtool_steps(self):
         """The list of Task' steps asociated a given MTOOL step."""
-        steps_map = {'transfer': ('early-fetch', 'fetch', 'backup', 'late-backup'),
-                     'fetch': ('early-fetch', ),
-                     'compute': ('early-fetch', 'fetch', 'compute', 'backup'),
-                     'backup': ('backup', 'late-backup'), }
+        steps_map = {
+            "transfer": ("early-fetch", "fetch", "backup", "late-backup"),
+            "fetch": ("early-fetch",),
+            "compute": ("early-fetch", "fetch", "compute", "backup"),
+            "backup": ("backup", "late-backup"),
+        }
         try:
             return steps_map[self.stepid]
         except KeyError:
@@ -956,24 +1093,24 @@ class JobAssistantMtoolPlugin(JobAssistantPlugin):
         """Set the rundir according to MTTOL's spool."""
         t.rundir = t.env.MTOOL_STEP_SPOOL
         t.sh.cd(t.rundir)
-        self._printfmt('+ Current rundir < {:s} >', t.rundir)
+        self._printfmt("+ Current rundir < {:s} >", t.rundir)
         # Load the session's data store
         if self.step > 1 and self.masterja.subjob_tag is None:
             t.datastore.pickle_load()
-            self._printfmt('+ The datastore was read from disk.')
+            self._printfmt("+ The datastore was read from disk.")
         # Check that the log directory exists
         if "MTOOL_STEP_LOGFILE" in t.env:
             logfile = t.sh.path.normpath(t.env.MTOOL_STEP_LOGFILE)
             logdir = t.sh.path.dirname(logfile)
             if not t.sh.path.isdir(logdir):
                 t.sh.mkdir(logdir)
-            self._printfmt('+ Current logfile < {:s} >', logfile)
+            self._printfmt("+ Current logfile < {:s} >", logfile)
         # Only allow subjobs in compute steps
-        self.masterja.subjob_allowed = self.stepid == 'compute'
+        self.masterja.subjob_allowed = self.stepid == "compute"
 
     def plugable_toolbox_setup(self, t, **kw):
         """Toolbox MTOOL setup."""
-        if self.stepid == 'compute':
+        if self.stepid == "compute":
             # No network activity during the compute step + promises already made
             vortex.toolbox.active_promise = False
             vortex.toolbox.active_insitu = True
@@ -985,7 +1122,7 @@ class JobAssistantMtoolPlugin(JobAssistantPlugin):
         # Dump the session datastore in the rundir
         if self.masterja.subjob_tag is None:
             t.datastore.pickle_dump()
-            self._printfmt('+ The datastore is dumped to disk')
+            self._printfmt("+ The datastore is dumped to disk")
 
     def plugable_rescue(self, t):
         """Called at the end of a job when something went wrong.
@@ -998,28 +1135,27 @@ class JobAssistantMtoolPlugin(JobAssistantPlugin):
 
 
 class JobAssistantFlowSchedPlugin(JobAssistantPlugin):
-
     _footprint = dict(
-        info = 'JobAssistant Flow Scheduler Plugin',
-        attr = dict(
-            kind = dict(
-                values = ['flow', ]
+        info="JobAssistant Flow Scheduler Plugin",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "flow",
+                ]
             ),
-            backend = dict(
-                values = ['ecflow', 'sms']
-            ),
-            jobidlabels = dict(
+            backend=dict(values=["ecflow", "sms"]),
+            jobidlabels=dict(
                 info="Update the task's jobid label.",
                 default=False,
                 optional=True,
                 type=bool,
             ),
-            mtoolmeters  = dict(
+            mtoolmeters=dict(
                 info="Update the MTOOL's work meter.",
                 default=False,
                 optional=True,
                 type=bool,
-            )
+            ),
         ),
     )
 
@@ -1033,15 +1169,15 @@ class JobAssistantFlowSchedPlugin(JobAssistantPlugin):
         if self._flow_sched_saved_mtplug == 0:
             self._flow_sched_saved_mtplug = None
             for p in self.masterja.plugins:
-                if p.kind == 'mtool':
+                if p.kind == "mtool":
                     self._flow_sched_saved_mtplug = p
         return self._flow_sched_saved_mtplug
 
     def _flow_sched_ids(self, t):
         """Return the jobid and RID."""
         # Simple heuristic to find a job id
-        jid = t.env.PBS_JOBID or t.env.SLURM_JOB_ID or 'localpid'
-        if jid == 'localpid':
+        jid = t.env.PBS_JOBID or t.env.SLURM_JOB_ID or "localpid"
+        if jid == "localpid":
             jid = t.sh.getpid()
         # Find a suitable RID
         mtplug = self._flow_sched_mtool_plugin
@@ -1061,35 +1197,37 @@ class JobAssistantFlowSchedPlugin(JobAssistantPlugin):
             # Configure the action
             jid, rid = self._flow_sched_ids(t)
             label = "{:s}".format(jid)
-            confdict = kw.get('flowscheduler', dict())
-            confdict.setdefault('ECF_RID', rid)
+            confdict = kw.get("flowscheduler", dict())
+            confdict.setdefault("ECF_RID", rid)
             ad.flow_conf(confdict)
 
-            t.sh.highlight('Flow Scheduler ({:s}) Settings'.format(self.backend))
+            t.sh.highlight(
+                "Flow Scheduler ({:s}) Settings".format(self.backend)
+            )
             ad.flow_info()
-            self._printfmt('')
-            self._printfmt('Flow scheduler client path: {:s}', ad.flow_path())
+            self._printfmt("")
+            self._printfmt("Flow scheduler client path: {:s}", ad.flow_path())
 
             # Initialise the flow scheduler
-            mstep_first = getattr(self.masterja, 'mstep_is_first', True)
+            mstep_first = getattr(self.masterja, "mstep_is_first", True)
             mtplug = self._flow_sched_mtool_plugin
             if mstep_first:
                 ad.flow_init(rid)
             if mtplug is not None:
                 label = "{:s} (mtoolid={!s})".format(label, mtplug.mtoolid)
                 if self.mtoolmeters:
-                    ad.flow_meter('work', 1 + (mtplug.step - 1) * 2)
+                    ad.flow_meter("work", 1 + (mtplug.step - 1) * 2)
             if self.jobidlabels:
-                ad.flow_label('jobid', label)
+                ad.flow_label("jobid", label)
 
     def plugable_complete(self, t):
         """Should be called when a job finishes successfully."""
         if self.masterja.subjob_tag is None:
-            mstep_last = getattr(self.masterja, 'mstep_is_last', True)
+            mstep_last = getattr(self.masterja, "mstep_is_last", True)
             mtplug = self._flow_sched_mtool_plugin
             if mtplug is not None:
                 if self.mtoolmeters:
-                    ad.flow_meter('work', 2 + (mtplug.step - 1) * 2)
+                    ad.flow_meter("work", 2 + (mtplug.step - 1) * 2)
             if mstep_last:
                 ad.flow_complete()
 
@@ -1100,35 +1238,40 @@ class JobAssistantFlowSchedPlugin(JobAssistantPlugin):
 
 
 class JobAssistantEpygramPlugin(JobAssistantPlugin):
-
     _footprint = dict(
-        info = 'JobAssistant Plugin to perform the epygram setup',
-        attr = dict(
-            kind = dict(
-                values      = ['epygram_setup', ]
+        info="JobAssistant Plugin to perform the epygram setup",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "epygram_setup",
+                ]
             ),
         ),
     )
 
     def plugable_env_setup(self, t, **kw):  # @UnusedVariable
         # Is epygram here ?
-        epygram_re = re.compile(r'.*epygram$')
+        epygram_re = re.compile(r".*epygram$")
         epygram_path = [bool(epygram_re.match(p)) for p in sys.path]
         if any(epygram_path):
             # Add eccodes and site subdirectories if necessary
             i_epygram = epygram_path.index(True)
-            logger.info('Epygram package found in path: %s', sys.path[i_epygram])
-            for spath in ('eccodes_python', 'site'):
+            logger.info(
+                "Epygram package found in path: %s", sys.path[i_epygram]
+            )
+            for spath in ("eccodes_python", "site"):
                 full_spath = t.sh.path.join(sys.path[i_epygram], spath)
                 if full_spath not in sys.path:
-                    logger.info('Extending python path with: %s', full_spath)
+                    logger.info("Extending python path with: %s", full_spath)
                     sys.path.insert(i_epygram + 1, full_spath)
-                edir_path = t.sh.path.join(sys.path[i_epygram], 'eccodes_dir')
+                edir_path = t.sh.path.join(sys.path[i_epygram], "eccodes_dir")
             if t.sh.path.exists(edir_path):
-                logger.info('ECCODES_DIR environment variable setup to %s', edir_path)
+                logger.info(
+                    "ECCODES_DIR environment variable setup to %s", edir_path
+                )
                 t.env.ECCODES_DIR = edir_path
             # In any case, run with the Agg matplotlib backend
-            t.env.MPLBACKEND = 'Agg'
+            t.env.MPLBACKEND = "Agg"
 
 
 class JobAssistantAppWideLockPlugin(JobAssistantPlugin):
@@ -1157,8 +1300,8 @@ class JobAssistantAppWideLockPlugin(JobAssistantPlugin):
 
     _abstract = True
     _footprint = dict(
-        info='JobAssistant to deal with application wide locks.',
-        attr = dict(
+        info="JobAssistant to deal with application wide locks.",
+        attr=dict(
             label=dict(
                 info="The name of the lock.",
             ),
@@ -1196,31 +1339,44 @@ class JobAssistantAppWideLockPlugin(JobAssistantPlugin):
 
     def plugable_job_final_init(self, t, **kw):
         """Acquire the lock on job startup."""
-        self._appwide_lock_label = self.label.format(** self.masterja.special_variables)
+        self._appwide_lock_label = self.label.format(
+            **self.masterja.special_variables
+        )
         if self.acquire:
-            if getattr(self.masterja, 'mstep_is_first', True):
-                logger.info("Acquiring the '%s' application wide lock",
-                            self._appwide_lock_label)
-                self._appwide_lock_acquired = t.sh.appwide_lock(self._appwide_lock_label,
-                                                                blocking=self.blocking,
-                                                                timeout=self.blocking_timeout)
+            if getattr(self.masterja, "mstep_is_first", True):
+                logger.info(
+                    "Acquiring the '%s' application wide lock",
+                    self._appwide_lock_label,
+                )
+                self._appwide_lock_acquired = t.sh.appwide_lock(
+                    self._appwide_lock_label,
+                    blocking=self.blocking,
+                    timeout=self.blocking_timeout,
+                )
                 if not self._appwide_lock_acquired:
-                    logger.error("Acquiring the '%s' application wide lock failed.",
-                                 self._appwide_lock_label)
-                    raise RuntimeError("Unable to acquire the '{:s}' application wide lock."
-                                       .format(self._appwide_lock_label))
+                    logger.error(
+                        "Acquiring the '%s' application wide lock failed.",
+                        self._appwide_lock_label,
+                    )
+                    raise RuntimeError(
+                        "Unable to acquire the '{:s}' application wide lock.".format(
+                            self._appwide_lock_label
+                        )
+                    )
 
     def _appwide_lock_release(self, t):
         """Actualy release the lock."""
         if self._appwide_lock_label:
-            logger.info("Releasing the '%s' application wide lock",
-                        self._appwide_lock_label)
+            logger.info(
+                "Releasing the '%s' application wide lock",
+                self._appwide_lock_label,
+            )
             t.sh.appwide_unlock(self._appwide_lock_label)
 
     def plugable_complete(self, t):
         """Should be called when a job finishes successfully."""
         if self.release:
-            if getattr(self.masterja, 'mstep_is_last', True):
+            if getattr(self.masterja, "mstep_is_last", True):
                 self._appwide_lock_release(t)
 
     def plugable_rescue(self, t):
@@ -1233,22 +1389,27 @@ class JobAssistantRdMailSetupPlugin(JobAssistantPlugin):
     """Activate/Deactivate mail actions for R&D tasks."""
 
     _footprint = dict(
-        info='JobAssistant to deal with application wide locks.',
-        attr = dict(
+        info="JobAssistant to deal with application wide locks.",
+        attr=dict(
             kind=dict(
-                values=['rd_mail_setup', ]
+                values=[
+                    "rd_mail_setup",
+                ]
             ),
-        )
+        ),
     )
 
     def plugable_actions_setup(self, t, **kw):
         """Acquire the lock on job startup."""
-        if self.masterja.conf.get('mail_to', None):
-            todo = {a for a in ad.actions
-                    if a.endswith('mail') and a not in ('mail', 'opmail')}
+        if self.masterja.conf.get("mail_to", None):
+            todo = {
+                a
+                for a in ad.actions
+                if a.endswith("mail") and a not in ("mail", "opmail")
+            }
             for candidate in todo:
                 for action in ad.candidates(candidate):
-                    logger.info('Activating the << %s >> action.', action.kind)
+                    logger.info("Activating the << %s >> action.", action.kind)
                     action.on()
 
 
@@ -1256,21 +1417,28 @@ class JobAssistantUenvGdataDetourPlugin(JobAssistantPlugin):
     """Setup an alternative location for GCO data (gget) referenced in Uenvs."""
 
     _footprint = dict(
-        info='JobAssistant to deal with Uenv alternative locations .',
-        attr = dict(
+        info="JobAssistant to deal with Uenv alternative locations .",
+        attr=dict(
             kind=dict(
-                values=['uenv_gdata_detour', ]
+                values=[
+                    "uenv_gdata_detour",
+                ]
             ),
-        )
+        ),
     )
 
     def plugable_extra_session_setup(self, t, **kw):
         """Acquire the lock on job startup."""
-        detour = self.masterja.conf.get('uenv_gdata_detour', None)
+        detour = self.masterja.conf.get("uenv_gdata_detour", None)
         if detour:
             from vortex_gco.tools.uenv import config as u_config
-            u_config('gdata_detour', value=detour)
-            logger.info('gdata referenced in uenvs will be taken in the "@%s" uget location.',
-                        detour)
+
+            u_config("gdata_detour", value=detour)
+            logger.info(
+                'gdata referenced in uenvs will be taken in the "@%s" uget location.',
+                detour,
+            )
         else:
-            logger.info('No relevant uenv_gdata_detour variable was found in the job conf.')
+            logger.info(
+                "No relevant uenv_gdata_detour variable was found in the job conf."
+            )

--- a/src/vortex/layout/nodes.py
+++ b/src/vortex/layout/nodes.py
@@ -29,33 +29,38 @@ from vortex.util.config import GenericConfigParser
 logger = loggers.getLogger(__name__)
 
 #: Export real nodes.
-__all__ = ['Driver', 'Task', 'Family']
+__all__ = ["Driver", "Task", "Family"]
 
-OBSERVER_TAG = 'Layout-Nodes'
+OBSERVER_TAG = "Layout-Nodes"
 
 #: Definition of a named tuple for Node Statuses
-_NodeStatusTuple = collections.namedtuple('_NodeStatusTuple',
-                                          ['CREATED', 'READY', 'RUNNING', 'DONE', 'FAILED'])
+_NodeStatusTuple = collections.namedtuple(
+    "_NodeStatusTuple", ["CREATED", "READY", "RUNNING", "DONE", "FAILED"]
+)
 
 #: Predefined Node Status values
-NODE_STATUS = _NodeStatusTuple(CREATED='created',
-                               READY='ready to start',
-                               RUNNING='running',
-                               DONE='done',
-                               FAILED='FAILED')
+NODE_STATUS = _NodeStatusTuple(
+    CREATED="created",
+    READY="ready to start",
+    RUNNING="running",
+    DONE="done",
+    FAILED="FAILED",
+)
 
 #: Definition of a named tuple for Node on_error behaviour
-_NodeOnErrorTuple = collections.namedtuple('_NodeOnErrorTuple',
-                                           ['FAIL', 'DELAYED_FAIL', 'CONTINUE'])
+_NodeOnErrorTuple = collections.namedtuple(
+    "_NodeOnErrorTuple", ["FAIL", "DELAYED_FAIL", "CONTINUE"]
+)
 
 #: Predefined Node Status values
-NODE_ON_ERROR = _NodeOnErrorTuple(FAIL='fail',
-                                  DELAYED_FAIL='delayed_fail',
-                                  CONTINUE='continue')
+NODE_ON_ERROR = _NodeOnErrorTuple(
+    FAIL="fail", DELAYED_FAIL="delayed_fail", CONTINUE="continue"
+)
 
 
 class PreviousFailureError(RuntimeError):
     """This exception is raised in multistep jobs (when a failure already occurred)."""
+
     pass
 
 
@@ -64,6 +69,7 @@ class RequestedFailureError(RuntimeError):
     This exception is raised, when a Node finishes, if the `fail_at_the_end`
     property is True.
     """
+
     pass
 
 
@@ -92,7 +98,7 @@ class NiceLayout(observer.Observer):
 
     def highlight(self, *args, **kw):
         """Proxy to :meth:`~vortex.tools.systems.subtitle` method."""
-        return self.sh.highlight(*args, bchar=' #', bline0=False, **kw)
+        return self.sh.highlight(*args, bchar=" #", bline0=False, **kw)
 
     def subtitle(self, *args, **kw):
         """Proxy to :meth:`~vortex.tools.systems.subtitle` method."""
@@ -109,65 +115,82 @@ class NiceLayout(observer.Observer):
         if kw:
             maxlen = max([len(x) for x in kw.keys()])
             for k, v in sorted(kw.items()):
-                print(' +', k.ljust(maxlen), '=', str(v))
+                print(" +", k.ljust(maxlen), "=", str(v))
             print()
         else:
             print(" + ...\n")
 
     def _print_traceback(self):
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        print('Exception type: {!s}'.format(exc_type))
-        print('Exception values: {!s}'.format(exc_value))
-        self.header('Traceback Error / BEGIN')
+        print("Exception type: {!s}".format(exc_type))
+        print("Exception values: {!s}".format(exc_value))
+        self.header("Traceback Error / BEGIN")
         print("\n".join(traceback.format_tb(exc_traceback)))
-        self.header('Traceback Error / END')
+        self.header("Traceback Error / END")
 
     @property
     def _ds_extra(self):
-        return {'tag': self.tag, 'class': self.__class__.__name__}
+        return {"tag": self.tag, "class": self.__class__.__name__}
 
     def _nicelayout_init(self, kw):
         """Initialise generic stuff."""
-        self._on_error = kw.get('on_error', NODE_ON_ERROR.FAIL)
+        self._on_error = kw.get("on_error", NODE_ON_ERROR.FAIL)
         if self._on_error not in NODE_ON_ERROR:
-            raise ValueError('Erroneous value for on_error: {!s}'.format(self._on_error))
+            raise ValueError(
+                "Erroneous value for on_error: {!s}".format(self._on_error)
+            )
         self._obs_board = observer.get(tag=OBSERVER_TAG)
-        self._obs_board.notify_new(self, dict(tag=self.tag, typename=type(self).__name__,
-                                              status=self.status,
-                                              on_error=self.on_error))
+        self._obs_board.notify_new(
+            self,
+            dict(
+                tag=self.tag,
+                typename=type(self).__name__,
+                status=self.status,
+                on_error=self.on_error,
+            ),
+        )
         self._obs_board.register(self)
         # Increment the mstep counter
-        self.ticket.datastore.insert('layout_mstep_counter', self._ds_extra,
-                                     self.mstep_counter + 1, readonly=False)
+        self.ticket.datastore.insert(
+            "layout_mstep_counter",
+            self._ds_extra,
+            self.mstep_counter + 1,
+            readonly=False,
+        )
 
     def updobsitem(self, item, info):
-        if info.get('observerboard', '') == OBSERVER_TAG:
-            o_id = (info['tag'], info['typename'])
-            if info.get('subjob_replay', False):
+        if info.get("observerboard", "") == OBSERVER_TAG:
+            o_id = (info["tag"], info["typename"])
+            if info.get("subjob_replay", False):
                 # If the status/delayed_error_flag chatter is being replayed,
                 # deal with it
                 if o_id == (self.tag, type(self).__name__):
-                    if 'new_status' in info:
-                        self._store_status(info['new_status'])
-                    if info.get('delayed_error_flag', False):
+                    if "new_status" in info:
+                        self._store_status(info["new_status"])
+                    if info.get("delayed_error_flag", False):
                         self._store_delayed_error_flag(True)
             else:
-                if (self.status != NODE_STATUS.CREATED and
-                        any([o_id == (k.tag, type(k).__name__) for k in self.contents])):
+                if self.status != NODE_STATUS.CREATED and any(
+                    [o_id == (k.tag, type(k).__name__) for k in self.contents]
+                ):
                     # We are only interested in child nodes
-                    if info.get('new_status', None) == NODE_STATUS.FAILED:
+                    if info.get("new_status", None) == NODE_STATUS.FAILED:
                         # On kid failure, update my own status
-                        if info['on_error'] == NODE_ON_ERROR.FAIL:
+                        if info["on_error"] == NODE_ON_ERROR.FAIL:
                             self.status = NODE_STATUS.FAILED
-                    if 'delayed_error_flag' in info:
+                    if "delayed_error_flag" in info:
                         # Propagate the delayed error flag
                         self.delayed_error_flag = True
 
     @property
     def mstep_counter(self):
         """Count how many times this object was created."""
-        return self.ticket.datastore.get('layout_mstep_counter', self._ds_extra,
-                                         default_payload=0, readonly=False)
+        return self.ticket.datastore.get(
+            "layout_mstep_counter",
+            self._ds_extra,
+            default_payload=0,
+            readonly=False,
+        )
 
     @property
     def on_error(self):
@@ -177,55 +200,92 @@ class NiceLayout(observer.Observer):
     @property
     def delayed_error_flag(self):
         """Return the delayed error flag."""
-        return self.ticket.datastore.get('layout_delayed_error_flag', self._ds_extra,
-                                         default_payload=False, readonly=False)
+        return self.ticket.datastore.get(
+            "layout_delayed_error_flag",
+            self._ds_extra,
+            default_payload=False,
+            readonly=False,
+        )
 
     def _store_delayed_error_flag(self, value):
-        self.ticket.datastore.insert('layout_delayed_error_flag', self._ds_extra,
-                                     value, readonly=False)
+        self.ticket.datastore.insert(
+            "layout_delayed_error_flag", self._ds_extra, value, readonly=False
+        )
 
     @delayed_error_flag.setter
     def delayed_error_flag(self, value):
         """Set the status of the current Node/Driver."""
         if not bool(value):
-            raise ValueError('True is the only possible value for delayed_error_flag')
+            raise ValueError(
+                "True is the only possible value for delayed_error_flag"
+            )
         if not self.delayed_error_flag:
-            self._obs_board.notify_upd(self, dict(tag=self.tag, typename=type(self).__name__,
-                                                  delayed_error_flag=True))
+            self._obs_board.notify_upd(
+                self,
+                dict(
+                    tag=self.tag,
+                    typename=type(self).__name__,
+                    delayed_error_flag=True,
+                ),
+            )
             self._store_delayed_error_flag(True)
 
     @property
     def status(self):
         """Return the status of the current Node/Driver."""
-        return self.ticket.datastore.get('layout_status', self._ds_extra,
-                                         default_payload=NODE_STATUS.CREATED, readonly=False)
+        return self.ticket.datastore.get(
+            "layout_status",
+            self._ds_extra,
+            default_payload=NODE_STATUS.CREATED,
+            readonly=False,
+        )
 
     @property
     def status_mstep_counter(self):
         """Return the number of the multi-step that last updated the status."""
-        return self.ticket.datastore.get('layout_status_mstep', self._ds_extra,
-                                         default_payload=0, readonly=False)
+        return self.ticket.datastore.get(
+            "layout_status_mstep",
+            self._ds_extra,
+            default_payload=0,
+            readonly=False,
+        )
 
     def _store_status(self, value):
-        self.ticket.datastore.insert('layout_status', self._ds_extra,
-                                     value, readonly=False)
+        self.ticket.datastore.insert(
+            "layout_status", self._ds_extra, value, readonly=False
+        )
         self._store_status_mstep_counter()
 
     def _store_status_mstep_counter(self):
-        self.ticket.datastore.insert('layout_status_mstep', self._ds_extra,
-                                     self.mstep_counter, readonly=False)
+        self.ticket.datastore.insert(
+            "layout_status_mstep",
+            self._ds_extra,
+            self.mstep_counter,
+            readonly=False,
+        )
 
     @status.setter
     def status(self, value):
         """Set the status of the current Node/Driver."""
         if value not in NODE_STATUS:
-            raise ValueError('Erroneous value for the node status: {!s}'.format(value))
+            raise ValueError(
+                "Erroneous value for the node status: {!s}".format(value)
+            )
         if value != self.status:
-            self._obs_board.notify_upd(self, dict(tag=self.tag, typename=type(self).__name__,
-                                                  previous_status=self.status,
-                                                  new_status=value,
-                                                  on_error=self.on_error))
-            if value == NODE_STATUS.FAILED and self.on_error == NODE_ON_ERROR.DELAYED_FAIL:
+            self._obs_board.notify_upd(
+                self,
+                dict(
+                    tag=self.tag,
+                    typename=type(self).__name__,
+                    previous_status=self.status,
+                    new_status=value,
+                    on_error=self.on_error,
+                ),
+            )
+            if (
+                value == NODE_STATUS.FAILED
+                and self.on_error == NODE_ON_ERROR.DELAYED_FAIL
+            ):
                 self.delayed_error_flag = True
             self._store_status(value)
         else:
@@ -240,43 +300,71 @@ class NiceLayout(observer.Observer):
     @property
     def any_currently_running(self):
         """Return True if self or any of the subnodes is running."""
-        running = (self.status == NODE_STATUS.RUNNING and
-                   self.status_mstep_counter == self.mstep_counter)
+        running = (
+            self.status == NODE_STATUS.RUNNING
+            and self.status_mstep_counter == self.mstep_counter
+        )
         return running or any([k.any_currently_running for k in self.contents])
 
     def tree_str(self, statuses_filter=(), with_conf=False):
         """Print the node's tree."""
         # Kids contribution
-        filtered_kids = [k for k in self.contents
-                         if not statuses_filter or k.status in statuses_filter]
-        kids_str = ['\n'.join('{:s}{:s} {:s}'.format('|' if i == 0 or ikid < len(filtered_kids) - 1 else ' ',
-                                                     '--' if i == 0 else '  ',
-                                                     line)
-                              for i, line in enumerate(kid.tree_str(statuses_filter=statuses_filter,
-                                                                    with_conf=with_conf).split('\n')))
-                    for ikid, kid in enumerate(filtered_kids)]
+        filtered_kids = [
+            k
+            for k in self.contents
+            if not statuses_filter or k.status in statuses_filter
+        ]
+        kids_str = [
+            "\n".join(
+                "{:s}{:s} {:s}".format(
+                    "|" if i == 0 or ikid < len(filtered_kids) - 1 else " ",
+                    "--" if i == 0 else "  ",
+                    line,
+                )
+                for i, line in enumerate(
+                    kid.tree_str(
+                        statuses_filter=statuses_filter, with_conf=with_conf
+                    ).split("\n")
+                )
+            )
+            for ikid, kid in enumerate(filtered_kids)
+        ]
         # Myself
         tree = []
         if not statuses_filter or self.status in statuses_filter:
             if len(statuses_filter) != 1:
-                me_fmt = '{tag:s} ({what:s}) -> {status:s}'
+                me_fmt = "{tag:s} ({what:s}) -> {status:s}"
             else:
-                me_fmt = '{tag:s} ({what:s})'
+                me_fmt = "{tag:s} ({what:s})"
             x_status = self.status
-            if x_status == NODE_STATUS.RUNNING and self.status_mstep_counter < self.mstep_counter:
+            if (
+                x_status == NODE_STATUS.RUNNING
+                and self.status_mstep_counter < self.mstep_counter
+            ):
                 x_status = "interrupted because of others errors"
-            me = me_fmt.format(tag=self.tag, what=self.__class__.__name__, status=x_status)
-            if self.status == NODE_STATUS.FAILED and self.on_error != NODE_ON_ERROR.FAIL:
-                me += ' (but {:s})'.format(self.on_error)
+            me = me_fmt.format(
+                tag=self.tag, what=self.__class__.__name__, status=x_status
+            )
+            if (
+                self.status == NODE_STATUS.FAILED
+                and self.on_error != NODE_ON_ERROR.FAIL
+            ):
+                me += " (but {:s})".format(self.on_error)
             tree.append(me)
             if with_conf:
                 cd = self.confdiff
                 if cd:
-                    tree.extend(['{:s}      {:s}={!s}'.format('|' if self.contents else ' ', k, v)
-                                 for k, v in sorted(cd.items())])
+                    tree.extend(
+                        [
+                            "{:s}      {:s}={!s}".format(
+                                "|" if self.contents else " ", k, v
+                            )
+                            for k, v in sorted(cd.items())
+                        ]
+                    )
         # Myself + kids
         tree.extend(kids_str)
-        return '\n'.join(tree)
+        return "\n".join(tree)
 
     def __str__(self):
         """Print the node's tree."""
@@ -308,28 +396,30 @@ class Node(getbytag.GetByTag, NiceLayout):
     """
 
     def __init__(self, kw):
-        logger.debug('Node initialisation %s', repr(self))
+        logger.debug("Node initialisation %s", repr(self))
         self.options = dict()
-        self.play = kw.pop('play', False)
-        self._ticket = kw.pop('ticket', None)
+        self.play = kw.pop("play", False)
+        self._ticket = kw.pop("ticket", None)
         if self._ticket is None:
-            raise ValueError("The session's ticket must be provided (using a `ticket` argument)")
-        self._configtag = kw.pop('config_tag', self.tag)
-        self._active_cb = kw.pop('active_callback', None)
+            raise ValueError(
+                "The session's ticket must be provided (using a `ticket` argument)"
+            )
+        self._configtag = kw.pop("config_tag", self.tag)
+        self._active_cb = kw.pop("active_callback", None)
         if self._active_cb is not None and not callable(self._active_cb):
             raise ValueError("If provided, active_callback must be a callable")
-        self._locprefix = kw.pop('special_prefix', 'OP_').upper()
-        self._subjobok = kw.pop('subjob_allowed', True)
-        self._subjobtag = kw.pop('subjob_tag', None)
-        self._cycle_cb = kw.pop('register_cycle_prefix', None)
-        j_assist = kw.pop('jobassistant', None)
+        self._locprefix = kw.pop("special_prefix", "OP_").upper()
+        self._subjobok = kw.pop("subjob_allowed", True)
+        self._subjobtag = kw.pop("subjob_tag", None)
+        self._cycle_cb = kw.pop("register_cycle_prefix", None)
+        j_assist = kw.pop("jobassistant", None)
         if j_assist is not None:
             self._locprefix = j_assist.special_prefix.upper()
             self._cycle_cb = j_assist.register_cycle
             self._subjobok = j_assist.subjob_allowed
             self._subjobtag = j_assist.subjob_tag
-        self._mstep_job_last = kw.pop('mstep_job_last', True)
-        self._dryrun = kw.pop('dryrun', False)
+        self._mstep_job_last = kw.pop("mstep_job_last", True)
+        self._dryrun = kw.pop("dryrun", False)
         self._conf = None
         self._parentconf = None
         self._activenode = None
@@ -338,17 +428,18 @@ class Node(getbytag.GetByTag, NiceLayout):
 
     def _args_loopclone(self, tagsuffix, extras):  # @UnusedVariable
         """All the necessary arguments to build a copy of this object."""
-        argsdict = dict(play=self.play,
-                        ticket=self.ticket,
-                        config_tag=self.config_tag,
-                        active_callback=self._active_cb,
-                        special_prefix=self._locprefix,
-                        register_cycle_prefix=self._cycle_cb,
-                        subjob_tag=self._subjobtag,
-                        subjob_allowed=self._subjobok,
-                        mstep_job_last=self._mstep_job_last,
-                        dryrun=self._dryrun
-                        )
+        argsdict = dict(
+            play=self.play,
+            ticket=self.ticket,
+            config_tag=self.config_tag,
+            active_callback=self._active_cb,
+            special_prefix=self._locprefix,
+            register_cycle_prefix=self._cycle_cb,
+            subjob_tag=self._subjobtag,
+            subjob_allowed=self._subjobok,
+            mstep_job_last=self._mstep_job_last,
+            dryrun=self._dryrun,
+        )
         argsdict.update(self.options)
         return argsdict
 
@@ -364,7 +455,7 @@ class Node(getbytag.GetByTag, NiceLayout):
     @classmethod
     def tag_clean(cls, tag):
         """Lower case, space-free and underscore-free tag."""
-        return tag.lower().replace(' ', '')
+        return tag.lower().replace(" ", "")
 
     @property
     def ticket(self):
@@ -381,15 +472,22 @@ class Node(getbytag.GetByTag, NiceLayout):
     @property
     def confdiff(self):
         cs = ConfigSet()
-        cs.update({k: v for k, v in self._conf.items()
-                  if k not in self._parentconf or self._parentconf[k] != v})
+        cs.update(
+            {
+                k: v
+                for k, v in self._conf.items()
+                if k not in self._parentconf or self._parentconf[k] != v
+            }
+        )
         return cs
 
     @property
     def activenode(self):
         if self._activenode is None:
             if self.conf is None:
-                raise RuntimeError('Setup the configuration object before calling activenode !')
+                raise RuntimeError(
+                    "Setup the configuration object before calling activenode !"
+                )
             self._activenode = self._active_cb is None or self._active_cb(self)
         return self._activenode
 
@@ -415,14 +513,22 @@ class Node(getbytag.GetByTag, NiceLayout):
     @property
     def fail_at_the_end(self):
         """Tells whether the Node should fail when it reaches the end of 'run'."""
-        return self.ticket.datastore.get('layout_fail_at_the_end', self._ds_extra,
-                                         default_payload=False, readonly=False)
+        return self.ticket.datastore.get(
+            "layout_fail_at_the_end",
+            self._ds_extra,
+            default_payload=False,
+            readonly=False,
+        )
 
     @fail_at_the_end.setter
     def fail_at_the_end(self, value):
         """Tells whether the Node should fail when it reaches the end of 'run'."""
-        self.ticket.datastore.insert('layout_fail_at_the_end', self._ds_extra,
-                                     bool(value), readonly=False)
+        self.ticket.datastore.insert(
+            "layout_fail_at_the_end",
+            self._ds_extra,
+            bool(value),
+            readonly=False,
+        )
 
     def build_context(self):
         """Build the context and subcontexts of the current node."""
@@ -461,12 +567,12 @@ class Node(getbytag.GetByTag, NiceLayout):
         self._oldctx = self.ticket.context
         ctx = self.ticket.context.switch(self.tag)
         ctx.cocoon()
-        logger.debug('Node context directory <%s>', self.sh.getcwd())
+        logger.debug("Node context directory <%s>", self.sh.getcwd())
         try:
             yield
         finally:
             ctx.free_resources()
-            logger.debug('Exit context directory <%s>', self.sh.getcwd())
+            logger.debug("Exit context directory <%s>", self.sh.getcwd())
             self._oldctx.activate()
             self.ticket.context.cocoon()
 
@@ -481,7 +587,11 @@ class Node(getbytag.GetByTag, NiceLayout):
             self.status = NODE_STATUS.FAILED
             if extra_verbose or self.on_error != NODE_ON_ERROR.FAIL:
                 # Mask the exception
-                self.subtitle('An exception occurred (on_error={:s})'.format(self.on_error))
+                self.subtitle(
+                    "An exception occurred (on_error={:s})".format(
+                        self.on_error
+                    )
+                )
                 self._print_traceback()
             if self.on_error == NODE_ON_ERROR.FAIL:
                 raise
@@ -504,7 +614,10 @@ class Node(getbytag.GetByTag, NiceLayout):
         # This configuration is updated with any section with the current tag name
         updconf = conf_global.get(self.config_tag, dict())
         if self.mstep_counter <= 1:
-            self.nicedump(' '.join(('Configuration for', self.realkind, self.tag)), **updconf)
+            self.nicedump(
+                " ".join(("Configuration for", self.realkind, self.tag)),
+                **updconf,
+            )
         self.conf.update(updconf)
 
         # Add exported local variables
@@ -513,8 +626,11 @@ class Node(getbytag.GetByTag, NiceLayout):
         # Add potential options
         if self.options:
             if self.mstep_counter <= 1:
-                self.nicedump('Update conf with last minute arguments',
-                              titlecallback=self.highlight, **self.options)
+                self.nicedump(
+                    "Update conf with last minute arguments",
+                    titlecallback=self.highlight,
+                    **self.options,
+                )
             self.conf.update(self.options)
 
         if self.activenode:
@@ -522,27 +638,35 @@ class Node(getbytag.GetByTag, NiceLayout):
             for node in self.contents:
                 node.setconf(self.conf, conf_global)
         else:
-            logger.info('Under present conditions/configuration, this node will not be activated.')
+            logger.info(
+                "Under present conditions/configuration, this node will not be activated."
+            )
 
     def localenv(self):
         """Dump the actual env variables."""
-        self.header('ENV catalog')
+        self.header("ENV catalog")
         self.env.mydump()
 
     def local2conf(self):
         """Set some parameters if defined in environment but not in actual conf."""
         autoconf = dict()
         localstrip = len(self._locprefix)
-        for localvar in sorted([x for x in self.env.keys() if x.startswith(self._locprefix)]):
-            if (localvar[localstrip:] not in self.conf or
-                    (localvar[localstrip:] not in ('rundate', ) and
-                     self.env[localvar] is not None and
-                     self.env[localvar] != self.conf[localvar[localstrip:]])):
+        for localvar in sorted(
+            [x for x in self.env.keys() if x.startswith(self._locprefix)]
+        ):
+            if localvar[localstrip:] not in self.conf or (
+                localvar[localstrip:] not in ("rundate",)
+                and self.env[localvar] is not None
+                and self.env[localvar] != self.conf[localvar[localstrip:]]
+            ):
                 autoconf[localvar[localstrip:].lower()] = self.env[localvar]
         if autoconf:
             if self.mstep_counter <= 1:
-                self.nicedump('Populate conf with local variables',
-                              titlecallback=self.highlight, **autoconf)
+                self.nicedump(
+                    "Populate conf with local variables",
+                    titlecallback=self.highlight,
+                    **autoconf,
+                )
             self.conf.update(autoconf)
 
     def conf2io(self):
@@ -551,10 +675,10 @@ class Node(getbytag.GetByTag, NiceLayout):
 
     def xp2conf(self):
         """Set the actual experiment value -- Could be the name of the op suite if any."""
-        if 'xpid' not in self.conf:
-            self.conf.xpid = self.conf.get('suite', self.env.VORTEX_XPID)
+        if "xpid" not in self.conf:
+            self.conf.xpid = self.conf.get("suite", self.env.VORTEX_XPID)
         if self.conf.xpid is None:
-            raise ValueError('Could not set a proper experiment id.')
+            raise ValueError("Could not set a proper experiment id.")
 
     def register_cycle(self, cyclename):
         """Adds a new cycle to genv if a proper callback is defined."""
@@ -566,12 +690,12 @@ class Node(getbytag.GetByTag, NiceLayout):
     def cycles(self):
         """Update and register some configuration cycles."""
 
-        other_cycles = [x for x in self.conf.keys() if x.endswith('_cycle')]
-        if 'cycle' in self.conf or other_cycles:
+        other_cycles = [x for x in self.conf.keys() if x.endswith("_cycle")]
+        if "cycle" in self.conf or other_cycles:
             self.header("Registering cycles")
 
         # At least, look for the main cycle
-        if 'cycle' in self.conf:
+        if "cycle" in self.conf:
             self.register_cycle(self.conf.cycle)
 
         # Have a look to other cycles
@@ -580,25 +704,25 @@ class Node(getbytag.GetByTag, NiceLayout):
 
     def geometries(self):
         """Setup geometries according to actual tag."""
-        thisgeo = self.tag + '_geometry'
+        thisgeo = self.tag + "_geometry"
         if thisgeo in self.conf:
             self.conf.geometry = self.conf.get(thisgeo)
-        if 'geometry' not in self.conf:
-            logger.warning('No default geometry defined !')
+        if "geometry" not in self.conf:
+            logger.warning("No default geometry defined !")
 
     def defaults(self, extras):
         """Set toolbox defaults, extended with actual arguments ``extras``."""
         t = self.ticket
         toolbox.defaults(
             model=t.glove.vapp,
-            namespace=self.conf.get('namespace', Namespace('vortex.cache.fr')),
-            gnamespace=self.conf.get('gnamespace', Namespace('gco.multi.fr')),
+            namespace=self.conf.get("namespace", Namespace("vortex.cache.fr")),
+            gnamespace=self.conf.get("gnamespace", Namespace("gco.multi.fr")),
         )
 
-        if 'rundate' in self.conf:
-            toolbox.defaults['date'] = self.conf.rundate
+        if "rundate" in self.conf:
+            toolbox.defaults["date"] = self.conf.rundate
 
-        for optk in ('cutoff', 'geometry', 'cycle', 'model'):
+        for optk in ("cutoff", "geometry", "cycle", "model"):
             if optk in self.conf:
                 value = self.conf.get(optk)
                 if isinstance(value, dict):
@@ -606,31 +730,33 @@ class Node(getbytag.GetByTag, NiceLayout):
                 toolbox.defaults[optk] = self.conf.get(optk)
 
         toolbox.defaults(**extras)
-        self.header('Toolbox defaults')
+        self.header("Toolbox defaults")
         toolbox.defaults.show()
 
     def setup(self, **kw):
         """A methodic way to build the conf of the node."""
-        self.subtitle(self.realkind.upper() + ' setup')
+        self.subtitle(self.realkind.upper() + " setup")
         self.localenv()
         self.local2conf()
         self.conf2io()
         self.xp2conf()
         if kw:
             if self.mstep_counter <= 1:
-                self.nicedump('Update conf with last minute arguments', **kw)
+                self.nicedump("Update conf with last minute arguments", **kw)
             self.conf.update(kw)
         self.cycles()
         self.geometries()
-        self.defaults(kw.get('defaults', dict()))
+        self.defaults(kw.get("defaults", dict()))
 
     def summary(self):
         """Dump actual parameters of the configuration."""
         if self.mstep_counter <= 1:
-            self.nicedump('Complete parameters', **self.conf)
+            self.nicedump("Complete parameters", **self.conf)
         else:
-            self.header('Complete parameters')
-            print("Silent Node' setup: please refer to the first job step for more details")
+            self.header("Complete parameters")
+            print(
+                "Silent Node' setup: please refer to the first job step for more details"
+            )
 
     def complete(self):
         """Some cleaning and completion status."""
@@ -643,8 +769,10 @@ class Node(getbytag.GetByTag, NiceLayout):
     def run(self, sjob_activated=True):
         """Execution driver: setup, run, complete... (if needed)."""
         if self._dryrun:
-            raise RuntimeError('This Node was initialised with "dryrun". ' +
-                               'It is not allowed to call run().')
+            raise RuntimeError(
+                'This Node was initialised with "dryrun". '
+                + "It is not allowed to call run()."
+            )
         if self.activenode:
             try:
                 self._actual_run(sjob_activated)
@@ -654,8 +782,8 @@ class Node(getbytag.GetByTag, NiceLayout):
             else:
                 if self.fail_at_the_end:
                     raise RequestedFailureError(
-                        'An error occurred in {:s}. '.format(self.tag) +
-                        'Please dive into the present log to understand why.'
+                        "An error occurred in {:s}. ".format(self.tag)
+                        + "Please dive into the present log to understand why."
                     )
 
     def filter_execution_error(self, exc):  # @UnusedVariable
@@ -712,7 +840,7 @@ class Node(getbytag.GetByTag, NiceLayout):
 
         :note: Do not re-raised the **exc** exception in this method.
         """
-        return self.conf.get('delay_component_errors', False)
+        return self.conf.get("delay_component_errors", False)
 
     def component_runner(self, tbalgo, tbx=(None,), **kwargs):
         """Run the binaries listed in tbx using the tbalgo algo component.
@@ -721,40 +849,63 @@ class Node(getbytag.GetByTag, NiceLayout):
         """
         # it may be necessary to setup a default value for OpenMP...
         env_update = dict()
-        if 'openmp' not in self.conf or not isinstance(self.conf.openmp, (list, tuple)):
-            env_update['OMP_NUM_THREADS'] = int(self.conf.get('openmp', 1))
+        if "openmp" not in self.conf or not isinstance(
+            self.conf.openmp, (list, tuple)
+        ):
+            env_update["OMP_NUM_THREADS"] = int(self.conf.get("openmp", 1))
 
         # If some mpiopts are in the config file, use them...
-        mpiopts = kwargs.pop('mpiopts', dict())
-        mpiopts_map = dict(nnodes='nn', ntasks='nnp', nprocs='np', proc='np')
-        for stuff in [s
-                      for s in ('proc', 'nprocs', 'nnodes', 'ntasks', 'openmp',
-                                'prefixcommand', 'envelope')
-                      if s in mpiopts or s in self.conf]:
-            mpiopts[mpiopts_map.get(stuff, stuff)] = mpiopts.pop(stuff, self.conf[stuff])
+        mpiopts = kwargs.pop("mpiopts", dict())
+        mpiopts_map = dict(nnodes="nn", ntasks="nnp", nprocs="np", proc="np")
+        for stuff in [
+            s
+            for s in (
+                "proc",
+                "nprocs",
+                "nnodes",
+                "ntasks",
+                "openmp",
+                "prefixcommand",
+                "envelope",
+            )
+            if s in mpiopts or s in self.conf
+        ]:
+            mpiopts[mpiopts_map.get(stuff, stuff)] = mpiopts.pop(
+                stuff, self.conf[stuff]
+            )
 
         # if the prefix command is missing in the configuration file, look in the input sequence
-        if 'prefixcommand' not in mpiopts:
-            prefixes = self.ticket.context.sequence.effective_inputs(role=re.compile('Prefixcommand'))
+        if "prefixcommand" not in mpiopts:
+            prefixes = self.ticket.context.sequence.effective_inputs(
+                role=re.compile("Prefixcommand")
+            )
             if len(prefixes) > 1:
                 raise RuntimeError("Only one prefix command can be used...")
             for sec in prefixes:
                 prefixpath = sec.rh.container.actualpath()
-                logger.info('The following MPI prefix command will be used: %s', prefixpath)
-                mpiopts['prefixcommand'] = prefixpath
+                logger.info(
+                    "The following MPI prefix command will be used: %s",
+                    prefixpath,
+                )
+                mpiopts["prefixcommand"] = prefixpath
 
         # Ensure that some of the mpiopts are integers
-        for stuff in [s for s in ('nn', 'nnp', 'openmp', 'np') if s in mpiopts]:
+        for stuff in [
+            s for s in ("nn", "nnp", "openmp", "np") if s in mpiopts
+        ]:
             if isinstance(mpiopts[stuff], (list, tuple)):
                 mpiopts[stuff] = [int(v) for v in mpiopts[stuff]]
             else:
                 mpiopts[stuff] = int(mpiopts[stuff])
 
         # Read the configuration file for some extra configuration
-        allowed_conf_extras = ('launcher', 'opts', 'wrapstd', 'bind_topology')
+        allowed_conf_extras = ("launcher", "opts", "wrapstd", "bind_topology")
         for k, v in self.conf.items():
-            if (k not in kwargs and '_mpi' in k and
-                    any([k.endswith('_mpi' + a) for a in allowed_conf_extras])):
+            if (
+                k not in kwargs
+                and "_mpi" in k
+                and any([k.endswith("_mpi" + a) for a in allowed_conf_extras])
+            ):
                 kwargs[k] = v
 
         # When multiple list of binaries are given (i.e several binaries are launched
@@ -762,21 +913,35 @@ class Node(getbytag.GetByTag, NiceLayout):
         if tbx and isinstance(tbx[0], (list, tuple)):
             tbx = zip(*tbx)
         with self.env.delta_context(**env_update):
-            with self.sh.default_target.algo_run_context(self.ticket, self.conf):
+            with self.sh.default_target.algo_run_context(
+                self.ticket, self.conf
+            ):
                 for binary in tbx:
                     try:
                         tbalgo.run(binary, mpiopts=mpiopts, **kwargs)
-                    except (Exception, SignalInterruptError, KeyboardInterrupt) as e:
+                    except (
+                        Exception,
+                        SignalInterruptError,
+                        KeyboardInterrupt,
+                    ) as e:
                         mask_delayed, f_infos = self.filter_execution_error(e)
                         if isinstance(e, Exception) and mask_delayed:
-                            logger.warning("The delayed exception is masked:\n%s", str(f_infos))
+                            logger.warning(
+                                "The delayed exception is masked:\n%s",
+                                str(f_infos),
+                            )
                             self.report_execution_warning(e, **f_infos)
                         else:
-                            logger.error("Un-filtered execution error:\n%s", str(f_infos))
+                            logger.error(
+                                "Un-filtered execution error:\n%s",
+                                str(f_infos),
+                            )
                             self.report_execution_error(e, **f_infos)
-                            if isinstance(e, Exception) and self.delay_execution_error(e, **f_infos):
+                            if isinstance(
+                                e, Exception
+                            ) and self.delay_execution_error(e, **f_infos):
                                 self.subtitle(
-                                    'An exception occurred but the crash is delayed until the end of the Node'
+                                    "An exception occurred but the crash is delayed until the end of the Node"
                                 )
                                 self._print_traceback()
                                 # Actually delay the crash
@@ -796,9 +961,9 @@ class Family(Node):
     """
 
     def __init__(self, **kw):
-        logger.debug('Family init %s', repr(self))
+        logger.debug("Family init %s", repr(self))
         super().__init__(kw)
-        nodes = kw.pop('nodes', list())
+        nodes = kw.pop("nodes", list())
         self.options = kw.copy()
 
         # Build the nodes sequence
@@ -810,20 +975,22 @@ class Family(Node):
                 fcount += 1
                 self._contents.append(
                     Family(
-                        tag='{:s}.f{:02d}'.format(self.tag, fcount),
+                        tag="{:s}.f{:02d}".format(self.tag, fcount),
                         ticket=self.ticket,
                         nodes=x,
-                        **kw
+                        **kw,
                     )
                 )
 
     @property
     def realkind(self):
-        return 'family'
+        return "family"
 
     def _args_loopclone(self, tagsuffix, extras):  # @UnusedVariable
         baseargs = super()._args_loopclone(tagsuffix, extras)
-        baseargs['nodes'] = [node.loopclone(tagsuffix, extras) for node in self._contents]
+        baseargs["nodes"] = [
+            node.loopclone(tagsuffix, extras) for node in self._contents
+        ]
         return baseargs
 
     def _setup_context(self, ctx):
@@ -842,18 +1009,29 @@ class Family(Node):
     @property
     def _parallel_launchtool(self):
         """Create a launchtool for parallel runs (if sensible only)."""
-        if self._subjobok and self._subjobtag is None and 'paralleljobs_kind' in self.conf:
+        if (
+            self._subjobok
+            and self._subjobtag is None
+            and "paralleljobs_kind" in self.conf
+        ):
             # Subjob are allowed and I'am the main job (because self._subjobtag is None) :
             # => Run the family's content using subjobs
 
             # Create the subjob launcher
-            launcher_opts = {k[len('paralleljobs_'):]: self.conf[k]
-                             for k in self.conf if k.startswith('paralleljobs_')}
-            launchtool = fpx.subjobslauncher(scriptpath=sys.argv[0],
-                                             nodes_obsboard_tag=OBSERVER_TAG,
-                                             ** launcher_opts)
+            launcher_opts = {
+                k[len("paralleljobs_") :]: self.conf[k]
+                for k in self.conf
+                if k.startswith("paralleljobs_")
+            }
+            launchtool = fpx.subjobslauncher(
+                scriptpath=sys.argv[0],
+                nodes_obsboard_tag=OBSERVER_TAG,
+                **launcher_opts,
+            )
             if launchtool is None:
-                raise RuntimeError('No subjob launcher could be found: check "paralleljobs_kind".')
+                raise RuntimeError(
+                    'No subjob launcher could be found: check "paralleljobs_kind".'
+                )
             launchtool.ticket = self.ticket
             return launchtool
         else:
@@ -863,7 +1041,9 @@ class Family(Node):
         """Execution driver: setup, run kids, complete."""
         launchtool = self._parallel_launchtool
         if launchtool:
-            self.ticket.sh.title(' '.join(('Build', self.realkind, self.tag, '(using subjobs)')))
+            self.ticket.sh.title(
+                " ".join(("Build", self.realkind, self.tag, "(using subjobs)"))
+            )
 
             def node_recurse(some_node):
                 """Recursively find tags."""
@@ -878,13 +1058,18 @@ class Family(Node):
             # Wait for everybody to complete
             done, ko = launchtool.waitall()
             if ko:
-                raise SubJobLauncherError("Execution failed for some subjobs: {:s}"
-                                          .format(','.join(ko)))
+                raise SubJobLauncherError(
+                    "Execution failed for some subjobs: {:s}".format(
+                        ",".join(ko)
+                    )
+                )
         else:
             # No subjobs configured or allowed: run the usual way...
             sjob_activated = sjob_activated or self._subjobtag == self.tag
             try:
-                self.ticket.sh.title(' '.join(('Build', self.realkind, self.tag)))
+                self.ticket.sh.title(
+                    " ".join(("Build", self.realkind, self.tag))
+                )
                 self.setup()
                 self.summary()
                 for node in self.contents:
@@ -913,28 +1098,30 @@ class LoopFamily(Family):
     """
 
     def __init__(self, **kw):
-        logger.debug('LoopFamily init %s', repr(self))
+        logger.debug("LoopFamily init %s", repr(self))
         # On what should we iterate ?
-        self._loopconf = kw.pop('loopconf', None)
+        self._loopconf = kw.pop("loopconf", None)
         if not self._loopconf:
             raise ValueError('The "loopconf" named argument must be given')
         else:
-            self._loopconf = self._loopconf.split(',')
+            self._loopconf = self._loopconf.split(",")
         # Find the loop's variable names
-        self._loopvariable = kw.pop('loopvariable', None)
+        self._loopvariable = kw.pop("loopvariable", None)
         if self._loopvariable is None:
-            self._loopvariable = [s.rstrip('s') for s in self._loopconf]
+            self._loopvariable = [s.rstrip("s") for s in self._loopconf]
         else:
-            self._loopvariable = self._loopvariable.split(',')
+            self._loopvariable = self._loopvariable.split(",")
             if len(self._loopvariable) != len(self._loopconf):
-                raise ValueError('Inconsistent size between loopconf and loopvariable')
+                raise ValueError(
+                    "Inconsistent size between loopconf and loopvariable"
+                )
         # Find the loop suffixes
-        self._loopsuffix = kw.pop('loopsuffix', None)
+        self._loopsuffix = kw.pop("loopsuffix", None)
         if self._loopsuffix is None:
-            self._loopsuffix = '+' + self._loopvariable[0] + '{0!s}'
+            self._loopsuffix = "+" + self._loopvariable[0] + "{0!s}"
         # Prev/Next
-        self._loopneedprev = kw.pop('loopneedprev', False)
-        self._loopneednext = kw.pop('loopneednext', False)
+        self._loopneedprev = kw.pop("loopneedprev", False)
+        self._loopneednext = kw.pop("loopneednext", False)
         # Generic init...
         super().__init__(**kw)
         # Initialisation stuff
@@ -942,25 +1129,31 @@ class LoopFamily(Family):
 
     def _args_loopclone(self, tagsuffix, extras):  # @UnusedVariable
         baseargs = super()._args_loopclone(tagsuffix, extras)
-        baseargs['loopconf'] = ','.join(self._loopconf)
-        baseargs['loopvariable'] = ','.join(self._loopvariable)
-        baseargs['loopsuffix'] = self._loopsuffix
-        baseargs['loopneedprev'] = self._loopneedprev
-        baseargs['loopneednext'] = self._loopneednext
+        baseargs["loopconf"] = ",".join(self._loopconf)
+        baseargs["loopvariable"] = ",".join(self._loopvariable)
+        baseargs["loopsuffix"] = self._loopsuffix
+        baseargs["loopneedprev"] = self._loopneedprev
+        baseargs["loopneednext"] = self._loopneednext
         return baseargs
 
     @property
     def contents(self):
         if self._actual_content is None:
             self._actual_content = list()
-            for pvars, cvars, nvars in izip_pcn(*[self.conf.get(lc) for lc in self._loopconf]):
+            for pvars, cvars, nvars in izip_pcn(
+                *[self.conf.get(lc) for lc in self._loopconf]
+            ):
                 if self._loopneedprev and all([v is None for v in pvars]):
                     continue
                 if self._loopneednext and all([v is None for v in nvars]):
                     continue
                 extras = {v: x for v, x in zip(self._loopvariable, cvars)}
-                extras.update({v + '_prev': x for v, x in zip(self._loopvariable, pvars)})
-                extras.update({v + '_next': x for v, x in zip(self._loopvariable, nvars)})
+                extras.update(
+                    {v + "_prev": x for v, x in zip(self._loopvariable, pvars)}
+                )
+                extras.update(
+                    {v + "_next": x for v, x in zip(self._loopvariable, nvars)}
+                )
                 suffix = self._loopsuffix.format(*cvars)
                 for node in self._contents:
                     self._actual_content.append(node.loopclone(suffix, extras))
@@ -986,25 +1179,31 @@ class WorkshareFamily(Family):
     """
 
     def __init__(self, **kw):
-        logger.debug('WorkshareFamily init %s', repr(self))
+        logger.debug("WorkshareFamily init %s", repr(self))
         # On what should we build the workshare ?
-        self._workshareconf = kw.pop('workshareconf', None)
+        self._workshareconf = kw.pop("workshareconf", None)
         if not self._workshareconf:
-            raise ValueError('The "workshareconf" named argument must be given')
+            raise ValueError(
+                'The "workshareconf" named argument must be given'
+            )
         else:
-            self._workshareconf = self._workshareconf.split(',')
+            self._workshareconf = self._workshareconf.split(",")
         # Find the loop's variable names
-        self._worksharename = kw.pop('worksharename', None)
+        self._worksharename = kw.pop("worksharename", None)
         if not self._worksharename:
-            raise ValueError('The "worksharename" named argument must be given')
+            raise ValueError(
+                'The "worksharename" named argument must be given'
+            )
         else:
-            self._worksharename = self._worksharename.split(',')
+            self._worksharename = self._worksharename.split(",")
             if len(self._worksharename) != len(self._workshareconf):
-                raise ValueError('Inconsistent size between workshareconf and worksharename')
+                raise ValueError(
+                    "Inconsistent size between workshareconf and worksharename"
+                )
         # Minimum size for a workshare
-        self._worksharesize = int(kw.pop('worksharesize', 1))
+        self._worksharesize = int(kw.pop("worksharesize", 1))
         # Maximum number of workshares
-        self._worksharelimit = kw.pop('worksharelimit', None)
+        self._worksharelimit = kw.pop("worksharelimit", None)
         # Generic init
         super().__init__(**kw)
         # Initialisation stuff
@@ -1012,10 +1211,10 @@ class WorkshareFamily(Family):
 
     def _args_loopclone(self, tagsuffix, extras):  # @UnusedVariable
         baseargs = super()._args_loopclone(tagsuffix, extras)
-        baseargs['workshareconf'] = ','.join(self._workshareconf)
-        baseargs['worksharename'] = ','.join(self._worksharename)
-        baseargs['worksharesize'] = self._worksharesize
-        baseargs['worksharelimit'] = self._worksharelimit
+        baseargs["workshareconf"] = ",".join(self._workshareconf)
+        baseargs["worksharename"] = ",".join(self._worksharename)
+        baseargs["worksharesize"] = self._worksharesize
+        baseargs["worksharelimit"] = self._worksharelimit
         return baseargs
 
     @property
@@ -1025,7 +1224,9 @@ class WorkshareFamily(Family):
             populations = [self.conf.get(lc) for lc in self._workshareconf]
             n_population = {len(p) for p in populations}
             if not (len(n_population) == 1):
-                raise RuntimeError('Inconsistent sizes in "workshareconf" lists')
+                raise RuntimeError(
+                    'Inconsistent sizes in "workshareconf" lists'
+                )
             n_population = n_population.pop()
             # Number of workshares if worksharesize alone is considered
             sb_ws_number = n_population // self._worksharesize
@@ -1038,7 +1239,9 @@ class WorkshareFamily(Family):
             ws_number = max(min([sb_ws_number, lb_ws_number]), 1)
             # Find out the workshares sizes
             floorsize = n_population // ws_number
-            ws_sizes = [floorsize, ] * ws_number
+            ws_sizes = [
+                floorsize,
+            ] * ws_number
             for i in range(n_population - ws_number * floorsize):
                 ws_sizes[i % ws_number] += 1
             # Build de family's content
@@ -1046,11 +1249,16 @@ class WorkshareFamily(Family):
             ws_start = 0
             for i, ws_size in enumerate(ws_sizes):
                 ws_slice = slice(ws_start, ws_start + ws_size)
-                extras = {v: x[ws_slice] for v, x in zip(self._worksharename, populations)}
+                extras = {
+                    v: x[ws_slice]
+                    for v, x in zip(self._worksharename, populations)
+                }
                 ws_start += ws_size
-                ws_suffix = '_ws{:03d}'.format(i + 1)
+                ws_suffix = "_ws{:03d}".format(i + 1)
                 for node in self._contents:
-                    self._actual_content.append(node.loopclone(ws_suffix, extras))
+                    self._actual_content.append(
+                        node.loopclone(ws_suffix, extras)
+                    )
         return self._actual_content
 
 
@@ -1058,26 +1266,26 @@ class Task(Node):
     """Terminal node including a :class:`Sequence`."""
 
     def __init__(self, **kw):
-        logger.debug('Task init %s', repr(self))
+        logger.debug("Task init %s", repr(self))
         super().__init__(kw)
-        self.steps = kw.pop('steps', tuple())
-        self.fetch = kw.pop('fetch', 'fetch')
-        self.compute = kw.pop('compute', 'compute')
-        self.backup = kw.pop('backup', 'backup')
+        self.steps = kw.pop("steps", tuple())
+        self.fetch = kw.pop("fetch", "fetch")
+        self.compute = kw.pop("compute", "compute")
+        self.backup = kw.pop("backup", "backup")
         self.options = kw.copy()
         if isinstance(self.steps, str):
-            self.steps = tuple(self.steps.replace(' ', '').split(','))
+            self.steps = tuple(self.steps.replace(" ", "").split(","))
 
     @property
     def realkind(self):
-        return 'task'
+        return "task"
 
     def _args_loopclone(self, tagsuffix, extras):  # @UnusedVariable
         baseargs = super()._args_loopclone(tagsuffix, extras)
-        baseargs['steps'] = self.steps
-        baseargs['fetch'] = self.fetch
-        baseargs['compute'] = self.compute
-        baseargs['backup'] = self.backup
+        baseargs["steps"] = self.steps
+        baseargs["fetch"] = self.fetch
+        baseargs["compute"] = self.compute
+        baseargs["backup"] = self.backup
         return baseargs
 
     @property
@@ -1088,70 +1296,98 @@ class Task(Node):
         """Switch to rundir and check the active steps."""
 
         t = self.ticket
-        t.sh.title(' '.join(('Build', self.realkind, self.tag)))
+        t.sh.title(" ".join(("Build", self.realkind, self.tag)))
 
         # Change actual rundir if specified
-        rundir = self.options.get('rundir', None)
+        rundir = self.options.get("rundir", None)
         if rundir:
             t.env.RUNDIR = rundir
             t.sh.cd(rundir, create=True)
             t.rundir = t.sh.getcwd()
-        print('The current directory is: {}'.format(t.sh.getcwd()))
+        print("The current directory is: {}".format(t.sh.getcwd()))
 
         # Some attempt to find the current active steps
         if not self.steps:
             new_steps = []
-            if (self.env.get(self._locprefix + 'WARMSTART')
-                    or self.conf.get('warmstart', False)):
-                new_steps.append('warmstart')
-            if (self.env.get(self._locprefix + 'REFILL')
-                    or self.conf.get('refill', False)):
-                new_steps.append('refill')
+            if self.env.get(self._locprefix + "WARMSTART") or self.conf.get(
+                "warmstart", False
+            ):
+                new_steps.append("warmstart")
+            if self.env.get(self._locprefix + "REFILL") or self.conf.get(
+                "refill", False
+            ):
+                new_steps.append("refill")
             if new_steps:
                 self.steps = tuple(new_steps)
             else:
                 if self.play:
-                    self.steps = ('early-{:s}'.format(self.fetch), self.fetch,
-                                  self.compute,
-                                  self.backup, 'late-{:s}'.format(self.backup))
+                    self.steps = (
+                        "early-{:s}".format(self.fetch),
+                        self.fetch,
+                        self.compute,
+                        self.backup,
+                        "late-{:s}".format(self.backup),
+                    )
                 else:
-                    self.steps = ('early-{:s}'.format(self.fetch), self.fetch)
-        self.header('Active steps: ' + ' '.join(self.steps))
+                    self.steps = ("early-{:s}".format(self.fetch), self.fetch)
+        self.header("Active steps: " + " ".join(self.steps))
 
     def conf2io(self):
         """Broadcast IO SERVER configuration values to environment."""
         t = self.ticket
-        triggered = any([i in self.conf
-                         for i in ('io_nodes', 'io_companions', 'io_incore_tasks',
-                                   'io_openmp')])
-        if 'io_nodes' in self.conf:
+        triggered = any(
+            [
+                i in self.conf
+                for i in (
+                    "io_nodes",
+                    "io_companions",
+                    "io_incore_tasks",
+                    "io_openmp",
+                )
+            ]
+        )
+        if "io_nodes" in self.conf:
             t.env.default(VORTEX_IOSERVER_NODES=self.conf.io_nodes)
-            if 'io_tasks' in self.conf:
+            if "io_tasks" in self.conf:
                 t.env.default(VORTEX_IOSERVER_TASKS=self.conf.io_tasks)
-        elif 'io_companions' in self.conf:
-            t.env.default(VORTEX_IOSERVER_COMPANION_TASKS=self.conf.io_companions)
-        elif 'io_incore_tasks' in self.conf:
-            t.env.default(VORTEX_IOSERVER_INCORE_TASKS=self.conf.io_incore_tasks)
-            if 'io_incore_fixer' in self.conf:
-                t.env.default(VORTEX_IOSERVER_INCORE_FIXER=self.conf.io_incore_fixer)
-            if 'io_incore_dist' in self.conf:
-                t.env.default(VORTEX_IOSERVER_INCORE_DIST=self.conf.io_incore_dist)
-        if 'io_openmp' in self.conf:
+        elif "io_companions" in self.conf:
+            t.env.default(
+                VORTEX_IOSERVER_COMPANION_TASKS=self.conf.io_companions
+            )
+        elif "io_incore_tasks" in self.conf:
+            t.env.default(
+                VORTEX_IOSERVER_INCORE_TASKS=self.conf.io_incore_tasks
+            )
+            if "io_incore_fixer" in self.conf:
+                t.env.default(
+                    VORTEX_IOSERVER_INCORE_FIXER=self.conf.io_incore_fixer
+                )
+            if "io_incore_dist" in self.conf:
+                t.env.default(
+                    VORTEX_IOSERVER_INCORE_DIST=self.conf.io_incore_dist
+                )
+        if "io_openmp" in self.conf:
             t.env.default(VORTEX_IOSERVER_OPENMP=self.conf.io_openmp)
         if triggered and self.mstep_counter <= 1:
-            self.nicedump('IOSERVER Environment', **{k: v for k, v in t.env.items()
-                                                     if k.startswith('VORTEX_IOSERVER_')})
+            self.nicedump(
+                "IOSERVER Environment",
+                **{
+                    k: v
+                    for k, v in t.env.items()
+                    if k.startswith("VORTEX_IOSERVER_")
+                },
+            )
 
     def io_poll(self, prefix=None):
         """Complete the polling of data produced by the execution step."""
         sh = self.sh
-        if prefix and sh.path.exists('io_poll.todo'):
+        if prefix and sh.path.exists("io_poll.todo"):
             for iopr in prefix:
-                sh.header('IO poll <' + iopr + '>')
+                sh.header("IO poll <" + iopr + ">")
                 rc = sh.io_poll(iopr)
                 print(rc)
                 print(rc.result)
-            sh.header('Post-IO Poll directory listing')
+            sh.header("Post-IO Poll directory listing")
             sh.ll(output=False, fatal=False)
 
     def warmstart(self, **kw):
@@ -1166,7 +1402,7 @@ class Task(Node):
         """
         # This method acts as an example: if a refill is actually needed,
         # it should be overwritten.
-        if 'warmstart' in self.steps:
+        if "warmstart" in self.steps:
             pass
 
     def refill(self, **kw):
@@ -1178,14 +1414,14 @@ class Task(Node):
         """
         # This method acts as an example: if a refill is actually needed,
         # it should be overwritten.
-        if 'refill' in self.steps:
+        if "refill" in self.steps:
             pass
 
     def process(self):
         """Abstract method: perform the task to do."""
         # This method acts as an example: it should be overwritten.
 
-        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+        if "early-fetch" in self.steps or "fetch" in self.steps:
             # In a multi step job (MTOOL, ...), this step will be run on a
             # transfer node. Consequently, data that may be missing from the
             # local cache must be fetched here. (e.g. GCO's genv, data from the
@@ -1193,7 +1429,7 @@ class Task(Node):
             # retrieved here since the use of transfer node is costless.
             pass
 
-        if 'fetch' in self.steps:
+        if "fetch" in self.steps:
             # In a multi step job (MTOOL, ...), this step will be run, on a
             # compute node, just before the beginning of computations. It is the
             # appropriate place to fetch data produced by a previous task (the
@@ -1202,19 +1438,19 @@ class Task(Node):
             # in the local cache).
             pass
 
-        if 'compute' in self.steps:
+        if "compute" in self.steps:
             # The actual computations... (usually a call to the run method of an
             # AlgoComponent)
             pass
 
-        if 'backup' in self.steps or 'late-backup' in self.steps:
+        if "backup" in self.steps or "late-backup" in self.steps:
             # In a multi step job (MTOOL, ...), this step will be run, on a
             # compute node, just after the computations. It is the appropriate
             # place to put data in the local cache in order to make it available
             # to a subsequent step.
             pass
 
-        if 'late-backup' in self.steps:
+        if "late-backup" in self.steps:
             # In a multi step job (MTOOL, ...), this step will be run on a
             # transfer node. Consequently, most of the data should be archived
             # here.
@@ -1224,8 +1460,9 @@ class Task(Node):
         """Execution driver: build, setup, refill, process, complete."""
         sjob_activated = sjob_activated or self._subjobtag == self.tag
         if sjob_activated:
-            if (self.status == NODE_STATUS.RUNNING or
-                    (self.status == NODE_STATUS.FAILED and self.fail_at_the_end)):
+            if self.status == NODE_STATUS.RUNNING or (
+                self.status == NODE_STATUS.FAILED and self.fail_at_the_end
+            ):
                 try:
                     self.build()
                     self.setup()
@@ -1234,42 +1471,64 @@ class Task(Node):
                     self.refill()
                     self.process()
                 except VortexForceComplete:
-                    self.sh.title('Force complete')
+                    self.sh.title("Force complete")
                 finally:
                     self.complete()
             else:
                 self.build()
-                self.subtitle('This task will not run since it failed in a previous step.')
+                self.subtitle(
+                    "This task will not run since it failed in a previous step."
+                )
                 raise PreviousFailureError(
-                    'Previous error re-raised from tag={:s}'.format(self.tag)
+                    "Previous error re-raised from tag={:s}".format(self.tag)
                 )
 
 
 class Driver(getbytag.GetByTag, NiceLayout):
     """Iterable object for a simple scheduling of :class:`Application` objects."""
 
-    _tag_default = 'pilot'
+    _tag_default = "pilot"
 
-    def __init__(self, ticket, nodes=(), rundate=None, iniconf=None,
-                 jobname=None, options=None, iniencoding=None):
+    def __init__(
+        self,
+        ticket,
+        nodes=(),
+        rundate=None,
+        iniconf=None,
+        jobname=None,
+        options=None,
+        iniencoding=None,
+    ):
         """Setup default args value and read config file job."""
         self._ticket = t = ticket
         self._conf = None
 
         # Set default parameters for the actual job
         self._options = dict() if options is None else options
-        self._special_prefix = self._options.get('special_prefix', 'OP_').upper()
-        self._subjob_tag = self._options.get('subjob_tag', None)
-        j_assist = self._options.get('jobassistant', None)
+        self._special_prefix = self._options.get(
+            "special_prefix", "OP_"
+        ).upper()
+        self._subjob_tag = self._options.get("subjob_tag", None)
+        j_assist = self._options.get("jobassistant", None)
         if j_assist is not None:
             self._special_prefix = j_assist.special_prefix.upper()
             self._subjob_tag = j_assist.subjob_tag
-        self._mstep_job_last = self._options.get('mstep_job_last', True)
-        self._dryrun = self._options.get('dryrun', False)
-        self._iniconf = iniconf or t.env.get('{:s}INICONF'.format(self._special_prefix))
-        self._iniencoding = iniencoding or t.env.get('{:s}INIENCODING'.format(self._special_prefix), None)
-        self._jobname = jobname or t.env.get('{:s}JOBNAME'.format(self._special_prefix)) or 'void'
-        self._rundate = rundate or t.env.get('{:s}RUNDATE'.format(self._special_prefix))
+        self._mstep_job_last = self._options.get("mstep_job_last", True)
+        self._dryrun = self._options.get("dryrun", False)
+        self._iniconf = iniconf or t.env.get(
+            "{:s}INICONF".format(self._special_prefix)
+        )
+        self._iniencoding = iniencoding or t.env.get(
+            "{:s}INIENCODING".format(self._special_prefix), None
+        )
+        self._jobname = (
+            jobname
+            or t.env.get("{:s}JOBNAME".format(self._special_prefix))
+            or "void"
+        )
+        self._rundate = rundate or t.env.get(
+            "{:s}RUNDATE".format(self._special_prefix)
+        )
         self._nicelayout_init(dict())
 
         # Build the tree to schedule
@@ -1282,10 +1541,10 @@ class Driver(getbytag.GetByTag, NiceLayout):
                 fcount += 1
                 self._contents.append(
                     Family(
-                        tag='{:s}.f{:02d}'.format(self.tag, fcount),
+                        tag="{:s}.f{:02d}".format(self.tag, fcount),
                         ticket=self.ticket,
                         nodes=x,
-                        ** dict(self._options)
+                        **dict(self._options),
                     )
                 )
 
@@ -1343,7 +1602,7 @@ class Driver(getbytag.GetByTag, NiceLayout):
             iniparser = GenericConfigParser(inifile, encoding=iniencoding)
             thisconf = iniparser.as_dict(merged=False)
         except Exception:
-            logger.critical('Could not read config %s', inifile)
+            logger.critical("Could not read config %s", inifile)
             raise
         return thisconf
 
@@ -1354,28 +1613,44 @@ class Driver(getbytag.GetByTag, NiceLayout):
 
         rundate = date or self.rundate
         if rundate is None:
-            logger.info('No date provided for this run.')
+            logger.info("No date provided for this run.")
 
         if verbose:
             if rundate is None:
-                self.sh.title(['Starting job', '', jobname, ])
+                self.sh.title(
+                    [
+                        "Starting job",
+                        "",
+                        jobname,
+                    ]
+                )
             else:
-                self.sh.title(['Starting job', '', jobname, '', 'date ' + rundate.isoformat()])
+                self.sh.title(
+                    [
+                        "Starting job",
+                        "",
+                        jobname,
+                        "",
+                        "date " + rundate.isoformat(),
+                    ]
+                )
 
         # Read once for all the job configuration file
         if self.iniconf is None:
-            logger.warning('This driver does not have any configuration file')
+            logger.warning("This driver does not have any configuration file")
             self._jobconf = dict()
         else:
             self._jobconf = self.read_config(self.iniconf, self.iniencoding)
 
         self._conf = ConfigSet()
-        updconf = self.jobconf.get('defaults', dict())
+        updconf = self.jobconf.get("defaults", dict())
         updconf.update(self.jobconf.get(self.jobname, dict()))
         if self.mstep_counter <= 1:
-            self.nicedump('Configuration for job ' + self.jobname, **updconf)
+            self.nicedump("Configuration for job " + self.jobname, **updconf)
         else:
-            print("Silent Driver' setup: please refer to the first job step for more details")
+            print(
+                "Silent Driver' setup: please refer to the first job step for more details"
+            )
         self.conf.update(updconf)
 
         # Recursively set the configuration tree and contexts
@@ -1388,14 +1663,18 @@ class Driver(getbytag.GetByTag, NiceLayout):
         if self.mstep_counter <= 1:
             self.status = NODE_STATUS.READY
             if not self._dryrun:
-                self.header('The various nodes were configured. Here is a Tree-View of the Driver:')
+                self.header(
+                    "The various nodes were configured. Here is a Tree-View of the Driver:"
+                )
                 print(self)
 
     def run(self):
         """Assume recursion of nodes `run` methods."""
         if self._dryrun:
-            raise RuntimeError('This Driver was initialised with "dryrun". ' +
-                               'It is not allowed to call run().')
+            raise RuntimeError(
+                'This Driver was initialised with "dryrun". '
+                + "It is not allowed to call run()."
+            )
         self.status = NODE_STATUS.RUNNING
         try:
             for node in self.contents:
@@ -1405,20 +1684,30 @@ class Driver(getbytag.GetByTag, NiceLayout):
                 self.status = NODE_STATUS.DONE
         except Exception:
             if not self._mstep_job_last and self.any_currently_running:
-                self.sh.title("Handling of the job failure in a multi-job context.")
+                self.sh.title(
+                    "Handling of the job failure in a multi-job context."
+                )
                 self._print_traceback()
                 print()
-                print("Since it is not the last step of this multi-step job, " +
-                      "the job failure is ignored... for now.")
+                print(
+                    "Since it is not the last step of this multi-step job, "
+                    + "the job failure is ignored... for now."
+                )
             else:
                 raise
         else:
-            if self.delayed_error_flag and self._subjob_tag is None and self._mstep_job_last:
+            if (
+                self.delayed_error_flag
+                and self._subjob_tag is None
+                and self._mstep_job_last
+            ):
                 # Test on _subjob_tag because we do not want to crash in subjobs
-                raise RuntimeError("One or several error occurred during the Driver execution. " +
-                                   "The exceptions were delayed but now that the Driver ended let's crash !")
+                raise RuntimeError(
+                    "One or several error occurred during the Driver execution. "
+                    + "The exceptions were delayed but now that the Driver ended let's crash !"
+                )
         finally:
             if self.any_failure:
-                self.sh.title('An error occurred during job...')
-                print('Here is the tree-view of the present Driver:')
+                self.sh.title("An error occurred during job...")
+                print("Here is the tree-view of the present Driver:")
                 print(self)

--- a/src/vortex/layout/subjobs.py
+++ b/src/vortex/layout/subjobs.py
@@ -18,14 +18,14 @@ import footprints as fp
 
 logger = loggers.getLogger(__name__)
 
-_LOG_CAPTURE_START = '>>>> subjob stdeo start <<<<\n'
-_LOG_CAPTURE_END = '>>>> subjob stdeo end <<<<\n'
+_LOG_CAPTURE_START = ">>>> subjob stdeo start <<<<\n"
+_LOG_CAPTURE_END = ">>>> subjob stdeo end <<<<\n"
 
-_DSTORE_IN = '{:s}_datastore.in'
-_DSTORE_OUT = '{:s}_{:s}_datastore.out'
-_JOB_STDEO = '{:s}_{:s}.stdeo'
+_DSTORE_IN = "{:s}_datastore.in"
+_DSTORE_OUT = "{:s}_{:s}_datastore.out"
+_JOB_STDEO = "{:s}_{:s}.stdeo"
 
-_SUBJOB_NODES_CHATTER = 'subjob_nodes_observerboard_chatter'
+_SUBJOB_NODES_CHATTER = "subjob_nodes_observerboard_chatter"
 
 
 class NodesObserverboardRecorder(observer.Observer):
@@ -45,8 +45,9 @@ class NodesObserverboardRecorder(observer.Observer):
 
     def updobsitem(self, item, info):
         """Store the observer board messages"""
-        self._messages.append({k: v for k, v in info.items()
-                               if k != 'observerboard'})
+        self._messages.append(
+            {k: v for k, v in info.items() if k != "observerboard"}
+        )
 
     @property
     def messages(self):
@@ -70,36 +71,37 @@ def subjob_handling(node, observer_tag):
         sys.stdout.flush()
         sys.stdout.write(_LOG_CAPTURE_END)
         sys.stdout.flush()
-        node.ticket.datastore.insert(_SUBJOB_NODES_CHATTER,
-                                     dict(tag=node.tag), recorder.messages)
+        node.ticket.datastore.insert(
+            _SUBJOB_NODES_CHATTER, dict(tag=node.tag), recorder.messages
+        )
 
 
 class SubJobLauncherError(Exception):
     """Raise whenever an error occurred in at least on of the subjobs."""
+
     pass
 
 
 class AbstractSubJobLauncher(fp.FootprintBase):
     """Abstract subjob launcher class."""
 
-    _collector = ('subjobslauncher',)
+    _collector = ("subjobslauncher",)
     _abstract = True
     _footprint = dict(
-        info = 'Abstract SubJob launcher.',
-        attr = dict(
-            kind = dict(
+        info="Abstract SubJob launcher.",
+        attr=dict(
+            kind=dict(),
+            nodes_obsboard_tag=dict(
+                info="The name of the Layout-Nodes observer board.",
             ),
-            nodes_obsboard_tag = dict(
-                info = "The name of the Layout-Nodes observer board.",
+            limit=dict(
+                info="The maximum number of parallel subjobs.",
+                type=int,
+                optional=True,
             ),
-            limit = dict(
-                info = "The maximum number of parallel subjobs.",
-                type = int,
-                optional = True
+            scriptpath=dict(
+                info="The path to the current job script.",
             ),
-            scriptpath = dict(
-                info = "The path to the current job script.",
-            )
         ),
     )
 
@@ -108,8 +110,12 @@ class AbstractSubJobLauncher(fp.FootprintBase):
         self._ticket = None
         self._watermark = 0
         self._running = dict()
-        logger.info('"%s" subjob launcher created (limit=%s, scriptpath=%s)',
-                    self.kind, str(self.limit), self.scriptpath)
+        logger.info(
+            '"%s" subjob launcher created (limit=%s, scriptpath=%s)',
+            self.kind,
+            str(self.limit),
+            self.scriptpath,
+        )
 
     @property
     def actual_limit(self):
@@ -122,7 +128,7 @@ class AbstractSubJobLauncher(fp.FootprintBase):
 
     def _set_ticket(self, t):
         self._ticket = t
-        self.fsid = self.ticket.sh.path.join(self.ticket.sh.pwd(), 'sjob_fs')
+        self.fsid = self.ticket.sh.path.join(self.ticket.sh.pwd(), "sjob_fs")
         self._ticket.datastore.pickle_dump(_DSTORE_IN.format(self.fsid))
         self._new_ticket_hook(t)
 
@@ -130,26 +136,37 @@ class AbstractSubJobLauncher(fp.FootprintBase):
         assert self._ticket is not None
         return self._ticket
 
-    ticket = property(_get_ticket, _set_ticket, doc="The current Session's ticket")
+    ticket = property(
+        _get_ticket, _set_ticket, doc="The current Session's ticket"
+    )
 
     def __call__(self, tag, subtags):
         """Launch the subjob that will be in charge of processing the **tag** node."""
-        if self.actual_limit is not None and self._watermark == self.actual_limit:
-            logger.info("The subjobs limit is reached (%d). Waiting for some subjobs to finish.",
-                        self.actual_limit)
+        if (
+            self.actual_limit is not None
+            and self._watermark == self.actual_limit
+        ):
+            logger.info(
+                "The subjobs limit is reached (%d). Waiting for some subjobs to finish.",
+                self.actual_limit,
+            )
             self.wait()
         self._running[tag] = subtags
         self._watermark += 1
-        with self.ticket.env.delta_context(VORTEX_SUBJOB_ACTIVATED='{:s}:{:s}'.format(tag, self.fsid)):
-            logger.info("Launching subjob with VORTEX_SUBJOB_ACTIVATED='%s'",
-                        self.ticket.env.VORTEX_SUBJOB_ACTIVATED)
+        with self.ticket.env.delta_context(
+            VORTEX_SUBJOB_ACTIVATED="{:s}:{:s}".format(tag, self.fsid)
+        ):
+            logger.info(
+                "Launching subjob with VORTEX_SUBJOB_ACTIVATED='%s'",
+                self.ticket.env.VORTEX_SUBJOB_ACTIVATED,
+            )
             self._actual_launch(tag)
 
     def wait(self):
         """Wait for at least one subjob to complete."""
         done, ko = self._actual_wait()
         for tag in done | ko:
-            self._stdeo_dump(tag, 'succeeded' if tag in done else 'failed')
+            self._stdeo_dump(tag, "succeeded" if tag in done else "failed")
             self._update_context(tag)
             del self._running[tag]
             self._watermark -= 1
@@ -166,15 +183,17 @@ class AbstractSubJobLauncher(fp.FootprintBase):
             ko.update(new_ko)
         return done, ko
 
-    def _stdeo_dump(self, tag, outcome='succeeded', ignore_end=False):
+    def _stdeo_dump(self, tag, outcome="succeeded", ignore_end=False):
         """Dump the standard output of the subjob refered by **tag**.
 
         :param tag: The subjob's tag
         :param outcome: Some indication on how the subjob ended
         :param ignore_end: Print the entire standard output (usefull for debuging)
         """
-        plocale = locale.getlocale()[1] or 'ascii'
-        self.ticket.sh.title('subjob "{:s}" {:s}. Here is the output:'.format(tag, outcome))
+        plocale = locale.getlocale()[1] or "ascii"
+        self.ticket.sh.title(
+            'subjob "{:s}" {:s}. Here is the output:'.format(tag, outcome)
+        )
         with open(_JOB_STDEO.format(self.fsid, tag), encoding=plocale) as fhst:
             started = False
             for lst in fhst:
@@ -187,7 +206,7 @@ class AbstractSubJobLauncher(fp.FootprintBase):
                 else:
                     started = lst == _LOG_CAPTURE_START
         print()
-        print('Full Log available at: {:s}_{:s}.stdeo'.format(self.fsid, tag))
+        print("Full Log available at: {:s}_{:s}.stdeo".format(self.fsid, tag))
         print()
 
     def _update_context(self, tag):
@@ -196,29 +215,35 @@ class AbstractSubJobLauncher(fp.FootprintBase):
         ds = datastore.DataStore()
         ds.pickle_load(_DSTORE_OUT.format(self.fsid, tag))
         for k in ds.keys():
-            if re.match('context_', k.kind):
-                xpath = k.extras.get('path', '').split('/')
+            if re.match("context_", k.kind):
+                xpath = k.extras.get("path", "").split("/")
                 for stag in stags:
                     # Only update relevant entries
                     if xpath[-1] == stag:
-                        logger.info('Updating "%s, path=%s" in the datastore',
-                                    k.kind, '/'.join(xpath))
+                        logger.info(
+                            'Updating "%s, path=%s" in the datastore',
+                            k.kind,
+                            "/".join(xpath),
+                        )
                         curv = self.ticket.datastore.get(k.kind, k.extras)
-                        if hasattr(curv, 'datastore_inplace_overwrite'):
-                            curv.datastore_inplace_overwrite(ds.get(k.kind, k.extras))
+                        if hasattr(curv, "datastore_inplace_overwrite"):
+                            curv.datastore_inplace_overwrite(
+                                ds.get(k.kind, k.extras)
+                            )
                         else:
-                            self.ticket.datastore.insert(k.kind, k.extras,
-                                                         ds.get(k.kind, k.extras))
+                            self.ticket.datastore.insert(
+                                k.kind, k.extras, ds.get(k.kind, k.extras)
+                            )
                         break
-            if k.kind == _SUBJOB_NODES_CHATTER and k.extras['tag'] == tag:
+            if k.kind == _SUBJOB_NODES_CHATTER and k.extras["tag"] == tag:
                 messages = ds.get(k.kind, k.extras)
                 if messages:
                     oboard = observer.get(tag=self.nodes_obsboard_tag)
                     oboard.notify_new(self, dict(tag=tag, subjob_replay=True))
                     for message in messages:
-                        message['subjob_replay'] = True
+                        message["subjob_replay"] = True
                         oboard.notify_upd(self, message)
-                        logger.debug('Relaying status change: %s', message)
+                        logger.debug("Relaying status change: %s", message)
                     oboard.notify_del(self, dict(tag=tag, subjob_replay=False))
 
     def _actual_launch(self, tag):
@@ -234,9 +259,11 @@ class SpawnSubJobLauncher(AbstractSubJobLauncher):
     """A very simple subjob launcher: just starts a new process."""
 
     _footprint = dict(
-        attr = dict(
-            kind =dict(
-                values = ['spawn', ]
+        attr=dict(
+            kind=dict(
+                values=[
+                    "spawn",
+                ]
             )
         )
     )
@@ -255,20 +282,24 @@ class SpawnSubJobLauncher(AbstractSubJobLauncher):
         elif self.limit is None and self._nvcores is not None:
             return self._nvcores
         else:
-            raise ValueError('No limit could be found for the number of subprocesses.')
+            raise ValueError(
+                "No limit could be found for the number of subprocesses."
+            )
 
     def _new_ticket_hook(self, t):
         """Tries to find out the number of virtual cores available."""
         super()._new_ticket_hook(t)
         if self.limit is None and t.sh.cpus_info is not None:
             self._nvcores = t.sh.cpus_info.nphysical_cores
-            logger.info('"spawn" subjob launcher set to %d (i.e the number of virtual cores)',
-                        self._nvcores)
+            logger.info(
+                '"spawn" subjob launcher set to %d (i.e the number of virtual cores)',
+                self._nvcores,
+            )
 
     def _actual_launch(self, tag):
         """Just launch the subjob using a subprocess... easy!"""
         sh = self.ticket.sh
-        ofh = open(_JOB_STDEO.format(self.fsid, tag), mode='wb')
+        ofh = open(_JOB_STDEO.format(self.fsid, tag), mode="wb")
         p = sh.popen([sys.executable, self.scriptpath], stdout=ofh, stderr=ofh)
         self._outfhs[tag] = ofh
         self._processes[tag] = p
@@ -304,11 +335,11 @@ class AbstractSshSubJobLauncher(AbstractSubJobLauncher):
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            taskspn = dict(
-                type = int,
-                default = 1,
-                optional = True,
+        attr=dict(
+            taskspn=dict(
+                type=int,
+                default=1,
+                optional=True,
             ),
         )
     )
@@ -344,28 +375,34 @@ class AbstractSshSubJobLauncher(AbstractSubJobLauncher):
         # Several tasks may be launched on a single node
         self.nodes = self.nodes * self.taskspn
         if self.limit is not None and len(self.nodes) < self.limit:
-            raise RuntimeError('The are not enough compute nodes (available:{:s}/requested={:d})'
-                               .format(len(self.nodes), self.limit))
+            raise RuntimeError(
+                "The are not enough compute nodes (available:{:s}/requested={:d})".format(
+                    len(self.nodes), self.limit
+                )
+            )
         # Summary
-        logger.info("%d task(s) per node will be launched. Nodes list: %s",
-                    self.taskspn, ",".join(sorted(set(self.nodes))))
+        logger.info(
+            "%d task(s) per node will be launched. Nodes list: %s",
+            self.taskspn,
+            ",".join(sorted(set(self.nodes))),
+        )
         # Available nodes
         self._avnodes = collections.deque(self.nodes)
         # Freeze the root environment in a wrapper
-        self._lwrapper = '{:s}.wrap.sh'.format(self.fsid)
-        with open(self._lwrapper, 'w', encoding='utf-8') as fhwrap:
-            fhwrap.write('#! /bin/bash\n')
-            fhwrap.write('set -x\n')
-            fhwrap.write('set -e\n')
+        self._lwrapper = "{:s}.wrap.sh".format(self.fsid)
+        with open(self._lwrapper, "w", encoding="utf-8") as fhwrap:
+            fhwrap.write("#! /bin/bash\n")
+            fhwrap.write("set -x\n")
+            fhwrap.write("set -e\n")
             fhwrap.write('echo "I am running on $(hostname) !"\n')
             for k, v in self._env_variables_iterator(t):
-                if re.match(r'[-_\w]+$', k):  # Get rid of weird variable names
+                if re.match(r"[-_\w]+$", k):  # Get rid of weird variable names
                     fhwrap.write("export {:s}='{!s}'\n".format(k.upper(), v))
-            fhwrap.write('exec $*\n')
+            fhwrap.write("exec $*\n")
         t.sh.xperm(self._lwrapper, force=True)
         # Put the script on the parallel file-system (otherwise it won't be accessible
         # from other nodes)
-        self._pfs_scriptpath = '{:s}.script.py'.format(self.fsid)
+        self._pfs_scriptpath = "{:s}.script.py".format(self.fsid)
         t.sh.cp(self.scriptpath, self._pfs_scriptpath)
 
     def _env_lastminute_update(self, tag, thost):
@@ -377,14 +414,21 @@ class AbstractSshSubJobLauncher(AbstractSubJobLauncher):
         sh = self.ticket.sh
         thost = self._avnodes.popleft()
         logger.info('"%s" will be used (through SSH).', thost)
-        ofh = open(_JOB_STDEO.format(self.fsid, tag), mode='wb')
-        cmd = "export VORTEX_SUBJOB_ACTIVATED='{:s}'; ".format(sh.env.VORTEX_SUBJOB_ACTIVATED)
-        cmd += ' '.join(["export {:s}='{!s}'; ".format(k, v)
-                         for k, v in self._env_lastminute_update(tag, thost)])
-        cmd += ' '.join([self._lwrapper, sys.executable, self._pfs_scriptpath])
+        ofh = open(_JOB_STDEO.format(self.fsid, tag), mode="wb")
+        cmd = "export VORTEX_SUBJOB_ACTIVATED='{:s}'; ".format(
+            sh.env.VORTEX_SUBJOB_ACTIVATED
+        )
+        cmd += " ".join(
+            [
+                "export {:s}='{!s}'; ".format(k, v)
+                for k, v in self._env_lastminute_update(tag, thost)
+            ]
+        )
+        cmd += " ".join([self._lwrapper, sys.executable, self._pfs_scriptpath])
         print(cmd)
-        p = sh.ssh(thost).background_execute(cmd, sshopts='-o CheckHostIP=no',
-                                             stdout=ofh, stderr=ofh)
+        p = sh.ssh(thost).background_execute(
+            cmd, sshopts="-o CheckHostIP=no", stdout=ofh, stderr=ofh
+        )
         self._outfhs[tag] = ofh
         self._hosts[tag] = thost
         self._processes[tag] = p
@@ -423,32 +467,40 @@ class SlurmSshSubJobLauncher(AbstractSshSubJobLauncher):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['slurm:ssh', ]
+        attr=dict(
+            kind=dict(
+                values=[
+                    "slurm:ssh",
+                ]
             ),
         )
     )
 
     def _env_variables_iterator(self, t):
         """Return the environment variables that will be used."""
-        blacklist = {"SLURM_{:s}".format(s)
-                     for s in ('NNODES', 'JOB_NNODES', 'JOB_NUM_NODES',
-                               'NODELIST', 'JOB_NODELIST')}
-        slurmnodes_ids = re.compile(r'(\(x\d+\))$')
+        blacklist = {
+            "SLURM_{:s}".format(s)
+            for s in (
+                "NNODES",
+                "JOB_NNODES",
+                "JOB_NUM_NODES",
+                "NODELIST",
+                "JOB_NODELIST",
+            )
+        }
+        slurmnodes_ids = re.compile(r"(\(x\d+\))$")
         for k, v in t.topenv.items():
             if k not in blacklist:
-                if k.startswith('SLURM') and slurmnodes_ids.search(v):
-                    yield k, slurmnodes_ids.sub('(x1)', v)
+                if k.startswith("SLURM") and slurmnodes_ids.search(v):
+                    yield k, slurmnodes_ids.sub("(x1)", v)
                 else:
                     yield k, v
-        for k in ('SLURM_NNODES', 'SLURM_JOB_NNODES', 'SLURM_JOB_NUM_NODES'):
+        for k in ("SLURM_NNODES", "SLURM_JOB_NNODES", "SLURM_JOB_NUM_NODES"):
             yield k, "1"
 
     def _env_lastminute_update(self, tag, thost):  # @UnusedVariable
         """Add some lastminute environment variables."""
-        return dict(SLURM_NODELIST=thost,
-                    SLURM_JOB_NODELIST=thost).items()
+        return dict(SLURM_NODELIST=thost, SLURM_JOB_NODELIST=thost).items()
 
     def _find_raw_nodes_list(self, t):
         """Find out what is the nodes list.
@@ -456,9 +508,12 @@ class SlurmSshSubJobLauncher(AbstractSshSubJobLauncher):
         To do so, the SLURM_JOB_NODELIST environment variable is processed.
         """
         # Process SLURM's nodes list
-        nlist = t.env.get('SLURM_JOB_NODELIST',
-                          t.env.get('SLURM_NODELIST', None))
+        nlist = t.env.get(
+            "SLURM_JOB_NODELIST", t.env.get("SLURM_NODELIST", None)
+        )
         if nlist:
             return xlist_strings(nlist)
         else:
-            raise RuntimeError('The "SLURM_JOB_NODELIST" environment variable is not defined.')
+            raise RuntimeError(
+                'The "SLURM_JOB_NODELIST" environment variable is not defined.'
+            )

--- a/src/vortex/nwp/__init__.py
+++ b/src/vortex/nwp/__init__.py
@@ -8,4 +8,4 @@ from . import algo, data, tools, syntax
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'The NWP VORTEX extension'
+__tocinfoline__ = "The NWP VORTEX extension"

--- a/src/vortex/nwp/__init__.py
+++ b/src/vortex/nwp/__init__.py
@@ -3,7 +3,10 @@ The NWP VORTEX extension package.
 """
 
 # Recursive inclusion of packages with potential FootprintBase classes
-from . import algo, data, tools, syntax
+from . import algo as algo
+from . import data as data
+from . import tools as tools
+from . import syntax as syntax
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/nwp/algo/__init__.py
+++ b/src/vortex/nwp/algo/__init__.py
@@ -3,22 +3,19 @@ AlgoComponents for NWP
 """
 
 # Recursive inclusion of packages with potential FootprintBase classes
-from . import (
-    forecasts,
-    fpserver,
-    coupling,
-    mpitools,
-    odbtools,
-    stdpost,
-    assim,
-    eps,
-    eda,
-    request,
-    monitoring,
-    clim,
-)
-from . import oopsroot, oopstests
+from . import forecasts as forecasts
+from . import fpserver as fpserver
+from . import coupling as coupling
+from . import mpitools as mpitools
+from . import odbtools as odbtools
+from . import stdpost as stdpost
+from . import assim as assim
+from . import eps as eps
+from . import eda as eda
+from . import request as request
+from . import monitoring as monitoring
+from . import clim as clim
+from . import oopsroot as oopsroot
+from . import oopstests as oopstests
 
-
-#: No automatic export
 __all__ = []

--- a/src/vortex/nwp/algo/__init__.py
+++ b/src/vortex/nwp/algo/__init__.py
@@ -3,8 +3,20 @@ AlgoComponents for NWP
 """
 
 # Recursive inclusion of packages with potential FootprintBase classes
-from . import forecasts, fpserver, coupling, mpitools, odbtools, stdpost, assim, \
-    eps, eda, request, monitoring, clim
+from . import (
+    forecasts,
+    fpserver,
+    coupling,
+    mpitools,
+    odbtools,
+    stdpost,
+    assim,
+    eps,
+    eda,
+    request,
+    monitoring,
+    clim,
+)
 from . import oopsroot, oopstests
 
 

--- a/src/vortex/nwp/algo/assim.py
+++ b/src/vortex/nwp/algo/assim.py
@@ -24,13 +24,13 @@ class MergeVarBC(Parallel):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['mergevarbc'],
+        attr=dict(
+            kind=dict(
+                values=["mergevarbc"],
             ),
-            varbcout = dict(
-                optional = True,
-                default  = 'VARBC.cycle_out',
+            varbcout=dict(
+                optional=True,
+                default="VARBC.cycle_out",
             ),
         )
     )
@@ -50,21 +50,21 @@ class Anamix(IFSParallel):
     """Merge the surface and atmospheric analyses into a single file"""
 
     _footprint = dict(
-        info='Merge surface and atmospheric analyses',
+        info="Merge surface and atmospheric analyses",
         attr=dict(
             kind=dict(
-                values=['anamix'],
+                values=["anamix"],
             ),
             conf=dict(
                 default=701,
             ),
             xpname=dict(
-                default='CANS',
+                default="CANS",
             ),
             timestep=dict(
                 default=1,
-            )
-        )
+            ),
+        ),
     )
 
 
@@ -72,19 +72,19 @@ class SstAnalysis(IFSParallel):
     """SST (Sea Surface Temperature) Analysis"""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values  = ['sstana', 'sst_ana', 'sst_analysis', 'c931'],
-                remap   = dict(autoremap = 'first'),
+        attr=dict(
+            kind=dict(
+                values=["sstana", "sst_ana", "sst_analysis", "c931"],
+                remap=dict(autoremap="first"),
             ),
-            conf = dict(
-                default = 931,
+            conf=dict(
+                default=931,
             ),
-            xpname = dict(
-                default = 'ANAL',
+            xpname=dict(
+                default="ANAL",
             ),
-            timestep = dict(
-                default  = '1.',
+            timestep=dict(
+                default="1.",
             ),
         )
     )
@@ -94,36 +94,36 @@ class SeaIceAnalysis(IFSParallel):
     """Sea Ice Analysis"""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values  = ['seaiceana', 'seaice_ana', 'seaice_analysis', 'c932'],
-                remap   = dict(autoremap = 'first'),
+        attr=dict(
+            kind=dict(
+                values=["seaiceana", "seaice_ana", "seaice_analysis", "c932"],
+                remap=dict(autoremap="first"),
             ),
-            conf = dict(
-                default = 932,
+            conf=dict(
+                default=932,
             ),
-            xpname = dict(
-                default = 'ANAL',
+            xpname=dict(
+                default="ANAL",
             ),
-            timestep = dict(
-                default  = '1.',
+            timestep=dict(
+                default="1.",
             ),
-            date = dict(
-                type     = Date,
-            )
+            date=dict(
+                type=Date,
+            ),
         )
     )
 
     def find_namelists(self, opts=None):
         namrh_list = super().find_namelists(opts)
         if not namrh_list:
-            logger.critical('No namelist was found.')
-            raise ValueError('No namelist was found for seaice analysis')
+            logger.critical("No namelist was found.")
+            raise ValueError("No namelist was found for seaice analysis")
         return namrh_list
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         super().prepare_namelist_delta(rh, namcontents, namlocal)
-        self._set_nam_macro(namcontents, namlocal, 'IDAT', int(self.date.ymd))
+        self._set_nam_macro(namcontents, namlocal, "IDAT", int(self.date.ymd))
         return True
 
 
@@ -131,21 +131,21 @@ class Canari(IFSParallel, odb.OdbComponentDecoMixin):
     """Surface analysis."""
 
     _footprint = dict(
-        info = 'Surface assimilation based on optimal interpolation',
-        attr = dict(
-            kind = dict(
-                values  = ['canari'],
+        info="Surface assimilation based on optimal interpolation",
+        attr=dict(
+            kind=dict(
+                values=["canari"],
             ),
-            binarysingle = dict(
-                default = 'basicnwpobsort',
+            binarysingle=dict(
+                default="basicnwpobsort",
             ),
-            conf = dict(
-                default = 701,
+            conf=dict(
+                default=701,
             ),
-            xpname = dict(
-                default = 'CANS',
+            xpname=dict(
+                default="CANS",
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
@@ -153,18 +153,30 @@ class Canari(IFSParallel, odb.OdbComponentDecoMixin):
         super().prepare(rh, opts)
 
         # Looking for input observations
-        obsodb = [x for x in self.lookupodb() if x.rh.resource.part.startswith('surf')]
+        obsodb = [
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.part.startswith("surf")
+        ]
         if not obsodb:
-            raise ValueError('No surface obsdata for canari')
+            raise ValueError("No surface obsdata for canari")
         self.odb_date_and_layout_from_sections(obsodb)
 
         # Find the unique input ODb database
         ssurf = obsodb.pop()
         if obsodb:
-            logger.error('More than one surface obsdata provided')
-            logger.error('Using : %s / %s', ssurf.rh.resource.layout, ssurf.rh.resource.part)
+            logger.error("More than one surface obsdata provided")
+            logger.error(
+                "Using : %s / %s",
+                ssurf.rh.resource.layout,
+                ssurf.rh.resource.part,
+            )
             for sobs in obsodb:
-                logger.error('Skip : %s / %s', sobs.rh.resource.layout, sobs.rh.resource.part)
+                logger.error(
+                    "Skip : %s / %s",
+                    sobs.rh.resource.layout,
+                    sobs.rh.resource.part,
+                )
 
         # Fix paths + generate a global IOASSING file
         cma_path = self.system.path.abspath(ssurf.rh.container.localpath())
@@ -188,25 +200,25 @@ class Screening(IFSParallel, odb.OdbComponentDecoMixin):
     """Observation screening."""
 
     _footprint = dict(
-        info = 'Observations screening.',
-        attr = dict(
-            kind = dict(
-                values  = ['screening', 'screen', 'thinning'],
-                remap   = dict(autoremap = 'first'),
+        info="Observations screening.",
+        attr=dict(
+            kind=dict(
+                values=["screening", "screen", "thinning"],
+                remap=dict(autoremap="first"),
             ),
-            binarysingle = dict(
-                default = 'basicnwpobsort',
+            binarysingle=dict(
+                default="basicnwpobsort",
             ),
-            ioassign = dict(
-                optional = False,
+            ioassign=dict(
+                optional=False,
             ),
-            conf = dict(
-                default = 2,
+            conf=dict(
+                default=2,
             ),
-            xpname = dict(
-                default = 'SCRE',
+            xpname=dict(
+                default="SCRE",
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
@@ -220,11 +232,11 @@ class Screening(IFSParallel, odb.OdbComponentDecoMixin):
         # Perform the pre-merging stuff (this will create the ECMA virtual DB)
         virtualdb_path = self.odb_merge_if_needed(allodb)
         # Prepare the CCMA DB
-        ccma_path = self.odb_create_db(layout='CCMA')
+        ccma_path = self.odb_create_db(layout="CCMA")
 
         # Fix paths + generate a global IOASSING file
         self.odb.fix_db_path(self.virtualdb, virtualdb_path)
-        self.odb.fix_db_path('CCMA', ccma_path)
+        self.odb.fix_db_path("CCMA", ccma_path)
         self.odb.ioassign_gather(virtualdb_path, ccma_path)
 
         # Some extra settings
@@ -235,7 +247,7 @@ class Screening(IFSParallel, odb.OdbComponentDecoMixin):
         self.odb_handle_raw_dbs()
 
         # Fix the input databases intent
-        self.odb_rw_or_overwrite_method(* allodb)
+        self.odb_rw_or_overwrite_method(*allodb)
 
         # Look for channels namelists and set appropriate links
         self.setchannels()
@@ -246,12 +258,12 @@ class IFSODBCCMA(IFSParallel, odb.OdbComponentDecoMixin):
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            virtualdb = dict(
-                default = 'ccma',
+        attr=dict(
+            virtualdb=dict(
+                default="ccma",
             ),
-            binarysingle = dict(
-                default = 'basicnwpobsort',
+            binarysingle=dict(
+                default="basicnwpobsort",
             ),
         )
     )
@@ -264,17 +276,23 @@ class IFSODBCCMA(IFSParallel, odb.OdbComponentDecoMixin):
 
         # Looking for input observations
         allodb = self.lookupodb()
-        allccma = [x for x in allodb if x.rh.resource.layout.lower() == 'ccma']
+        allccma = [x for x in allodb if x.rh.resource.layout.lower() == "ccma"]
         if allccma:
             if len(allccma) > 1:
-                logger.error('Multiple CCMA databases detected: only the first one is taken into account')
+                logger.error(
+                    "Multiple CCMA databases detected: only the first one is taken into account"
+                )
         else:
-            raise ValueError('Missing CCMA input data for ' + self.kind)
+            raise ValueError("Missing CCMA input data for " + self.kind)
 
         # Set env and IOASSIGN
         ccma = allccma.pop()
         ccma_path = sh.path.abspath(ccma.rh.container.localpath())
-        self.odb_date_and_layout_from_sections([ccma, ])
+        self.odb_date_and_layout_from_sections(
+            [
+                ccma,
+            ]
+        )
         self.odb.fix_db_path(ccma.rh.resource.layout, ccma_path)
         self.odb.ioassign_gather(ccma_path)
 
@@ -289,19 +307,19 @@ class Minim(IFSODBCCMA):
     """Observation minimisation."""
 
     _footprint = dict(
-        info='Minimisation in the assimilation process.',
+        info="Minimisation in the assimilation process.",
         attr=dict(
             kind=dict(
-                values=['minim', 'min', 'minimisation'],
-                remap=dict(autoremap='first'),
+                values=["minim", "min", "minimisation"],
+                remap=dict(autoremap="first"),
             ),
             conf=dict(
                 default=131,
             ),
             xpname=dict(
-                default='MINI',
+                default="MINI",
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
@@ -309,28 +327,44 @@ class Minim(IFSODBCCMA):
         super().prepare(rh, opts)
 
         # Check if a preconditioning EV map is here
-        evmaprh = self.context.sequence.effective_inputs(role=('PreconEVMap',
-                                                               'PreconditionningEVMap'),
-                                                         kind='precevmap')
+        evmaprh = self.context.sequence.effective_inputs(
+            role=("PreconEVMap", "PreconditionningEVMap"), kind="precevmap"
+        )
         if evmaprh:
             if len(evmaprh) > 1:
-                logger.warning("Several preconditioning EV maps provided. Using the first one.")
-            nprec_ev = evmaprh[0].rh.contents.data['evlen']
+                logger.warning(
+                    "Several preconditioning EV maps provided. Using the first one."
+                )
+            nprec_ev = evmaprh[0].rh.contents.data["evlen"]
             # If there are preconditioning EV: update the namelist
             if nprec_ev > 0:
-                for namrh in [x.rh for x in self.context.sequence.effective_inputs(role='Namelist',
-                                                                                   kind='namelist',)]:
+                for namrh in [
+                    x.rh
+                    for x in self.context.sequence.effective_inputs(
+                        role="Namelist",
+                        kind="namelist",
+                    )
+                ]:
                     namc = namrh.contents
                     try:
-                        namc['NAMVAR'].NPCVECS = nprec_ev
+                        namc["NAMVAR"].NPCVECS = nprec_ev
                         namc.rewrite(namrh.container)
                     except Exception:
-                        logger.critical('Could not fix NAMVAR in %s', namrh.container.actualpath())
+                        logger.critical(
+                            "Could not fix NAMVAR in %s",
+                            namrh.container.actualpath(),
+                        )
                         raise
-                logger.info("%d preconditioning EV will by used (NPCVECS=%d).", nprec_ev, nprec_ev)
+                logger.info(
+                    "%d preconditioning EV will by used (NPCVECS=%d).",
+                    nprec_ev,
+                    nprec_ev,
+                )
             else:
-                logger.warning("A preconditioning EV map was found, " +
-                               "but no preconditioning EV are available.")
+                logger.warning(
+                    "A preconditioning EV map was found, "
+                    + "but no preconditioning EV are available."
+                )
         else:
             logger.info("No preconditioning EV were found.")
 
@@ -339,11 +373,11 @@ class Minim(IFSODBCCMA):
         sh = self.system
 
         # Look up for PREConditionning Eigen Vectors
-        prec = sh.ls('MEMINI*')
+        prec = sh.ls("MEMINI*")
         if prec:
             prec_info = dict(evlen=len(prec))
-            prec_info['evnum'] = [int(x[6:]) for x in prec]
-            sh.json_dump(prec_info, 'precev_map.out', indent=4)
+            prec_info["evnum"] = [int(x[6:]) for x in prec]
+            sh.json_dump(prec_info, "precev_map.out", indent=4)
 
         super().postfix(rh, opts)
 
@@ -352,29 +386,30 @@ class Trajectory(IFSODBCCMA):
     """Observation trajectory."""
 
     _footprint = dict(
-        info='Trajectory in the assimilation process.',
+        info="Trajectory in the assimilation process.",
         attr=dict(
             kind=dict(
-                values=['traj', 'trajectory'],
-                remap=dict(autoremap='first'),
+                values=["traj", "trajectory"],
+                remap=dict(autoremap="first"),
             ),
             conf=dict(
                 default=2,
             ),
             xpname=dict(
-                default='TRAJ',
+                default="TRAJ",
             ),
-        )
+        ),
     )
 
 
 class PseudoTrajectory(BlindRun, drhook.DrHookDecoMixin):
     """Copy a few fields from the Guess file into the Analysis file"""
+
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['pseudotraj', 'traj', 'trajectory'],
-                remap   = dict(autoremap = 'first'),
+        attr=dict(
+            kind=dict(
+                values=["pseudotraj", "traj", "trajectory"],
+                remap=dict(autoremap="first"),
             ),
         )
     )
@@ -382,35 +417,43 @@ class PseudoTrajectory(BlindRun, drhook.DrHookDecoMixin):
 
 class SstGrb2Ascii(BlindRun):
     """Transform sst grib files from the BDAP into ascii files"""
+
     _footprint = dict(
-        info = 'Binary to change the format of sst BDAP files.',
-        attr = dict(
-            kind = dict(
-                values = ['lect_bdap'],
+        info="Binary to change the format of sst BDAP files.",
+        attr=dict(
+            kind=dict(
+                values=["lect_bdap"],
             ),
-            date = a_date,
-            nlat = dict(
-                default = 0,
+            date=a_date,
+            nlat=dict(
+                default=0,
             ),
-            nlon = dict(
-                default = 0,
-            )
-        )
+            nlon=dict(
+                default=0,
+            ),
+        ),
     )
 
     def prepare(self, rh, opts):
         """Add namelist delta, prepare the environment and build the arguments needed."""
         super().prepare(rh, opts)
-        for namrh in [x.rh for x in self.context.sequence.effective_inputs(role='Namelist',
-                                                                           kind='namelist', )]:
+        for namrh in [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role="Namelist",
+                kind="namelist",
+            )
+        ]:
             namc = namrh.contents
             try:
-                namc.newblock('NAMFILE')
-                namc['NAMFILE'].NBFICH = 1
-                namc['NAMFILE']['CCNFICH(1)'] = 'GRIB_SST'
+                namc.newblock("NAMFILE")
+                namc["NAMFILE"].NBFICH = 1
+                namc["NAMFILE"]["CCNFICH(1)"] = "GRIB_SST"
                 namc.rewrite(namrh.container)
             except Exception:
-                logger.critical('Could not fix NAMFILE in %s', namrh.container.actualpath())
+                logger.critical(
+                    "Could not fix NAMFILE in %s", namrh.container.actualpath()
+                )
                 raise
 
     def spawn_command_options(self):
@@ -427,49 +470,60 @@ class SstGrb2Ascii(BlindRun):
 
 class IceNetCDF2Ascii(BlindRun):
     """Transform ice NetCDF files from the BDPE into ascii files"""
+
     _footprint = dict(
-        info = 'Binary to change the format of ice BDPE files.',
-        attr = dict(
-            kind = dict(
-                values = ['ice_nc2ascii'],
+        info="Binary to change the format of ice BDPE files.",
+        attr=dict(
+            kind=dict(
+                values=["ice_nc2ascii"],
             ),
-            output_file = dict(
-                optional = True,
-                default = "ice_concent"
+            output_file=dict(optional=True, default="ice_concent"),
+            param=dict(
+                optional=True,
+                default="ice_conc",
             ),
-            param = dict(
-                optional = True,
-                default = "ice_conc",
-            ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
         super().prepare(rh, opts)
         # Look for the input files
-        list_netcdf = self.context.sequence.effective_inputs(role='NetCDFfiles',
-                                                             kind='observations')
-        hn_file = ''
-        hs_file = ''
+        list_netcdf = self.context.sequence.effective_inputs(
+            role="NetCDFfiles", kind="observations"
+        )
+        hn_file = ""
+        hs_file = ""
         for sect in list_netcdf:
             part = sect.rh.resource.part
             filename = sect.rh.container.filename
             if part == "ice_hn":
-                if hn_file == '':
+                if hn_file == "":
                     hn_file = filename
-                    logger.info('The input file for the North hemisphere is: %s.', hn_file)
+                    logger.info(
+                        "The input file for the North hemisphere is: %s.",
+                        hn_file,
+                    )
                 else:
-                    logger.warning('There was already one file for the North hemisphere. '
-                                   'The following one, %s, is not used.', filename)
+                    logger.warning(
+                        "There was already one file for the North hemisphere. "
+                        "The following one, %s, is not used.",
+                        filename,
+                    )
             elif part == "ice_hs":
-                if hs_file == '':
+                if hs_file == "":
                     hs_file = filename
-                    logger.info('The input file for the South hemisphere is: %s.', hs_file)
+                    logger.info(
+                        "The input file for the South hemisphere is: %s.",
+                        hs_file,
+                    )
                 else:
-                    logger.warning('There was already one file for the South hemisphere. '
-                                   'The following one, %s, is not used.', filename)
+                    logger.warning(
+                        "There was already one file for the South hemisphere. "
+                        "The following one, %s, is not used.",
+                        filename,
+                    )
             else:
-                logger.warning('The following file is not used: %s.', filename)
+                logger.warning("The following file is not used: %s.", filename)
         self.input_file_hn = hn_file
         self.input_file_hs = hs_file
 
@@ -479,5 +533,5 @@ class IceNetCDF2Ascii(BlindRun):
             file_in_hn=self.input_file_hn,
             file_in_hs=self.input_file_hs,
             param=self.param,
-            file_out=self.output_file
+            file_out=self.output_file,
         )

--- a/src/vortex/nwp/algo/clim.py
+++ b/src/vortex/nwp/algo/clim.py
@@ -26,12 +26,12 @@ class BuildPGD(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
     """Preparation of physiographic fields for Surfex."""
 
     _footprint = dict(
-        info = "Physiographic fields for Surfex.",
-        attr = dict(
-            kind = dict(
-                values   = ['buildpgd'],
+        info="Physiographic fields for Surfex.",
+        attr=dict(
+            kind=dict(
+                values=["buildpgd"],
             ),
-        )
+        ),
     )
 
 
@@ -39,12 +39,12 @@ class BuildPGD_MPI(Parallel, DrHookDecoMixin, EcGribDecoMixin):
     """Preparation of physiographic fields for Surfex."""
 
     _footprint = dict(
-        info = "Physiographic fields for Surfex.",
-        attr = dict(
-            kind = dict(
-                values   = ['buildpgd'],
+        info="Physiographic fields for Surfex.",
+        attr=dict(
+            kind=dict(
+                values=["buildpgd"],
             ),
-        )
+        ),
     )
 
 
@@ -52,64 +52,74 @@ class C923(IFSParallel):
     """Preparation of climatologic fields."""
 
     _footprint = dict(
-        info = "Climatologic fields for Arpege/Arome.",
-        attr = dict(
-            kind = dict(
-                values   = ['c923'],
+        info="Climatologic fields for Arpege/Arome.",
+        attr=dict(
+            kind=dict(
+                values=["c923"],
             ),
-            step = dict(
-                info = """Step of conf 923 (NAMCLI::N923).
+            step=dict(
+                info="""Step of conf 923 (NAMCLI::N923).
                           Defines the kind of fields and database processed.""",
-                type = int,
-                values = footprints.util.rangex(1, 10)
+                type=int,
+                values=footprints.util.rangex(1, 10),
             ),
-            orog_in_pgd = dict(
-                info = """Whether orography may be read in a PGD file.
+            orog_in_pgd=dict(
+                info="""Whether orography may be read in a PGD file.
                           (NAMCLA::LIPGD=.TRUE.)""",
-                type = bool,
-                optional = True,
-                default = False,
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            input_orog_name = dict(
-                info = "Filename for input orography file (case LNORO=.T.).",
-                optional = True,
-                default = 'Neworog',
+            input_orog_name=dict(
+                info="Filename for input orography file (case LNORO=.T.).",
+                optional=True,
+                default="Neworog",
             ),
-            xpname = dict(
-                default = 'CLIM',
+            xpname=dict(
+                default="CLIM",
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
         super().prepare(rh, opts)
         # check PGD if needed
         if self.orog_in_pgd:
-            pgd = self.context.sequence.effective_inputs(role=('Pgd',))
+            pgd = self.context.sequence.effective_inputs(role=("Pgd",))
             if len(pgd) == 0:
-                raise ValueError("As long as 'orog_in_pgd' attribute of this " +
-                                 "algo component is True, a 'Role: Pgd' " +
-                                 "resource must be provided.")
+                raise ValueError(
+                    "As long as 'orog_in_pgd' attribute of this "
+                    + "algo component is True, a 'Role: Pgd' "
+                    + "resource must be provided."
+                )
             pgd = pgd[0].rh
-            if pgd.resource.nativefmt == 'fa':
+            if pgd.resource.nativefmt == "fa":
                 self.algoassert(
                     pgd.container.basename == self.input_orog_name,
-                    "Local name for resource Pgd must be '{}'".
-                    format(self.input_orog_name))
-            elif pgd.resource.nativefmt == 'lfi':
-                raise NotImplementedError('CY43T2 onwards: lfi PGD should not be used.')
+                    "Local name for resource Pgd must be '{}'".format(
+                        self.input_orog_name
+                    ),
+                )
+            elif pgd.resource.nativefmt == "lfi":
+                raise NotImplementedError(
+                    "CY43T2 onwards: lfi PGD should not be used."
+                )
 
     def find_namelists(self, opts=None):
-        namrh_list = [x.rh
-                      for x in self.context.sequence.effective_inputs(role=('Namelist',))]
-        self.algoassert(len(namrh_list) == 1,
-                        "One and only one namelist necessary as input.")
+        namrh_list = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(role=("Namelist",))
+        ]
+        self.algoassert(
+            len(namrh_list) == 1,
+            "One and only one namelist necessary as input.",
+        )
         return namrh_list
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         super().prepare_namelist_delta(rh, namcontents, namlocal)
-        namcontents['NAMMCC']['N923'] = self.step
-        namcontents.setmacro('LPGD', self.orog_in_pgd)
+        namcontents["NAMMCC"]["N923"] = self.step
+        namcontents.setmacro("LPGD", self.orog_in_pgd)
         return True
 
 
@@ -122,64 +132,87 @@ class FinalizePGD(AlgoComponent):
     """
 
     _footprint = dict(
-        info = "Finalisation of PGD.",
-        attr = dict(
-            kind = dict(
-                values   = ['finalize_pgd'],
+        info="Finalisation of PGD.",
+        attr=dict(
+            kind=dict(
+                values=["finalize_pgd"],
             ),
-            pgd_out_name = dict(
-                optional = True,
-                default = 'PGD_final.fa'
-            ),
-        )
+            pgd_out_name=dict(optional=True, default="PGD_final.fa"),
+        ),
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.2.14'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
+
+        ev = "1.2.14"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
 
     def execute(self, rh, opts):  # @UnusedVariable
         """Convert SURFGEOPOTENTIEL from clim to SFX.ZS in pgd."""
         import numpy
         from ..util.usepygram import epygram, epy_env_prepare
         from bronx.meteo.constants import g0
+
         # Handle resources
-        clim = self.context.sequence.effective_inputs(role=('Clim',))
-        self.algoassert(len(clim) == 1, "One and only one Clim has to be provided")
-        pgdin = self.context.sequence.effective_inputs(role=('InputPGD',))
-        self.algoassert(len(pgdin) == 1, "One and only one InputPGD has to be provided")
+        clim = self.context.sequence.effective_inputs(role=("Clim",))
+        self.algoassert(
+            len(clim) == 1, "One and only one Clim has to be provided"
+        )
+        pgdin = self.context.sequence.effective_inputs(role=("InputPGD",))
+        self.algoassert(
+            len(pgdin) == 1, "One and only one InputPGD has to be provided"
+        )
         if self.system.path.exists(self.pgd_out_name):
-            raise OSError("The output pgd file {!r} already exists.".format(self.pgd_out_name))
+            raise OSError(
+                "The output pgd file {!r} already exists.".format(
+                    self.pgd_out_name
+                )
+            )
         # copy fields
         with epy_env_prepare(self.ticket):
             epyclim = clim[0].rh.contents.data
             epypgd = pgdin[0].rh.contents.data
             epyclim.open()
             epypgd.open()
-            pgdout = epygram.formats.resource(self.pgd_out_name, 'w', fmt='FA',
-                                              headername=epyclim.headername,
-                                              geometry=epyclim.geometry,
-                                              cdiden=epypgd.cdiden,
-                                              validity=epypgd.validity,
-                                              processtype=epypgd.processtype)
-            g = epyclim.readfield('SURFGEOPOTENTIEL')
-            g.operation('/', g0)
-            g.fid['FA'] = 'SFX.ZS'
+            pgdout = epygram.formats.resource(
+                self.pgd_out_name,
+                "w",
+                fmt="FA",
+                headername=epyclim.headername,
+                geometry=epyclim.geometry,
+                cdiden=epypgd.cdiden,
+                validity=epypgd.validity,
+                processtype=epypgd.processtype,
+            )
+            g = epyclim.readfield("SURFGEOPOTENTIEL")
+            g.operation("/", g0)
+            g.fid["FA"] = "SFX.ZS"
             for f in epypgd.listfields():
                 fld = epypgd.readfield(f)
-                if f == 'SFX.ZS':
+                if f == "SFX.ZS":
                     fld = g
-                elif (isinstance(fld, epygram.fields.H2DField) and
-                      fld.geometry.grid.get('LAMzone') is not None):
-                    ext_data = numpy.ma.masked_equal(numpy.zeros(g.data.shape), 0.)
-                    ext_data[:fld.geometry.dimensions['Y'],
-                             :fld.geometry.dimensions['X']] = fld.data[:, :]
-                    fld = footprints.proxy.fields.almost_clone(fld, geometry=g.geometry)
+                elif (
+                    isinstance(fld, epygram.fields.H2DField)
+                    and fld.geometry.grid.get("LAMzone") is not None
+                ):
+                    ext_data = numpy.ma.masked_equal(
+                        numpy.zeros(g.data.shape), 0.0
+                    )
+                    ext_data[
+                        : fld.geometry.dimensions["Y"],
+                        : fld.geometry.dimensions["X"],
+                    ] = fld.data[:, :]
+                    fld = footprints.proxy.fields.almost_clone(
+                        fld, geometry=g.geometry
+                    )
                     fld.setdata(ext_data)
-                pgdout.writefield(fld, compression=epypgd.fieldscompression.get(f, None))
+                pgdout.writefield(
+                    fld, compression=epypgd.fieldscompression.get(f, None)
+                )
 
 
 class SetFilteredOrogInPGD(AlgoComponent):
@@ -188,48 +221,58 @@ class SetFilteredOrogInPGD(AlgoComponent):
     """
 
     _footprint = dict(
-        info = "Report spectrally optimized, filtered orography from Clim to PGD.",
-        attr = dict(
-            kind = dict(
-                values   = ['set_filtered_orog_in_pgd'],
+        info="Report spectrally optimized, filtered orography from Clim to PGD.",
+        attr=dict(
+            kind=dict(
+                values=["set_filtered_orog_in_pgd"],
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.3.2'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
+
+        ev = "1.3.2"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
 
     def execute(self, rh, opts):  # @UnusedVariable
         """Convert SURFGEOPOTENTIEL from clim to SFX.ZS in pgd."""
         from ..util.usepygram import epygram_checker, epy_env_prepare
         from bronx.meteo.constants import g0
+
         # Handle resources
-        clim = self.context.sequence.effective_inputs(role=('Clim',))
+        clim = self.context.sequence.effective_inputs(role=("Clim",))
         self.algoassert(len(clim) == 1, "One and only one Clim to be provided")
-        pgdin = self.context.sequence.effective_inputs(role=('InputPGD',))
-        self.algoassert(len(pgdin) == 1, "One and only one InputPGD to be provided")
+        pgdin = self.context.sequence.effective_inputs(role=("InputPGD",))
+        self.algoassert(
+            len(pgdin) == 1, "One and only one InputPGD to be provided"
+        )
         # copy fields
         with epy_env_prepare(self.ticket):
             epyclim = clim[0].rh.contents.data
             epypgd = pgdin[0].rh.contents.data
             epyclim.open()
-            epypgd.open(openmode='a')
+            epypgd.open(openmode="a")
             # read spectrally fitted surface geopotential
-            g = epyclim.readfield('SURFGEOPOTENTIEL')
+            g = epyclim.readfield("SURFGEOPOTENTIEL")
             # convert to SURFEX orography
-            g.operation('/', g0)
-            g.fid['FA'] = 'SFX.ZS'
+            g.operation("/", g0)
+            g.fid["FA"] = "SFX.ZS"
             # write as orography
-            if epygram_checker.is_available(version='1.3.6'):
-                epypgd.fieldencoding(g.fid['FA'], update_fieldscompression=True)
+            if epygram_checker.is_available(version="1.3.6"):
+                epypgd.fieldencoding(
+                    g.fid["FA"], update_fieldscompression=True
+                )
             else:
                 # blank read, just to update fieldscompression
-                epypgd.readfield(g.fid['FA'], getdata=False)
-            epypgd.writefield(g, compression=epypgd.fieldscompression.get(g.fid['FA'], None))
+                epypgd.readfield(g.fid["FA"], getdata=False)
+            epypgd.writefield(
+                g, compression=epypgd.fieldscompression.get(g.fid["FA"], None)
+            )
             epypgd.close()
 
 
@@ -240,70 +283,78 @@ class MakeLAMDomain(AlgoComponent):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['make_domain', 'make_lam_domain'],
+        attr=dict(
+            kind=dict(
+                values=["make_domain", "make_lam_domain"],
             ),
-            geometry = dict(
-                info = "The horizontal geometry to be generated.",
-                type = HorizontalGeometry,
+            geometry=dict(
+                info="The horizontal geometry to be generated.",
+                type=HorizontalGeometry,
             ),
-            mode = dict(
-                info = ("Kind of input for building geometry:" +
-                        "'center_dims' to build domain given its centre and" +
-                        "dimensions; 'lonlat_included' to build domain given" +
-                        "an included lon/lat area."),
-                values = ['center_dims', 'lonlat_included']
+            mode=dict(
+                info=(
+                    "Kind of input for building geometry:"
+                    + "'center_dims' to build domain given its centre and"
+                    + "dimensions; 'lonlat_included' to build domain given"
+                    + "an included lon/lat area."
+                ),
+                values=["center_dims", "lonlat_included"],
             ),
-            geom_params = dict(
-                info = ("Set of parameters and/or options to be passed to" +
-                        "epygram.geometries.domain_making.build.build_geometry()" +
-                        "or" +
-                        "epygram.geometries.domain_making.build.build_geometry_fromlonlat()"),
-                type = footprints.FPDict,
+            geom_params=dict(
+                info=(
+                    "Set of parameters and/or options to be passed to"
+                    + "epygram.geometries.domain_making.build.build_geometry()"
+                    + "or"
+                    + "epygram.geometries.domain_making.build.build_geometry_fromlonlat()"
+                ),
+                type=footprints.FPDict,
             ),
-            truncation = dict(
-                info = ("Type of spectral truncation, among" +
-                        "('linear', 'quadratic', 'cubic')."),
-                optional = True,
-                default = 'linear',
+            truncation=dict(
+                info=(
+                    "Type of spectral truncation, among"
+                    + "('linear', 'quadratic', 'cubic')."
+                ),
+                optional=True,
+                default="linear",
             ),
-            orography_truncation = dict(
-                info = ("Type of truncation of orography, among" +
-                        "('linear', 'quadratic', 'cubic')."),
-                optional = True,
-                default = 'quadratic',
+            orography_truncation=dict(
+                info=(
+                    "Type of truncation of orography, among"
+                    + "('linear', 'quadratic', 'cubic')."
+                ),
+                optional=True,
+                default="quadratic",
             ),
-            e_zone_in_pgd = dict(
-                info = "Add E-zone sizes in BuildPGD namelist.",
-                optional = True,
-                type = bool,
-                default = False
+            e_zone_in_pgd=dict(
+                info="Add E-zone sizes in BuildPGD namelist.",
+                optional=True,
+                type=bool,
+                default=False,
             ),
-            i_width_in_pgd = dict(
-                info = "Add I-width size in BuildPGD namelist.",
-                optional = True,
-                type = bool,
-                default = False
+            i_width_in_pgd=dict(
+                info="Add I-width size in BuildPGD namelist.",
+                optional=True,
+                type=bool,
+                default=False,
             ),
             # plot
-            illustration = dict(
-                info = "Create the domain illustration image.",
-                type = bool,
-                optional = True,
-                default = True
+            illustration=dict(
+                info="Create the domain illustration image.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            illustration_fmt = dict(
-                info = "The format of the domain illustration image.",
-                values = ['png', 'pdf'],
-                optional = True,
-                default = 'png'
+            illustration_fmt=dict(
+                info="The format of the domain illustration image.",
+                values=["png", "pdf"],
+                optional=True,
+                default="png",
             ),
-            plot_params = dict(
-                info = "Plot geometry parameters.",
-                type = footprints.FPDict,
-                optional = True,
-                default = footprints.FPDict({'background': True})
+            plot_params=dict(
+                info="Plot geometry parameters.",
+                type=footprints.FPDict,
+                optional=True,
+                default=footprints.FPDict({"background": True}),
             ),
         )
     )
@@ -311,61 +362,87 @@ class MakeLAMDomain(AlgoComponent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.2.14'
+
+        ev = "1.2.14"
         if self.e_zone_in_pgd:
-            ev = '1.3.2'
+            ev = "1.3.2"
         if self.i_width_in_pgd:
-            ev = '1.3.3'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
+            ev = "1.3.3"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
         self._check_geometry()
 
     def _check_geometry(self):
-        if self.mode == 'center_dims':
-            params = ['center_lon', 'center_lat', 'Xpoints_CI', 'Ypoints_CI',
-                      'resolution']
-            params_extended = params + ['tilting', 'Iwidth', 'force_projection',
-                                        'maximize_CI_in_E', 'reference_lat']
-        elif self.mode == 'lonlat_included':
-            params = ['lonmin', 'lonmax', 'latmin', 'latmax',
-                      'resolution']
-            params_extended = params + ['Iwidth', 'force_projection', 'maximize_CI_in_E']
-        self.algoassert(set(params).issubset(set(self.geom_params.keys())),
-                        "With mode=={!s}, geom_params must contain at least {!s}".
-                        format(self.mode, params))
-        self.algoassert(set(self.geom_params.keys()).issubset(set(params_extended)),
-                        "With mode=={!s}, geom_params must contain at most {!s}".
-                        format(self.mode, params))
+        if self.mode == "center_dims":
+            params = [
+                "center_lon",
+                "center_lat",
+                "Xpoints_CI",
+                "Ypoints_CI",
+                "resolution",
+            ]
+            params_extended = params + [
+                "tilting",
+                "Iwidth",
+                "force_projection",
+                "maximize_CI_in_E",
+                "reference_lat",
+            ]
+        elif self.mode == "lonlat_included":
+            params = ["lonmin", "lonmax", "latmin", "latmax", "resolution"]
+            params_extended = params + [
+                "Iwidth",
+                "force_projection",
+                "maximize_CI_in_E",
+            ]
+        self.algoassert(
+            set(params).issubset(set(self.geom_params.keys())),
+            "With mode=={!s}, geom_params must contain at least {!s}".format(
+                self.mode, params
+            ),
+        )
+        self.algoassert(
+            set(self.geom_params.keys()).issubset(set(params_extended)),
+            "With mode=={!s}, geom_params must contain at most {!s}".format(
+                self.mode, params
+            ),
+        )
 
     def execute(self, rh, opts):  # @UnusedVariable
         from ..util.usepygram import epygram
+
         dm = epygram.geometries.domain_making
-        if self.mode == 'center_dims':
+        if self.mode == "center_dims":
             build_func = dm.build.build_geometry
             lonlat_included = None
-        elif self.mode == 'lonlat_included':
+        elif self.mode == "lonlat_included":
             build_func = dm.build.build_geometry_fromlonlat
             lonlat_included = self.geom_params
         # build geometry
         geometry = build_func(interactive=False, **self.geom_params)
         # summary, plot, namelists:
-        with open(self.geometry.tag + '_summary.txt', 'w') as o:
+        with open(self.geometry.tag + "_summary.txt", "w") as o:
             o.write(str(dm.output.summary(geometry)))
         if self.illustration:
-            dm.output.plot_geometry(geometry,
-                                    lonlat_included=lonlat_included,
-                                    out='.'.join([self.geometry.tag,
-                                                  self.illustration_fmt]),
-                                    **self.plot_params)
+            dm.output.plot_geometry(
+                geometry,
+                lonlat_included=lonlat_included,
+                out=".".join([self.geometry.tag, self.illustration_fmt]),
+                **self.plot_params,
+            )
         dm_extra_params = dict()
         if self.e_zone_in_pgd:
-            dm_extra_params['Ezone_in_pgd'] = self.e_zone_in_pgd
+            dm_extra_params["Ezone_in_pgd"] = self.e_zone_in_pgd
         if self.i_width_in_pgd:
-            dm_extra_params['Iwidth_in_pgd'] = self.i_width_in_pgd
-        namelists = dm.output.lam_geom2namelists(geometry,
-                                                 truncation=self.truncation,
-                                                 orography_subtruncation=self.orography_truncation,
-                                                 **dm_extra_params)
+            dm_extra_params["Iwidth_in_pgd"] = self.i_width_in_pgd
+        namelists = dm.output.lam_geom2namelists(
+            geometry,
+            truncation=self.truncation,
+            orography_subtruncation=self.orography_truncation,
+            **dm_extra_params,
+        )
         dm.output.write_namelists(namelists, prefix=self.geometry.tag)
 
 
@@ -376,95 +453,95 @@ class MakeGaussGeometry(Parallel):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['make_gauss_grid'],
+        attr=dict(
+            kind=dict(
+                values=["make_gauss_grid"],
             ),
-            geometry = dict(
-                info = "The vortex horizontal geometry to be generated.",
-                type = HorizontalGeometry,
+            geometry=dict(
+                info="The vortex horizontal geometry to be generated.",
+                type=HorizontalGeometry,
             ),
-            truncation = dict(
-                info = 'nominal truncation',
-                type = int,
+            truncation=dict(
+                info="nominal truncation",
+                type=int,
             ),
-            grid = dict(
-                info = 'type of grid with regards to truncation, among (linear, quadratic, cubic)',
-                optional = True,
-                default = 'linear'
+            grid=dict(
+                info="type of grid with regards to truncation, among (linear, quadratic, cubic)",
+                optional=True,
+                default="linear",
             ),
-            orography_grid = dict(
-                info = 'orography subtruncation (linear, quadratic, cubic)',
-                optional = True,
-                default = 'quadratic'
+            orography_grid=dict(
+                info="orography subtruncation (linear, quadratic, cubic)",
+                optional=True,
+                default="quadratic",
             ),
-            stretching = dict(
-                info = 'stretching factor',
-                type = float,
-                optional = True,
-                default = 1.,
+            stretching=dict(
+                info="stretching factor",
+                type=float,
+                optional=True,
+                default=1.0,
             ),
-            pole = dict(
-                info = 'pole of stretching (lon, lat), angles in degrees',
-                type = footprints.FPDict,
-                optional = True,
-                default = {'lon': 0., 'lat': 90.}
+            pole=dict(
+                info="pole of stretching (lon, lat), angles in degrees",
+                type=footprints.FPDict,
+                optional=True,
+                default={"lon": 0.0, "lat": 90.0},
             ),
             # RGRID commandline options
-            latitudes = dict(
-                info = 'number of Gaussian latitudes',
-                type = int,
-                optional = True,
-                default = None
+            latitudes=dict(
+                info="number of Gaussian latitudes",
+                type=int,
+                optional=True,
+                default=None,
             ),
-            longitudes = dict(
-                info = 'maximum (equatorial) number of longitudes',
-                type = int,
-                optional = True,
-                default = None
+            longitudes=dict(
+                info="maximum (equatorial) number of longitudes",
+                type=int,
+                optional=True,
+                default=None,
             ),
-            orthogonality = dict(
-                info = 'orthogonality precision, as Log10() value',
-                type = int,
-                optional = True,
-                default = None
+            orthogonality=dict(
+                info="orthogonality precision, as Log10() value",
+                type=int,
+                optional=True,
+                default=None,
             ),
-            aliasing = dict(
-                info = 'allowed aliasing, as a Log10() value',
-                type = int,
-                optional = True,
-                default = None
+            aliasing=dict(
+                info="allowed aliasing, as a Log10() value",
+                type=int,
+                optional=True,
+                default=None,
             ),
-            oddity = dict(
-                info = 'odd numbers allowed (1) or not (0)',
-                type = int,
-                optional = True,
-                default = None
+            oddity=dict(
+                info="odd numbers allowed (1) or not (0)",
+                type=int,
+                optional=True,
+                default=None,
             ),
-            verbosity = dict(
-                info = 'verbosity (0 or 1)',
-                type = int,
-                optional = True,
-                default = None
+            verbosity=dict(
+                info="verbosity (0 or 1)",
+                type=int,
+                optional=True,
+                default=None,
             ),
             # plot
-            illustration = dict(
-                info = "Create the domain illustration image.",
-                type = bool,
-                optional = True,
-                default = True
+            illustration=dict(
+                info="Create the domain illustration image.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            illustration_fmt = dict(
-                info = "The format of the domain illustration image.",
-                values = ['png', 'pdf'],
-                optional = True,
-                default = 'png'
+            illustration_fmt=dict(
+                info="The format of the domain illustration image.",
+                values=["png", "pdf"],
+                optional=True,
+                default="png",
             ),
-            plot_params = dict(
-                info = "Plot geometry parameters.",
-                type = footprints.FPDict,
-                optional = True,
-                default = footprints.FPDict({'background': True})
+            plot_params=dict(
+                info="Plot geometry parameters.",
+                type=footprints.FPDict,
+                optional=True,
+                default=footprints.FPDict({"background": True}),
             ),
         )
     )
@@ -472,51 +549,68 @@ class MakeGaussGeometry(Parallel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.2.14'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
+
+        ev = "1.2.14"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
         self._complete_dimensions()
         self._unit = 4
 
     def _complete_dimensions(self):
         from ..util.usepygram import epygram_checker
-        if epygram_checker.is_available(version='1.4.4'):
-            from epygram.geometries.SpectralGeometry import complete_gridpoint_dimensions
-            longitudes, latitudes = complete_gridpoint_dimensions(self.longitudes,
-                                                                  self.latitudes,
-                                                                  self.truncation,
-                                                                  self.grid,
-                                                                  self.stretching)
-            self._attributes['longitudes'] = longitudes
-            self._attributes['latitudes'] = latitudes
+
+        if epygram_checker.is_available(version="1.4.4"):
+            from epygram.geometries.SpectralGeometry import (
+                complete_gridpoint_dimensions,
+            )
+
+            longitudes, latitudes = complete_gridpoint_dimensions(
+                self.longitudes,
+                self.latitudes,
+                self.truncation,
+                self.grid,
+                self.stretching,
+            )
+            self._attributes["longitudes"] = longitudes
+            self._attributes["latitudes"] = latitudes
         else:
             self._old_internal_complete_dimensions()
 
     def _old_internal_complete_dimensions(self):
-        from epygram.geometries.SpectralGeometry import gridpoint_dims_from_truncation
+        from epygram.geometries.SpectralGeometry import (
+            gridpoint_dims_from_truncation,
+        )
+
         if self.latitudes is None and self.longitudes is None:
-            dims = gridpoint_dims_from_truncation({'max': self.truncation},
-                                                  grid=self.grid)
-            self._attributes['latitudes'] = dims['lat_number']
-            self._attributes['longitudes'] = dims['max_lon_number']
+            dims = gridpoint_dims_from_truncation(
+                {"max": self.truncation}, grid=self.grid
+            )
+            self._attributes["latitudes"] = dims["lat_number"]
+            self._attributes["longitudes"] = dims["max_lon_number"]
         elif self.longitudes is None:
-            self._attributes['longitudes'] = 2 * self.latitudes
+            self._attributes["longitudes"] = 2 * self.latitudes
         elif self.latitudes is None:
             if self.longitudes % 4 != 0:
-                self._attributes['latitudes'] = self.longitudes // 2 + 1
+                self._attributes["latitudes"] = self.longitudes // 2 + 1
             else:
-                self._attributes['latitudes'] = self.longitudes // 2
+                self._attributes["latitudes"] = self.longitudes // 2
 
     def spawn_command_options(self):
         """Prepare options for the resource's command line."""
-        options = {'t': str(self.truncation),
-                   'g': str(self.latitudes),
-                   'l': str(self.longitudes),
-                   'f': str(self._unit)}
-        options_dict = {'orthogonality': 'o',
-                        'aliasing': 'a',
-                        'oddity': 'n',
-                        'verbosity': 'v'}
+        options = {
+            "t": str(self.truncation),
+            "g": str(self.latitudes),
+            "l": str(self.longitudes),
+            "f": str(self._unit),
+        }
+        options_dict = {
+            "orthogonality": "o",
+            "aliasing": "a",
+            "oddity": "n",
+            "verbosity": "v",
+        }
         for k in options_dict.keys():
             if getattr(self, k) is not None:
                 options[options_dict[k]] = str(getattr(self, k))
@@ -525,16 +619,22 @@ class MakeGaussGeometry(Parallel):
     def postfix(self, rh, opts):
         """Complete and write namelists."""
         from ..util.usepygram import epygram_checker
-        if epygram_checker.is_available(version='1.4.4'):
-            from epygram.geometries.domain_making.output import gauss_rgrid2namelists
-            gauss_rgrid2namelists('fort.{!s}'.format(self._unit),
-                                  self.geometry.tag,
-                                  self.latitudes,
-                                  self.longitudes,
-                                  self.truncation,
-                                  self.stretching,
-                                  self.orography_grid,
-                                  self.pole)
+
+        if epygram_checker.is_available(version="1.4.4"):
+            from epygram.geometries.domain_making.output import (
+                gauss_rgrid2namelists,
+            )
+
+            gauss_rgrid2namelists(
+                "fort.{!s}".format(self._unit),
+                self.geometry.tag,
+                self.latitudes,
+                self.longitudes,
+                self.truncation,
+                self.stretching,
+                self.orography_grid,
+                self.pole,
+            )
         else:
             self._old_internal_postfix(rh, opts)
         super().postfix(rh, opts)
@@ -542,82 +642,97 @@ class MakeGaussGeometry(Parallel):
     def _old_internal_postfix(self, rh, opts):
         """Complete and write namelists."""
         import math
-        from epygram.geometries.SpectralGeometry import truncation_from_gridpoint_dims
+        from epygram.geometries.SpectralGeometry import (
+            truncation_from_gridpoint_dims,
+        )
+
         # complete scalar parameters
         nam = namelist.NamelistSet()
-        nam.add(namelist.NamelistBlock('NAM_PGD_GRID'))
-        nam.add(namelist.NamelistBlock('NAMDIM'))
-        nam.add(namelist.NamelistBlock('NAMGEM'))
-        nam['NAM_PGD_GRID']['CGRID'] = 'GAUSS'
-        nam['NAMDIM']['NDGLG'] = self.latitudes
-        nam['NAMDIM']['NDLON'] = self.longitudes
-        nam['NAMDIM']['NSMAX'] = self.truncation
-        nam['NAMGEM']['NHTYP'] = 2
-        nam['NAMGEM']['NSTTYP'] = 2 if self.pole != {'lon': 0., 'lat': 90.} else 1
-        nam['NAMGEM']['RMUCEN'] = math.sin(math.radians(float(self.pole['lat'])))
-        nam['NAMGEM']['RLOCEN'] = math.radians(float(self.pole['lon']))
-        nam['NAMGEM']['RSTRET'] = self.stretching
+        nam.add(namelist.NamelistBlock("NAM_PGD_GRID"))
+        nam.add(namelist.NamelistBlock("NAMDIM"))
+        nam.add(namelist.NamelistBlock("NAMGEM"))
+        nam["NAM_PGD_GRID"]["CGRID"] = "GAUSS"
+        nam["NAMDIM"]["NDGLG"] = self.latitudes
+        nam["NAMDIM"]["NDLON"] = self.longitudes
+        nam["NAMDIM"]["NSMAX"] = self.truncation
+        nam["NAMGEM"]["NHTYP"] = 2
+        nam["NAMGEM"]["NSTTYP"] = (
+            2 if self.pole != {"lon": 0.0, "lat": 90.0} else 1
+        )
+        nam["NAMGEM"]["RMUCEN"] = math.sin(
+            math.radians(float(self.pole["lat"]))
+        )
+        nam["NAMGEM"]["RLOCEN"] = math.radians(float(self.pole["lon"]))
+        nam["NAMGEM"]["RSTRET"] = self.stretching
         # numbers of longitudes
-        with open('fort.{!s}'.format(self._unit)) as n:
+        with open("fort.{!s}".format(self._unit)) as n:
             namrgri = namelist.namparse(n)
             nam.merge(namrgri)
         # PGD namelist
         nam_pgd = copy.deepcopy(nam)
-        nam_pgd['NAMGEM'].delvar('NHTYP')
-        nam_pgd['NAMGEM'].delvar('NSTTYP')
-        nam_pgd['NAMDIM'].delvar('NSMAX')
-        nam_pgd['NAMDIM'].delvar('NDLON')
-        with open('.'.join([self.geometry.tag,
-                            'namel_buildpgd',
-                            'geoblocks']),
-                  'w') as out:
+        nam_pgd["NAMGEM"].delvar("NHTYP")
+        nam_pgd["NAMGEM"].delvar("NSTTYP")
+        nam_pgd["NAMDIM"].delvar("NSMAX")
+        nam_pgd["NAMDIM"].delvar("NDLON")
+        with open(
+            ".".join([self.geometry.tag, "namel_buildpgd", "geoblocks"]), "w"
+        ) as out:
             out.write(nam_pgd.dumps(sorting=namelist.SECOND_ORDER_SORTING))
         # C923 namelist
-        del nam['NAM_PGD_GRID']
-        with open('.'.join([self.geometry.tag,
-                            'namel_c923',
-                            'geoblocks']),
-                  'w') as out:
+        del nam["NAM_PGD_GRID"]
+        with open(
+            ".".join([self.geometry.tag, "namel_c923", "geoblocks"]), "w"
+        ) as out:
             out.write(nam.dumps(sorting=namelist.SECOND_ORDER_SORTING))
         # subtruncated grid for orography
         from ..util.usepygram import epygram_checker
-        ev = '1.4.4'
+
+        ev = "1.4.4"
         if epygram_checker.is_available(version=ev):
-            trunc_nsmax = truncation_from_gridpoint_dims({'lat_number': self.latitudes,
-                                                          'max_lon_number': self.longitudes},
-                                                         grid=self.orography_grid,
-                                                         stretching_coef=self.stretching
-                                                         )['max']
+            trunc_nsmax = truncation_from_gridpoint_dims(
+                {
+                    "lat_number": self.latitudes,
+                    "max_lon_number": self.longitudes,
+                },
+                grid=self.orography_grid,
+                stretching_coef=self.stretching,
+            )["max"]
         else:
-            trunc_nsmax = truncation_from_gridpoint_dims({'lat_number': self.latitudes,
-                                                          'max_lon_number': self.longitudes},
-                                                         grid=self.orography_grid
-                                                         )['max']
-        nam['NAMDIM']['NSMAX'] = trunc_nsmax
-        with open('.'.join([self.geometry.tag,
-                            'namel_c923_orography',
-                            'geoblocks']),
-                  'w') as out:
+            trunc_nsmax = truncation_from_gridpoint_dims(
+                {
+                    "lat_number": self.latitudes,
+                    "max_lon_number": self.longitudes,
+                },
+                grid=self.orography_grid,
+            )["max"]
+        nam["NAMDIM"]["NSMAX"] = trunc_nsmax
+        with open(
+            ".".join([self.geometry.tag, "namel_c923_orography", "geoblocks"]),
+            "w",
+        ) as out:
             out.write(nam.dumps(sorting=namelist.SECOND_ORDER_SORTING))
         # C927 (fullpos) namelist
         nam = namelist.NamelistSet()
-        nam.add(namelist.NamelistBlock('NAMFPD'))
-        nam.add(namelist.NamelistBlock('NAMFPG'))
-        nam['NAMFPD']['NLAT'] = self.latitudes
-        nam['NAMFPD']['NLON'] = self.longitudes
-        nam['NAMFPG']['NFPMAX'] = self.truncation
-        nam['NAMFPG']['NFPHTYP'] = 2
-        nam['NAMFPG']['NFPTTYP'] = 2 if self.pole != {'lon': 0., 'lat': 90.} else 1
-        nam['NAMFPG']['FPMUCEN'] = math.sin(math.radians(float(self.pole['lat'])))
-        nam['NAMFPG']['FPLOCEN'] = math.radians(float(self.pole['lon']))
-        nam['NAMFPG']['FPSTRET'] = self.stretching
-        nrgri = [v for _, v in sorted(namrgri['NAMRGRI'].items())]
+        nam.add(namelist.NamelistBlock("NAMFPD"))
+        nam.add(namelist.NamelistBlock("NAMFPG"))
+        nam["NAMFPD"]["NLAT"] = self.latitudes
+        nam["NAMFPD"]["NLON"] = self.longitudes
+        nam["NAMFPG"]["NFPMAX"] = self.truncation
+        nam["NAMFPG"]["NFPHTYP"] = 2
+        nam["NAMFPG"]["NFPTTYP"] = (
+            2 if self.pole != {"lon": 0.0, "lat": 90.0} else 1
+        )
+        nam["NAMFPG"]["FPMUCEN"] = math.sin(
+            math.radians(float(self.pole["lat"]))
+        )
+        nam["NAMFPG"]["FPLOCEN"] = math.radians(float(self.pole["lon"]))
+        nam["NAMFPG"]["FPSTRET"] = self.stretching
+        nrgri = [v for _, v in sorted(namrgri["NAMRGRI"].items())]
         for i in range(len(nrgri)):
-            nam['NAMFPG']['NFPRGRI({:>4})'.format(i + 1)] = nrgri[i]
-        with open('.'.join([self.geometry.tag,
-                            'namel_c927',
-                            'geoblocks']),
-                  'w') as out:
+            nam["NAMFPG"]["NFPRGRI({:>4})".format(i + 1)] = nrgri[i]
+        with open(
+            ".".join([self.geometry.tag, "namel_c927", "geoblocks"]), "w"
+        ) as out:
             out.write(nam.dumps(sorting=namelist.SECOND_ORDER_SORTING))
 
 
@@ -628,68 +743,70 @@ class MakeBDAPDomain(AlgoComponent):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['make_domain', 'make_bdap_domain'],
+        attr=dict(
+            kind=dict(
+                values=["make_domain", "make_bdap_domain"],
             ),
-            geometry = dict(
-                info = "The horizontal geometry to be generated.",
-                type = HorizontalGeometry,
+            geometry=dict(
+                info="The horizontal geometry to be generated.",
+                type=HorizontalGeometry,
             ),
-            mode = dict(
-                info = ("Kind of input for building geometry:" +
-                        "'boundaries' to build domain given its lon/lat boundaries" +
-                        "(+ resolution); 'inside_model' to build domain given" +
-                        "a model geometry to be included in (+ resolution)."),
-                values = ['boundaries', 'inside_model']
+            mode=dict(
+                info=(
+                    "Kind of input for building geometry:"
+                    + "'boundaries' to build domain given its lon/lat boundaries"
+                    + "(+ resolution); 'inside_model' to build domain given"
+                    + "a model geometry to be included in (+ resolution)."
+                ),
+                values=["boundaries", "inside_model"],
             ),
-            resolution = dict(
-                info = "Resolution in degrees.",
-                type = float,
-                optional = True,
-                default = None,
+            resolution=dict(
+                info="Resolution in degrees.",
+                type=float,
+                optional=True,
+                default=None,
             ),
             resolution_x=dict(
                 info="X resolution in degrees (if different from Y).",
                 type=float,
-                optional = True,
-                default = None,
+                optional=True,
+                default=None,
             ),
             resolution_y=dict(
                 info="Y resolution in degrees (if different from X).",
                 type=float,
-                optional = True,
-                default = None,
+                optional=True,
+                default=None,
             ),
-            boundaries = dict(
-                info = "Lonlat boundaries of the domain, case mode='boundaries'.",
-                type = footprints.FPDict,
-                optional = True,
-                default = None,
+            boundaries=dict(
+                info="Lonlat boundaries of the domain, case mode='boundaries'.",
+                type=footprints.FPDict,
+                optional=True,
+                default=None,
             ),
-            model_clim = dict(
-                info = "Filename of the model clim, case mode='inside_model'.",
-                optional = True,
-                default = None,
+            model_clim=dict(
+                info="Filename of the model clim, case mode='inside_model'.",
+                optional=True,
+                default=None,
             ),
             # plot
-            illustration = dict(
-                info = "Create the domain illustration image.",
-                type = bool,
-                optional = True,
-                default = True
+            illustration=dict(
+                info="Create the domain illustration image.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            illustration_fmt = dict(
-                info = "The format of the domain illustration image.",
-                values = ['png', 'pdf'],
-                optional = True,
-                default = 'png'
+            illustration_fmt=dict(
+                info="The format of the domain illustration image.",
+                values=["png", "pdf"],
+                optional=True,
+                default="png",
             ),
-            plot_params = dict(
-                info = "Plot geometry parameters.",
-                type = footprints.FPDict,
-                optional = True,
-                default = footprints.FPDict({'background': True})
+            plot_params=dict(
+                info="Plot geometry parameters.",
+                type=footprints.FPDict,
+                optional=True,
+                default=footprints.FPDict({"background": True}),
             ),
         )
     )
@@ -697,37 +814,50 @@ class MakeBDAPDomain(AlgoComponent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.2.14'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
-        if self.mode == 'boundaries':
-            params = ['lonmin', 'lonmax', 'latmin', 'latmax']
-            self.algoassert(set(params) == set(self.boundaries.keys()),
-                            "With mode=={}, boundaries must contain at least {}".
-                            format(self.mode, str(params)))
+
+        ev = "1.2.14"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
+        if self.mode == "boundaries":
+            params = ["lonmin", "lonmax", "latmin", "latmax"]
+            self.algoassert(
+                set(params) == set(self.boundaries.keys()),
+                "With mode=={}, boundaries must contain at least {}".format(
+                    self.mode, str(params)
+                ),
+            )
             if self.model_clim is not None:
-                logger.info('attribute *model_clim* ignored')
-        elif self.mode == 'inside_model':
-            self.algoassert(self.model_clim is not None,
-                            "attribute *model_clim* must be provided with " +
-                            "mode=='inside_model'.")
+                logger.info("attribute *model_clim* ignored")
+        elif self.mode == "inside_model":
+            self.algoassert(
+                self.model_clim is not None,
+                "attribute *model_clim* must be provided with "
+                + "mode=='inside_model'.",
+            )
             self.algoassert(self.sh.path.exists(self.model_clim))
             if self.boundaries is not None:
-                logger.info('attribute *boundaries* ignored')
+                logger.info("attribute *boundaries* ignored")
         if self.resolution is None:
-            self.algoassert(None not in (self.resolution_x, self.resolution_y),
-                            "Must provide *resolution* OR *resolution_x/resolution_y*")
+            self.algoassert(
+                None not in (self.resolution_x, self.resolution_y),
+                "Must provide *resolution* OR *resolution_x/resolution_y*",
+            )
         else:
-            self.algoassert(self.resolution_x is None and self.resolution_y is None,
-                            "Must provide *resolution* OR *resolution_x/resolution_y*")
+            self.algoassert(
+                self.resolution_x is None and self.resolution_y is None,
+                "Must provide *resolution* OR *resolution_x/resolution_y*",
+            )
 
     def execute(self, rh, opts):  # @UnusedVariable
         from ..util.usepygram import epygram
+
         dm = epygram.geometries.domain_making
-        if self.mode == 'inside_model':
-            r = epygram.formats.resource(self.model_clim, 'r')
-            if r.format == 'FA':
-                g = r.readfield('SURFGEOPOTENTIEL')
+        if self.mode == "inside_model":
+            r = epygram.formats.resource(self.model_clim, "r")
+            if r.format == "FA":
+                g = r.readfield("SURFGEOPOTENTIEL")
             else:
                 raise NotImplementedError()
             boundaries = dm.build.compute_lonlat_included(g.geometry)
@@ -735,28 +865,28 @@ class MakeBDAPDomain(AlgoComponent):
             boundaries = self.boundaries
         # build geometry
         if self.resolution is None:
-            geometry = dm.build.build_lonlat_geometry(boundaries,
-                                                      resolution=(self.resolution_x,
-                                                                  self.resolution_y))
+            geometry = dm.build.build_lonlat_geometry(
+                boundaries, resolution=(self.resolution_x, self.resolution_y)
+            )
         else:
-            geometry = dm.build.build_lonlat_geometry(boundaries,
-                                                      resolution=self.resolution)
+            geometry = dm.build.build_lonlat_geometry(
+                boundaries, resolution=self.resolution
+            )
         # summary, plot, namelists:
         if self.illustration:
-            fig, _ = geometry.plotgeometry(color='red',
-                                           title=self.geometry.tag,
-                                           **self.plot_params)
-            fig.savefig('.'.join([self.geometry.tag,
-                                  self.illustration_fmt]),
-                        bbox_inches='tight')
+            fig, _ = geometry.plotgeometry(
+                color="red", title=self.geometry.tag, **self.plot_params
+            )
+            fig.savefig(
+                ".".join([self.geometry.tag, self.illustration_fmt]),
+                bbox_inches="tight",
+            )
         namelists = dm.output.regll_geom2namelists(geometry)
         dm.output.write_namelists(namelists, prefix=self.geometry.tag)
-        self.system.symlink('.'.join([self.geometry.tag,
-                                      'namel_c923',
-                                      'geoblocks']),
-                            '.'.join([self.geometry.tag,
-                                      'namel_c923_orography',
-                                      'geoblocks']))
+        self.system.symlink(
+            ".".join([self.geometry.tag, "namel_c923", "geoblocks"]),
+            ".".join([self.geometry.tag, "namel_c923_orography", "geoblocks"]),
+        )
 
 
 class AddPolesToGLOB(TaylorRun):
@@ -765,44 +895,50 @@ class AddPolesToGLOB(TaylorRun):
     """
 
     _footprint = dict(
-        info = "Add poles to a GLOB* regular FA Lon/Lat file that do not contain them.",
-        attr = dict(
-            kind = dict(
-                values   = ['add_poles'],
+        info="Add poles to a GLOB* regular FA Lon/Lat file that do not contain them.",
+        attr=dict(
+            kind=dict(
+                values=["add_poles"],
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..util.usepygram import epygram_checker
-        ev = '1.3.4'
-        self.algoassert(epygram_checker.is_available(version=ev), "Epygram >= " + ev +
-                        " is needed here")
+
+        ev = "1.3.4"
+        self.algoassert(
+            epygram_checker.is_available(version=ev),
+            "Epygram >= " + ev + " is needed here",
+        )
 
     def execute(self, rh, opts):  # @UnusedVariable
         """Add poles to a GLOB* regular FA Lon/Lat file that do not contain them."""
         self._default_pre_execute(rh, opts)
         common_i = self._default_common_instructions(rh, opts)
-        clims = self.context.sequence.effective_inputs(role=('Clim',))
-        self._add_instructions(common_i, dict(filename=[s.rh.container.localpath()
-                                                        for s in clims]))
+        clims = self.context.sequence.effective_inputs(role=("Clim",))
+        self._add_instructions(
+            common_i,
+            dict(filename=[s.rh.container.localpath() for s in clims]),
+        )
         self._default_post_execute(rh, opts)
 
 
 class _AddPolesWorker(TaylorVortexWorker):
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['add_poles']
-            ),
-            filename = dict(
-                info='The file to be processed.'),
+        attr=dict(
+            kind=dict(values=["add_poles"]),
+            filename=dict(info="The file to be processed."),
         )
     )
 
     def vortex_task(self, **_):
-        from ..util.usepygram import add_poles_to_reglonlat_file, epy_env_prepare
+        from ..util.usepygram import (
+            add_poles_to_reglonlat_file,
+            epy_env_prepare,
+        )
+
         with epy_env_prepare(self.ticket):
             add_poles_to_reglonlat_file(self.filename)
 
@@ -813,21 +949,23 @@ class Festat(Parallel):
     """
 
     _footprint = dict(
-        info = "Run festat",
-        attr = dict(
-            kind = dict(
-                values = ['run_festat', ],
+        info="Run festat",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "run_festat",
+                ],
             ),
-            nb_digits = dict(
-                info = "Number of digits on which the name of the files should be written",
-                type = int,
-                default = 3,
-                optional = True,
+            nb_digits=dict(
+                info="Number of digits on which the name of the files should be written",
+                type=int,
+                default=3,
+                optional=True,
             ),
-            prefix = dict(
-                info = "Name of the files for the binary",
-                optional = True,
-                default = "CNAME",
+            prefix=dict(
+                info="Name of the files for the binary",
+                optional=True,
+                default="CNAME",
             ),
         ),
     )
@@ -836,34 +974,52 @@ class Festat(Parallel):
 
     def prepare(self, rh, opts):
         # Check the namelist
-        input_namelist = self.context.sequence.effective_inputs(role="Namelist", kind="namelist")
+        input_namelist = self.context.sequence.effective_inputs(
+            role="Namelist", kind="namelist"
+        )
         if len(input_namelist) != 1:
             logger.error("One and only one namelist must be provided.")
             raise ValueError("One and only one namelist must be provided.")
         else:
             input_namelist = input_namelist[0].rh
         # Create links for the input files
-        maxinsec = 10 ** self.nb_digits
+        maxinsec = 10**self.nb_digits
         insec = self.context.sequence.effective_inputs(role="InputFiles")
         nbinsec = len(insec)
         if nbinsec > maxinsec:
-            logger.error("The number of input files %s exceed the maximum number of files available %s.",
-                         nbinsec, maxinsec)
-            raise ValueError("The number of input files exceed the maximum number of files available.")
+            logger.error(
+                "The number of input files %s exceed the maximum number of files available %s.",
+                nbinsec,
+                maxinsec,
+            )
+            raise ValueError(
+                "The number of input files exceed the maximum number of files available."
+            )
         else:
             logger.info("%s input files will be treated.", nbinsec)
         i = 0
         for sec in insec:
             i += 1
-            self.system.symlink(sec.rh.container.actualpath(),
-                                "{prefix}{number}".format(prefix=self.prefix,
-                                                          number=str(i).zfill(self.nb_digits)))
+            self.system.symlink(
+                sec.rh.container.actualpath(),
+                "{prefix}{number}".format(
+                    prefix=self.prefix, number=str(i).zfill(self.nb_digits)
+                ),
+            )
         # Put the number of sections and the prefix of the input files in the namelist
         namcontents = input_namelist.contents
-        logger.info('Setup macro CNAME=%s in %s', self.prefix, input_namelist.container.actualpath())
-        namcontents.setmacro('CNAME', self.prefix)
-        logger.info('Setup macro NCASES=%s in %s', i, input_namelist.container.actualpath())
-        namcontents.setmacro('NCASES', i)
+        logger.info(
+            "Setup macro CNAME=%s in %s",
+            self.prefix,
+            input_namelist.container.actualpath(),
+        )
+        namcontents.setmacro("CNAME", self.prefix)
+        logger.info(
+            "Setup macro NCASES=%s in %s",
+            i,
+            input_namelist.container.actualpath(),
+        )
+        namcontents.setmacro("NCASES", i)
         namcontents.rewrite(input_namelist.container)
         self._nb_input_files = i
         # Call the super class
@@ -873,19 +1029,27 @@ class Festat(Parallel):
         # Rename stabal files
         list_stabal = self.system.glob("stab*")
         for stabal in list_stabal:
-            self.system.mv(stabal,
-                           "{stabal}.ncases_{ncases}".format(stabal=stabal, ncases=self._nb_input_files))
+            self.system.mv(
+                stabal,
+                "{stabal}.ncases_{ncases}".format(
+                    stabal=stabal, ncases=self._nb_input_files
+                ),
+            )
         # Deal with diag files
         list_diag_stat = self.system.glob("co*y")
         if len(list_diag_stat) > 0:
-            diastat_dir_name = "dia.stat.ncases_{ncases}".format(ncases=self._nb_input_files)
+            diastat_dir_name = "dia.stat.ncases_{ncases}".format(
+                ncases=self._nb_input_files
+            )
             self.system.mkdir(diastat_dir_name)
             for file in list_diag_stat:
                 self.system.mv(file, diastat_dir_name + "/")
             self.system.tar(diastat_dir_name + ".tar", diastat_dir_name)
         list_diag_expl = self.system.glob("expl*y")
         if len(list_diag_expl) > 0:
-            diaexpl_dir_name = "dia.expl.ncases_{ncases}".format(ncases=self._nb_input_files)
+            diaexpl_dir_name = "dia.expl.ncases_{ncases}".format(
+                ncases=self._nb_input_files
+            )
             self.system.mkdir(diaexpl_dir_name)
             for file in list_diag_expl:
                 self.system.mv(file, diaexpl_dir_name + "/")
@@ -900,10 +1064,12 @@ class Fediacov(Parallel):
     """
 
     _footprint = dict(
-        info = "Run fediacov",
-        attr = dict(
-            kind = dict(
-                values = ['run_fediacov', ],
+        info="Run fediacov",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "run_fediacov",
+                ],
             ),
         ),
     )

--- a/src/vortex/nwp/algo/coupling.py
+++ b/src/vortex/nwp/algo/coupling.py
@@ -12,7 +12,10 @@ from bronx.stdtypes import date
 from .ifsroot import IFSParallel
 from ..tools.drhook import DrHookDecoMixin
 from vortex.algo.components import AlgoComponentError, BlindRun, Parallel
-from vortex.algo.components import AlgoComponentDecoMixin, algo_component_deco_mixin_autodoc
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    algo_component_deco_mixin_autodoc,
+)
 from vortex.layout.dataflow import intent
 from vortex.tools.grib import EcGribDecoMixin
 
@@ -29,7 +32,7 @@ coupling_basedate_fp = footprints.Footprint(
         basedate=dict(
             info="The run date of the coupling generating process",
             type=date.Date,
-            optional=True
+            optional=True,
         )
     )
 )
@@ -39,25 +42,31 @@ coupling_basedate_fp = footprints.Footprint(
 class CouplingBaseDateNamMixin(AlgoComponentDecoMixin):
     """Add a basedate attribute and make namelist substitution."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = (coupling_basedate_fp, )
+    _MIXIN_EXTRA_FOOTPRINTS = (coupling_basedate_fp,)
 
     def _prepare_basedate_hook(self, rh, opts):
         """Update the namelist with date information."""
 
         def set_nam_macro(namrh, macro, value):
             namrh.contents.setmacro(macro, value)
-            logger.info('Setup macro %s=%s in %s', macro, str(value),
-                        namrh.container.actualpath())
+            logger.info(
+                "Setup macro %s=%s in %s",
+                macro,
+                str(value),
+                namrh.container.actualpath(),
+            )
 
-        for namsec in self.context.sequence.effective_inputs(kind=('namelist',)):
+        for namsec in self.context.sequence.effective_inputs(
+            kind=("namelist",)
+        ):
             if self.basedate is not None:
-                set_nam_macro(namsec.rh, 'YYYY', int(self.basedate.year))
-                set_nam_macro(namsec.rh, 'MM', int(self.basedate.month))
-                set_nam_macro(namsec.rh, 'DD', int(self.basedate.day))
+                set_nam_macro(namsec.rh, "YYYY", int(self.basedate.year))
+                set_nam_macro(namsec.rh, "MM", int(self.basedate.month))
+                set_nam_macro(namsec.rh, "DD", int(self.basedate.day))
                 if namsec.rh.contents.dumps_needs_update:
                     namsec.rh.save()
 
-    _MIXIN_PREPARE_HOOKS = (_prepare_basedate_hook, )
+    _MIXIN_PREPARE_HOOKS = (_prepare_basedate_hook,)
 
 
 class Coupling(FullPos):
@@ -69,26 +78,28 @@ class Coupling(FullPos):
     _footprint = [
         coupling_basedate_fp,
         dict(
-            info = "Create coupling files for a Limited Area Model.",
-            attr = dict(
-                kind = dict(
-                    values   = ['coupling'],
+            info="Create coupling files for a Limited Area Model.",
+            attr=dict(
+                kind=dict(
+                    values=["coupling"],
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'coupling'
+        return "coupling"
 
     def prepare(self, rh, opts):
         """Default pre-link for namelist file and domain change."""
         super().prepare(rh, opts)
-        namsec = self.setlink(initrole='Namelist', initkind='namelist', initname='fort.4')
-        for nam in [x.rh for x in namsec if 'NAMFPC' in x.rh.contents]:
+        namsec = self.setlink(
+            initrole="Namelist", initkind="namelist", initname="fort.4"
+        )
+        for nam in [x.rh for x in namsec if "NAMFPC" in x.rh.contents]:
             logger.info('Substitute "AREA" to CFPDOM namelist entry')
-            nam.contents['NAMFPC']['CFPDOM(1)'] = 'AREA'
+            nam.contents["NAMFPC"]["CFPDOM(1)"] = "AREA"
             nam.save()
 
     def execute(self, rh, opts):
@@ -97,142 +108,202 @@ class Coupling(FullPos):
         sh = self.system
 
         cplsec = self.context.sequence.effective_inputs(
-            role=('InitialCondition', 'CouplingSource'),
-            kind=('historic', 'analysis')
+            role=("InitialCondition", "CouplingSource"),
+            kind=("historic", "analysis"),
         )
         cplsec.sort(key=lambda s: s.rh.resource.term)
-        ininc = self.naming_convention('ic', rh)
+        ininc = self.naming_convention("ic", rh)
         infile = ininc()
         isMany = len(cplsec) > 1
-        outprefix = 'PF{:s}AREA'.format(self.xpname)
+        outprefix = "PF{:s}AREA".format(self.xpname)
 
-        cplguess = self.context.sequence.effective_inputs(role='Guess')
+        cplguess = self.context.sequence.effective_inputs(role="Guess")
         cplguess.sort(key=lambda s: s.rh.resource.term)
         guessing = bool(cplguess)
 
-        cplsurf = self.context.sequence.effective_inputs(role=('SurfaceInitialCondition',
-                                                               'SurfaceCouplingSource'))
+        cplsurf = self.context.sequence.effective_inputs(
+            role=("SurfaceInitialCondition", "SurfaceCouplingSource")
+        )
         cplsurf.sort(key=lambda s: s.rh.resource.term)
         surfacing = bool(cplsurf)
-        inisurfnc = self.naming_convention('ic', rh, model='surfex')
+        inisurfnc = self.naming_convention("ic", rh, model="surfex")
         infilesurf = inisurfnc()
         if surfacing:
             # Link in the Surfex's PGD
-            sclimnc = self.naming_convention(kind='targetclim', rh=rh, model='surfex')
+            sclimnc = self.naming_convention(
+                kind="targetclim", rh=rh, model="surfex"
+            )
             self.setlink(
-                initrole=('ClimPGD',),
-                initkind=('pgdfa', 'pgdlfi'),
-                initname=sclimnc(area='AREA')
+                initrole=("ClimPGD",),
+                initkind=("pgdfa", "pgdlfi"),
+                initname=sclimnc(area="AREA"),
             )
 
         for sec in cplsec:
             r = sec.rh
-            sh.subtitle('Loop on {!s}'.format(r.resource))
+            sh.subtitle("Loop on {!s}".format(r.resource))
 
             # First attempt to set actual date as the one of the source model
             actualdate = r.resource.date + r.resource.term
 
             # Expect the coupling source to be there...
-            self.grab(sec, comment='coupling source')
+            self.grab(sec, comment="coupling source")
 
             # Set the actual init file
             if sh.path.exists(infile):
                 if isMany:
-                    logger.critical('Cannot process multiple Historic files if %s exists.', infile)
+                    logger.critical(
+                        "Cannot process multiple Historic files if %s exists.",
+                        infile,
+                    )
             else:
-                sh.cp(r.container.localpath(), infile, fmt=r.container.actualfmt, intent=intent.IN)
+                sh.cp(
+                    r.container.localpath(),
+                    infile,
+                    fmt=r.container.actualfmt,
+                    intent=intent.IN,
+                )
 
             # If the surface file is needed, set the actual initsurf file
             if cplsurf:
                 # Expecting the coupling surface source to be there...
                 cplsurf_in = cplsurf.pop(0)
-                self.grab(cplsurf_in, comment='coupling surface source')
+                self.grab(cplsurf_in, comment="coupling surface source")
                 if sh.path.exists(infilesurf):
                     if isMany:
-                        logger.critical('Cannot process multiple surface historic files if %s exists.',
-                                        infilesurf)
+                        logger.critical(
+                            "Cannot process multiple surface historic files if %s exists.",
+                            infilesurf,
+                        )
                 else:
-                    sh.cp(cplsurf_in.rh.container.localpath(), infilesurf,
-                          fmt=cplsurf_in.rh.container.actualfmt, intent=intent.IN)
+                    sh.cp(
+                        cplsurf_in.rh.container.localpath(),
+                        infilesurf,
+                        fmt=cplsurf_in.rh.container.actualfmt,
+                        intent=intent.IN,
+                    )
             elif surfacing:
-                logger.error('No more surface source to loop on for coupling')
+                logger.error("No more surface source to loop on for coupling")
 
             # The output could be an input as well
             if cplguess:
                 cplout = cplguess.pop(0)
                 cplpath = cplout.rh.container.localpath()
                 if sh.path.exists(cplpath):
-                    actualdateguess = cplout.rh.resource.date + cplout.rh.resource.term
-                    if (actualdate == actualdateguess):
-                        logger.error('The guess date, %s, is different from the source date %s, !',
-                                     actualdateguess.reallynice(), actualdate.reallynice())
+                    actualdateguess = (
+                        cplout.rh.resource.date + cplout.rh.resource.term
+                    )
+                    if actualdate == actualdateguess:
+                        logger.error(
+                            "The guess date, %s, is different from the source date %s, !",
+                            actualdateguess.reallynice(),
+                            actualdate.reallynice(),
+                        )
                     # Expect the coupling guess to be there...
-                    self.grab(cplout, comment='coupling guess')
-                    logger.info('Coupling with existing guess <%s>', cplpath)
-                    inoutfile = outprefix + '+0000'
+                    self.grab(cplout, comment="coupling guess")
+                    logger.info("Coupling with existing guess <%s>", cplpath)
+                    inoutfile = outprefix + "+0000"
                     if cplpath != inoutfile:
                         sh.remove(inoutfile, fmt=cplout.rh.container.actualfmt)
-                        sh.move(cplpath, inoutfile,
-                                fmt=cplout.rh.container.actualfmt,
-                                intent=intent.INOUT)
+                        sh.move(
+                            cplpath,
+                            inoutfile,
+                            fmt=cplout.rh.container.actualfmt,
+                            intent=intent.INOUT,
+                        )
                 else:
-                    logger.warning('Missing guess input for coupling <%s>', cplpath)
+                    logger.warning(
+                        "Missing guess input for coupling <%s>", cplpath
+                    )
             elif guessing:
-                logger.error('No more guess to loop on for coupling')
+                logger.error("No more guess to loop on for coupling")
 
             # Find out actual monthly climatological resource
             actualmonth = date.Month(actualdate)
-            self.climfile_fixer(rh, convkind='modelclim', month=actualmonth,
-                                inputrole=('GlobalClim', 'InitialClim'),
-                                inputkind='clim_model')
-            self.climfile_fixer(rh, convkind='targetclim', month=actualmonth,
-                                inputrole=('LocalClim', 'TargetClim'),
-                                inputkind='clim_model', area='AREA')
+            self.climfile_fixer(
+                rh,
+                convkind="modelclim",
+                month=actualmonth,
+                inputrole=("GlobalClim", "InitialClim"),
+                inputkind="clim_model",
+            )
+            self.climfile_fixer(
+                rh,
+                convkind="targetclim",
+                month=actualmonth,
+                inputrole=("LocalClim", "TargetClim"),
+                inputkind="clim_model",
+                area="AREA",
+            )
 
             # Standard execution
             super().execute(rh, opts)
 
             # Set a local appropriate file
-            posfile = [x for x in sh.glob(outprefix + '+*')
-                       if re.match(outprefix + r'\+\d+(?:\:\d+)?(?:\.sfx)?$', x)]
-            if (len(posfile) > 1):
-                logger.critical('Many ' + outprefix + ' files, do not know how to adress that')
+            posfile = [
+                x
+                for x in sh.glob(outprefix + "+*")
+                if re.match(outprefix + r"\+\d+(?:\:\d+)?(?:\.sfx)?$", x)
+            ]
+            if len(posfile) > 1:
+                logger.critical(
+                    "Many "
+                    + outprefix
+                    + " files, do not know how to adress that"
+                )
             posfile = posfile[0]
             if self.basedate is None:
                 actualterm = r.resource.term
             else:
                 actualterm = (actualdate - self.basedate).time()
-            actualname = (re.sub(r'^.+?((?:_\d+)?)(?:\+[:\d]+)?$', r'CPLOUT\1+', r.container.localpath()) +
-                          actualterm.fmthm)
+            actualname = (
+                re.sub(
+                    r"^.+?((?:_\d+)?)(?:\+[:\d]+)?$",
+                    r"CPLOUT\1+",
+                    r.container.localpath(),
+                )
+                + actualterm.fmthm
+            )
             if isMany:
-                sh.move(sh.path.realpath(posfile), actualname,
-                        fmt=r.container.actualfmt)
+                sh.move(
+                    sh.path.realpath(posfile),
+                    actualname,
+                    fmt=r.container.actualfmt,
+                )
                 if sh.path.exists(posfile):
                     sh.rm(posfile)
             else:
                 # This is here because of legacy with .sfx files
-                sh.cp(sh.path.realpath(posfile), actualname,
-                      fmt=r.container.actualfmt, intent=intent.IN)
+                sh.cp(
+                    sh.path.realpath(posfile),
+                    actualname,
+                    fmt=r.container.actualfmt,
+                    intent=intent.IN,
+                )
 
             # promises management
-            expected = [x for x in self.promises if x.rh.container.localpath() == actualname]
+            expected = [
+                x
+                for x in self.promises
+                if x.rh.container.localpath() == actualname
+            ]
             if expected:
                 for thispromise in expected:
                     thispromise.put(incache=True)
 
             # The only one listing
             if not self.server_run:
-                sh.cat('NODE.001_01', output='NODE.all')
+                sh.cat("NODE.001_01", output="NODE.all")
 
             # prepares the next execution
             if isMany:
                 # Some cleaning
-                sh.rmall('PXFPOS*', fmt=r.container.actualfmt)
+                sh.rmall("PXFPOS*", fmt=r.container.actualfmt)
                 sh.remove(infile, fmt=r.container.actualfmt)
                 if cplsurf:
                     sh.remove(infilesurf, fmt=r.container.actualfmt)
                 if not self.server_run:
-                    sh.rmall('ncf927', 'dirlst', 'NODE.[0123456789]*', 'std*')
+                    sh.rmall("ncf927", "dirlst", "NODE.[0123456789]*", "std*")
 
 
 class CouplingLAM(Coupling):
@@ -242,18 +313,18 @@ class CouplingLAM(Coupling):
     """
 
     _footprint = dict(
-        info = "Create coupling files for a Limited Area Model (useless beyond cy40).",
-        attr = dict(
-            kind = dict(
-                values   = ['lamcoupling'],
+        info="Create coupling files for a Limited Area Model (useless beyond cy40).",
+        attr=dict(
+            kind=dict(
+                values=["lamcoupling"],
             ),
-        )
+        ),
     )
 
     def spawn_command_options(self):
         """Dictionary provided for command line factory."""
         opts = super().spawn_command_options()
-        opts['model'] = 'aladin'
+        opts["model"] = "aladin"
         return opts
 
 
@@ -261,157 +332,219 @@ class CouplingLAM(Coupling):
 class PrepMixin(AlgoComponentDecoMixin):
     """Coupling/Interpolation of Surfex files."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = (footprints.Footprint(
-        info="Coupling/Interpolation of Surfex files.",
-        attr=dict(
-            kind=dict(
-                values=['prep'],
+    _MIXIN_EXTRA_FOOTPRINTS = (
+        footprints.Footprint(
+            info="Coupling/Interpolation of Surfex files.",
+            attr=dict(
+                kind=dict(
+                    values=["prep"],
+                ),
+                underlyingformat=dict(
+                    info="The format of input data (as expected by the PREP executable).",
+                    values=["fa", "lfi", "netcdf"],
+                    optional=True,
+                    default="fa",
+                ),
+                underlyingoutputformat=dict(
+                    info=(
+                        "The format of output data (as expected by the PREP executable)."
+                        + "If omited, *underlyingformat* is used."
+                    ),
+                    values=["fa", "lfi", "netcdf", "txt"],
+                    optional=True,
+                ),
+                outputformat=dict(
+                    info=(
+                        "The format of output data (as expected by the user)."
+                        + "If omited, same as input data."
+                    ),
+                    values=["fa", "lfi", "netcdf", "txt"],
+                    optional=True,
+                ),
             ),
-            underlyingformat=dict(
-                info="The format of input data (as expected by the PREP executable).",
-                values=['fa', 'lfi', 'netcdf'],
-                optional=True,
-                default='fa'
-            ),
-            underlyingoutputformat=dict(
-                info=("The format of output data (as expected by the PREP executable)." +
-                      "If omited, *underlyingformat* is used."),
-                values=['fa', 'lfi', 'netcdf', 'txt'],
-                optional=True,
-            ),
-            outputformat=dict(
-                info=("The format of output data (as expected by the user)." +
-                      "If omited, same as input data."),
-                values=['fa', 'lfi', 'netcdf', 'txt'],
-                optional=True,
-            ),
-        )
-    ), )
+        ),
+    )
 
     @cached_property
     def _actual_u_output_format(self):
-        return (self.underlyingoutputformat
-                if self.underlyingoutputformat is not None else
-                self.underlyingformat)
+        return (
+            self.underlyingoutputformat
+            if self.underlyingoutputformat is not None
+            else self.underlyingformat
+        )
 
     def _actual_output_format(self, in_format):
-        return (self.outputformat if self.outputformat is not None
-                else in_format)
+        return (
+            self.outputformat if self.outputformat is not None else in_format
+        )
 
     @staticmethod
     def _sfx_fmt_remap(fmt):
-        return dict(netcdf='nc').get(fmt, fmt)
+        return dict(netcdf="nc").get(fmt, fmt)
 
     @cached_property
     def _has_sfx_lfi(self):
-        addon_checked = ('sfx' in self.system.loaded_addons() and
-                         'lfi' in self.system.loaded_addons())
+        addon_checked = (
+            "sfx" in self.system.loaded_addons()
+            and "lfi" in self.system.loaded_addons()
+        )
         if not addon_checked:
             raise RuntimeError("The sfx addon is needed... please load it.")
         return addon_checked
 
     def _do_input_format_change(self, section, output_name, output_fmt):
-        (localpath, infmt) = (section.rh.container.localpath(),
-                              section.rh.container.actualfmt)
+        (localpath, infmt) = (
+            section.rh.container.localpath(),
+            section.rh.container.actualfmt,
+        )
         self.system.subtitle("Processing inputs/climatologies")
         if section.rh.container.actualfmt != output_fmt:
-            if infmt == 'fa' and output_fmt == 'lfi' and self._has_sfx_lfi:
+            if infmt == "fa" and output_fmt == "lfi" and self._has_sfx_lfi:
                 if self.system.path.exists(output_name):
-                    raise OSError("The file {!r} already exists.".format(output_name))
-                logger.info("Calling sfxtools' fa2lfi from %s to %s.", localpath, output_name)
+                    raise OSError(
+                        "The file {!r} already exists.".format(output_name)
+                    )
+                logger.info(
+                    "Calling sfxtools' fa2lfi from %s to %s.",
+                    localpath,
+                    output_name,
+                )
                 self.system.sfx_fa2lfi(localpath, output_name)
             else:
-                raise RuntimeError("Format conversion from {!r} to {!r} is not possible".format(
-                                   infmt, output_fmt))
+                raise RuntimeError(
+                    "Format conversion from {!r} to {!r} is not possible".format(
+                        infmt, output_fmt
+                    )
+                )
         else:
             if not self.system.path.exists(output_name):
                 logger.info("Linking %s to %s", localpath, output_name)
-                self.system.cp(localpath, output_name, intent=intent.IN, fmt=infmt)
+                self.system.cp(
+                    localpath, output_name, intent=intent.IN, fmt=infmt
+                )
 
     def _process_outputs(self, binrh, section, output_clim, output_name):
-        (radical, outfmt) = (self.system.path.splitext(section.rh.container.localpath())[0],
-                             self._actual_output_format(section.rh.container.actualfmt))
-        finaloutput = '{:s}_interpolated.{:s}'.format(radical, outfmt)
-        finallisting = '{:s}_listing'.format(radical)
+        (radical, outfmt) = (
+            self.system.path.splitext(section.rh.container.localpath())[0],
+            self._actual_output_format(section.rh.container.actualfmt),
+        )
+        finaloutput = "{:s}_interpolated.{:s}".format(radical, outfmt)
+        finallisting = "{:s}_listing".format(radical)
         self.system.subtitle("Processing outputs")
         if outfmt != self._actual_u_output_format:
             # There is a need for a format change
-            if outfmt == 'fa' and self._actual_u_output_format == 'lfi' and self._has_sfx_lfi:
-                logger.info("Calling lfitools' faempty from %s to %s.", output_clim, finaloutput)
+            if (
+                outfmt == "fa"
+                and self._actual_u_output_format == "lfi"
+                and self._has_sfx_lfi
+            ):
+                logger.info(
+                    "Calling lfitools' faempty from %s to %s.",
+                    output_clim,
+                    finaloutput,
+                )
                 self.system.fa_empty(output_clim, finaloutput)
-                logger.info("Calling sfxtools' lfi2fa from %s to %s.", output_name, finaloutput)
+                logger.info(
+                    "Calling sfxtools' lfi2fa from %s to %s.",
+                    output_name,
+                    finaloutput,
+                )
                 self.system.sfx_lfi2fa(output_name, finaloutput)
-                finallfi = '{:s}_interpolated.{:s}'.format(radical, self._actual_u_output_format)
+                finallfi = "{:s}_interpolated.{:s}".format(
+                    radical, self._actual_u_output_format
+                )
                 self.system.mv(output_name, finallfi)
             else:
-                raise RuntimeError("Format conversion from {!r} to {!r} is not possible".format(
-                                   self._actual_u_output_format, outfmt))
+                raise RuntimeError(
+                    "Format conversion from {!r} to {!r} is not possible".format(
+                        self._actual_u_output_format, outfmt
+                    )
+                )
         else:
             # No format change needed
             logger.info("Moving %s to %s", output_name, finaloutput)
             self.system.mv(output_name, finaloutput, fmt=outfmt)
         # Also rename the listing :-)
-        if binrh.resource.cycle < 'cy48t1':
+        if binrh.resource.cycle < "cy48t1":
             try:
-                self.system.mv('LISTING_PREP.txt', finallisting)
+                self.system.mv("LISTING_PREP.txt", finallisting)
             except OSError:
-                self.system.mv('LISTING_PREP0.txt', finallisting)
+                self.system.mv("LISTING_PREP0.txt", finallisting)
         else:
-            self.system.mv('LISTING_PREP0.txt', finallisting)
+            self.system.mv("LISTING_PREP0.txt", finallisting)
         return finaloutput
 
     def _prepare_prep_hook(self, rh, opts):
         """Default pre-link for namelist file and domain change."""
         # Convert the initial clim if needed...
-        iniclim = self.context.sequence.effective_inputs(role=('InitialClim',))
+        iniclim = self.context.sequence.effective_inputs(role=("InitialClim",))
         if not (len(iniclim) == 1):
             raise AlgoComponentError("One Initial clim have to be provided")
-        self._do_input_format_change(iniclim[0],
-                                     'PGD1.' + self._sfx_fmt_remap(self.underlyingformat),
-                                     self.underlyingformat)
+        self._do_input_format_change(
+            iniclim[0],
+            "PGD1." + self._sfx_fmt_remap(self.underlyingformat),
+            self.underlyingformat,
+        )
         # Convert the target clim if needed...
-        targetclim = self.context.sequence.effective_inputs(role=('TargetClim',))
+        targetclim = self.context.sequence.effective_inputs(
+            role=("TargetClim",)
+        )
         if not (len(targetclim) == 1):
             raise AlgoComponentError("One Target clim have to be provided")
-        self._do_input_format_change(targetclim[0],
-                                     'PGD2.' + self._sfx_fmt_remap(self._actual_u_output_format),
-                                     self._actual_u_output_format)
+        self._do_input_format_change(
+            targetclim[0],
+            "PGD2." + self._sfx_fmt_remap(self._actual_u_output_format),
+            self._actual_u_output_format,
+        )
 
-    _MIXIN_PREPARE_HOOKS = (_prepare_prep_hook, )
+    _MIXIN_PREPARE_HOOKS = (_prepare_prep_hook,)
 
     def _spawn_hook_prep_hook(self):
         """Dump the namelists."""
-        for namsec in self.context.sequence.effective_inputs(kind=('namelist', )):
-            self.system.subtitle("Here is the content of the {:s} namelist"
-                                 .format(namsec.rh.container.actualpath()))
+        for namsec in self.context.sequence.effective_inputs(
+            kind=("namelist",)
+        ):
+            self.system.subtitle(
+                "Here is the content of the {:s} namelist".format(
+                    namsec.rh.container.actualpath()
+                )
+            )
             namsec.rh.container.cat()
 
-    _MIXIN_SPAWN_HOOKS = (_spawn_hook_prep_hook, )
+    _MIXIN_SPAWN_HOOKS = (_spawn_hook_prep_hook,)
 
     def _execute_prep_common(self, rh, opts):
         """Loop on the various initial conditions provided."""
         sh = self.system
 
         cplsec = self.context.sequence.effective_inputs(
-            role=('InitialCondition', 'CouplingSource'),
-            kind=('historic', 'analysis')
+            role=("InitialCondition", "CouplingSource"),
+            kind=("historic", "analysis"),
         )
         cplsec.sort(key=lambda s: s.rh.resource.term)
-        infile = 'PREP1.{:s}'.format(self._sfx_fmt_remap(self.underlyingformat))
-        outfile = 'PREP2.{:s}'.format(self._sfx_fmt_remap(self._actual_u_output_format))
-        targetclim = self.context.sequence.effective_inputs(role=('TargetClim',))
+        infile = "PREP1.{:s}".format(
+            self._sfx_fmt_remap(self.underlyingformat)
+        )
+        outfile = "PREP2.{:s}".format(
+            self._sfx_fmt_remap(self._actual_u_output_format)
+        )
+        targetclim = self.context.sequence.effective_inputs(
+            role=("TargetClim",)
+        )
         targetclim = targetclim[0].rh.container.localpath()
 
         for sec in cplsec:
             r = sec.rh
-            sh.header('Loop on {:s}'.format(r.container.localpath()))
+            sh.header("Loop on {:s}".format(r.container.localpath()))
 
             # Expect the coupling source to be there...
-            self.grab(sec, comment='coupling source')
+            self.grab(sec, comment="coupling source")
 
             # Set the actual init file
             if sh.path.exists(infile):
-                logger.critical('Cannot process input files if %s exists.', infile)
+                logger.critical(
+                    "Cannot process input files if %s exists.", infile
+                )
             self._do_input_format_change(sec, infile, self.underlyingformat)
 
             # Standard execution
@@ -423,27 +556,43 @@ class PrepMixin(AlgoComponentDecoMixin):
             actualname = self._process_outputs(rh, sec, targetclim, outfile)
 
             # promises management
-            expected = [x for x in self.promises if x.rh.container.localpath() == actualname]
+            expected = [
+                x
+                for x in self.promises
+                if x.rh.container.localpath() == actualname
+            ]
             if expected:
                 for thispromise in expected:
                     thispromise.put(incache=True)
 
             # Some cleaning
-            sh.rmall('*.des')
-            sh.rmall('PREP1.*')
+            sh.rmall("*.des")
+            sh.rmall("PREP1.*")
 
     _MIXIN_EXECUTE_OVERWRITE = _execute_prep_common
 
 
-class Prep(BlindRun, PrepMixin, CouplingBaseDateNamMixin,
-           DrHookDecoMixin, EcGribDecoMixin):
+class Prep(
+    BlindRun,
+    PrepMixin,
+    CouplingBaseDateNamMixin,
+    DrHookDecoMixin,
+    EcGribDecoMixin,
+):
     """Coupling/Interpolation of Surfex files (non-MPI version)."""
+
     pass
 
 
-class ParallelPrep(Parallel, PrepMixin, CouplingBaseDateNamMixin,
-                   DrHookDecoMixin, EcGribDecoMixin):
+class ParallelPrep(
+    Parallel,
+    PrepMixin,
+    CouplingBaseDateNamMixin,
+    DrHookDecoMixin,
+    EcGribDecoMixin,
+):
     """Coupling/Interpolation of Surfex files (MPI version)."""
+
     pass
 
 
@@ -451,18 +600,16 @@ class C901(IFSParallel):
     """Run of C901 configuration."""
 
     _footprint = dict(
-        info = "Run C901 configuration",
-        attr = dict(
-            kind = dict(
-                values = ["c901", ]
+        info="Run C901 configuration",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "c901",
+                ]
             ),
-            clim = dict(
-                type = bool
-            ),
-            xpname = dict(
-                default = 'a001'
-            )
-        )
+            clim=dict(type=bool),
+            xpname=dict(default="a001"),
+        ),
     )
 
     SPECTRAL_FILE_SH = "ICMSH{prefix}INIT{suffix}"
@@ -470,12 +617,16 @@ class C901(IFSParallel):
     GRIDPOINT_FILE_GG = "ICMGG{prefix}INIT{suffix}"
     OUTPUT_FILE_NAME = "CN90x{}INIT"
     OUTPUT_LISTING_NAME = "NODE.001_01"
-    LIST_INPUT_FILES = [("SpectralFileSH", SPECTRAL_FILE_SH),
-                        ("GridpointFileUA", GRIDPOINT_FILE_UA),
-                        ("GridpointFileGG", GRIDPOINT_FILE_GG)]
-    LIST_CST_INPUT_FILES = [("ConstantSpectralFileSH", SPECTRAL_FILE_SH),
-                            ("ConstantGridpointFileUA", GRIDPOINT_FILE_UA),
-                            ("ConstantGridpointFileGG", GRIDPOINT_FILE_GG)]
+    LIST_INPUT_FILES = [
+        ("SpectralFileSH", SPECTRAL_FILE_SH),
+        ("GridpointFileUA", GRIDPOINT_FILE_UA),
+        ("GridpointFileGG", GRIDPOINT_FILE_GG),
+    ]
+    LIST_CST_INPUT_FILES = [
+        ("ConstantSpectralFileSH", SPECTRAL_FILE_SH),
+        ("ConstantGridpointFileUA", GRIDPOINT_FILE_UA),
+        ("ConstantGridpointFileGG", GRIDPOINT_FILE_GG),
+    ]
 
     @property
     def realkind(self):
@@ -484,30 +635,47 @@ class C901(IFSParallel):
     def sort_files_per_prefix(self, list_types, unique=False):
         """Function used to sort the files according to their prefix in a given type"""
         result = dict()
-        for (file_role, file_template) in list_types:
+        for file_role, file_template in list_types:
             result[file_role] = dict()
             input_files = self.context.sequence.effective_inputs(
                 role=file_role
             )
-            template = file_template.format(prefix=r"(?P<prefix>\S{4})", suffix=r"(?P<suffix>\S*)")
+            template = file_template.format(
+                prefix=r"(?P<prefix>\S{4})", suffix=r"(?P<suffix>\S*)"
+            )
             for file_s in input_files:
                 file_name = file_s.rh.container.filename
                 find_elements = re.search(template, file_name)
                 if find_elements is None:
-                    logger.error("The name of the file %s do not follow the template %s.",
-                                 file_name, template)
-                    raise ValueError("The name of the file do not follow the template.")
+                    logger.error(
+                        "The name of the file %s do not follow the template %s.",
+                        file_name,
+                        template,
+                    )
+                    raise ValueError(
+                        "The name of the file do not follow the template."
+                    )
                 else:
                     if find_elements.group("prefix") not in result[file_role]:
-                        result[file_role][find_elements.group("prefix")] = list()
+                        result[file_role][find_elements.group("prefix")] = (
+                            list()
+                        )
                     else:
                         if unique:
-                            logger.error("Only one file should be present for each type and each suffix.")
-                            raise ValueError("Only one file should be present for each suffix.")
-                    result[file_role][find_elements.group("prefix")].append(file_s)
+                            logger.error(
+                                "Only one file should be present for each type and each suffix."
+                            )
+                            raise ValueError(
+                                "Only one file should be present for each suffix."
+                            )
+                    result[file_role][find_elements.group("prefix")].append(
+                        file_s
+                    )
             if result[file_role]:
                 for file_prefix in result[file_role]:
-                    result[file_role][file_prefix].sort(key=lambda s: s.rh.resource.date + s.rh.resource.term)
+                    result[file_role][file_prefix].sort(
+                        key=lambda s: s.rh.resource.date + s.rh.resource.term
+                    )
             else:
                 del result[file_role]
         return result
@@ -518,13 +686,21 @@ class C901(IFSParallel):
         sh = self.system
 
         # Create the template for files to be removed at each validity date and for the outputname
-        deleted_spectral_file_SH = self.SPECTRAL_FILE_SH.format(prefix="*", suffix="")
-        deleted_gridpoint_file_UA = self.GRIDPOINT_FILE_UA.format(prefix="*", suffix="")
-        deleted_gridpoint_file_GG = self.GRIDPOINT_FILE_GG.format(prefix="*", suffix="")
+        deleted_spectral_file_SH = self.SPECTRAL_FILE_SH.format(
+            prefix="*", suffix=""
+        )
+        deleted_gridpoint_file_UA = self.GRIDPOINT_FILE_UA.format(
+            prefix="*", suffix=""
+        )
+        deleted_gridpoint_file_GG = self.GRIDPOINT_FILE_GG.format(
+            prefix="*", suffix=""
+        )
         output_name = self.OUTPUT_FILE_NAME.format(self.xpname.upper())
 
         # Sort input files
-        sorted_cst_input_files = self.sort_files_per_prefix(self.LIST_CST_INPUT_FILES, unique=True)
+        sorted_cst_input_files = self.sort_files_per_prefix(
+            self.LIST_CST_INPUT_FILES, unique=True
+        )
         sorted_input_files = self.sort_files_per_prefix(self.LIST_INPUT_FILES)
 
         # Determine the validity present for each non constant input files,
@@ -533,77 +709,123 @@ class C901(IFSParallel):
         input_validity = list()
         for file_role in sorted_input_files:
             for file_prefix in sorted_input_files[file_role]:
-                input_validity.append([s.rh.resource.date + s.rh.resource.term
-                                       for s in sorted_input_files[file_role][file_prefix]])
+                input_validity.append(
+                    [
+                        s.rh.resource.date + s.rh.resource.term
+                        for s in sorted_input_files[file_role][file_prefix]
+                    ]
+                )
         test_wrong_input_validity = True
         for i in range(1, len(input_validity)):
-            test_wrong_input_validity = test_wrong_input_validity and (input_validity[0] == input_validity[i])
-        self.algoassert(test_wrong_input_validity,
-                        "The files of each type must have the same validity dates.")
+            test_wrong_input_validity = test_wrong_input_validity and (
+                input_validity[0] == input_validity[i]
+            )
+        self.algoassert(
+            test_wrong_input_validity,
+            "The files of each type must have the same validity dates.",
+        )
 
         # Modify namelist
         input_namelist = self.context.sequence.effective_inputs(
-            role="Namelist",
-            kind="namelist"
+            role="Namelist", kind="namelist"
         )
         for namelist in input_namelist:
             namcontents = namelist.rh.contents
-            self._set_nam_macro(namcontents, namelist.rh.container.actualpath(),
-                                'LLCLIM', self.clim)
+            self._set_nam_macro(
+                namcontents,
+                namelist.rh.container.actualpath(),
+                "LLCLIM",
+                self.clim,
+            )
             if namcontents.dumps_needs_update:
                 namcontents.rewrite(namelist.rh.container)
 
         for current_validity in input_validity[0]:
             # Deal with constant input files (gridpoint and spectral)
-            for (file_role, file_template) in self.LIST_CST_INPUT_FILES:
+            for file_role, file_template in self.LIST_CST_INPUT_FILES:
                 if file_role in sorted_cst_input_files:
                     for file_prefix in sorted_cst_input_files[file_role]:
-                        file_name = file_template.format(prefix=file_prefix, suffix="")
-                        current_file_input = sorted_cst_input_files[file_role][file_prefix][0]
-                        self.algoassert(not sh.path.exists(file_name),
-                                        "The file {} already exists. It should not.".format(file_name))
-                        sh.cp(current_file_input.rh.container.iotarget(), file_name, intent="in")
+                        file_name = file_template.format(
+                            prefix=file_prefix, suffix=""
+                        )
+                        current_file_input = sorted_cst_input_files[file_role][
+                            file_prefix
+                        ][0]
+                        self.algoassert(
+                            not sh.path.exists(file_name),
+                            "The file {} already exists. It should not.".format(
+                                file_name
+                            ),
+                        )
+                        sh.cp(
+                            current_file_input.rh.container.iotarget(),
+                            file_name,
+                            intent="in",
+                        )
 
             # Deal with other input files (gridpoint and spectral)
-            for (file_role, file_template) in self.LIST_INPUT_FILES:
+            for file_role, file_template in self.LIST_INPUT_FILES:
                 if file_role in sorted_input_files:
                     for file_prefix in sorted_input_files[file_role]:
-                        file_name = file_template.format(prefix=file_prefix, suffix="")
-                        current_file_input = sorted_input_files[file_role][file_prefix].pop()
-                        self.algoassert(not sh.path.exists(file_name),
-                                        "The file {} already exists. It should not.".format(file_name))
-                        sh.cp(current_file_input.rh.container.iotarget(), file_name, intent="in")
+                        file_name = file_template.format(
+                            prefix=file_prefix, suffix=""
+                        )
+                        current_file_input = sorted_input_files[file_role][
+                            file_prefix
+                        ].pop()
+                        self.algoassert(
+                            not sh.path.exists(file_name),
+                            "The file {} already exists. It should not.".format(
+                                file_name
+                            ),
+                        )
+                        sh.cp(
+                            current_file_input.rh.container.iotarget(),
+                            file_name,
+                            intent="in",
+                        )
 
             if self.clim:
                 # Find the right climatology file
                 current_month = date.Month(current_validity)
-                self.climfile_fixer(rh, convkind='modelclim', month=current_month,
-                                    inputrole=('GlobalClim', 'InitialClim'),
-                                    inputkind='clim_model')
+                self.climfile_fixer(
+                    rh,
+                    convkind="modelclim",
+                    month=current_month,
+                    inputrole=("GlobalClim", "InitialClim"),
+                    inputkind="clim_model",
+                )
 
             # Standard execution
             super().execute(rh, opts)
             # Move the output file
             current_term = current_file_input.rh.resource.term
-            sh.move(output_name, output_name + "+{}".format(current_term.fmthm))
+            sh.move(
+                output_name, output_name + "+{}".format(current_term.fmthm)
+            )
             # Cat all the listings into a single one
-            sh.cat(self.OUTPUT_LISTING_NAME, output='NODE.all')
+            sh.cat(self.OUTPUT_LISTING_NAME, output="NODE.all")
             # Remove unneeded files
-            sh.rmall(deleted_spectral_file_SH, deleted_gridpoint_file_GG, deleted_gridpoint_file_UA,
-                     'std*', self.OUTPUT_LISTING_NAME)
+            sh.rmall(
+                deleted_spectral_file_SH,
+                deleted_gridpoint_file_GG,
+                deleted_gridpoint_file_UA,
+                "std*",
+                self.OUTPUT_LISTING_NAME,
+            )
 
 
 class DomeoForcingAtmo(BlindRun, CouplingBaseDateNamMixin):
     """Correct the Domeo forcing file."""
 
     _footprint = dict(
-        info='Domeo Forcing Atmo',
+        info="Domeo Forcing Atmo",
         attr=dict(
             kind=dict(
-                values=['domeo_forcing'],
+                values=["domeo_forcing"],
             ),
             basedate=dict(
                 optional=False,
             ),
-        )
+        ),
     )

--- a/src/vortex/nwp/algo/eda.py
+++ b/src/vortex/nwp/algo/eda.py
@@ -24,27 +24,30 @@ class IFSEdaAbstractAlgo(IFSParallel):
 
     _abstract = True
     _footprint = dict(
-        info='Base class for any EDA related task',
+        info="Base class for any EDA related task",
         attr=dict(
-            inputnaming = dict(
-                info = 'Prescribe your own naming template for input files.',
-                optional = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
+            inputnaming=dict(
+                info="Prescribe your own naming template for input files.",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-        )
+        ),
     )
 
     def naming_convention(self, kind, rh, actualfmt=None, **kwargs):
         """Take into account the *inputnaming* attribute."""
-        if kind == 'edainput':
-            return super().naming_convention(kind, rh,
-                                             actualfmt=actualfmt,
-                                             namingformat=self.inputnaming,
-                                             **kwargs)
+        if kind == "edainput":
+            return super().naming_convention(
+                kind,
+                rh,
+                actualfmt=actualfmt,
+                namingformat=self.inputnaming,
+                **kwargs,
+            )
         else:
-            return super().naming_convention(kind, rh,
-                                             actualfmt=actualfmt,
-                                             **kwargs)
+            return super().naming_convention(
+                kind, rh, actualfmt=actualfmt, **kwargs
+            )
 
 
 class IFSEdaEnsembleAbstractAlgo(IFSEdaAbstractAlgo):
@@ -55,24 +58,24 @@ class IFSEdaEnsembleAbstractAlgo(IFSEdaAbstractAlgo):
     to deal with missing members).
     """
 
-    _INPUTS_ROLE = 'ModelState'
+    _INPUTS_ROLE = "ModelState"
 
     _abstract = True
     _footprint = dict(
-        info='Base class for any EDA related task',
+        info="Base class for any EDA related task",
         attr=dict(
-            nbmember = dict(
-                info = "The number of members to deal will (auto-detected if omitted)",
-                type = int,
-                optional = True,
+            nbmember=dict(
+                info="The number of members to deal will (auto-detected if omitted)",
+                type=int,
+                optional=True,
             ),
-            nbmin = dict(
-                info = "The minimum number of input members that is mandatory to go one",
-                type = int,
-                optional = True,
-                default = 2,
-            )
-        )
+            nbmin=dict(
+                info="The minimum number of input members that is mandatory to go one",
+                type=int,
+                optional=True,
+                default=2,
+            ),
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -97,56 +100,80 @@ class IFSEdaEnsembleAbstractAlgo(IFSEdaAbstractAlgo):
     @staticmethod
     def _members_sorting_key(s):
         """Return the sorting key for the **s** section."""
-        member = getattr(s.rh.provider, 'member', None)
-        member = - math.inf if member is None else member
-        block = getattr(s.rh.provider, 'block', '')
-        filename = getattr(s.rh.container, 'basename', '')
+        member = getattr(s.rh.provider, "member", None)
+        member = -math.inf if member is None else member
+        block = getattr(s.rh.provider, "block", "")
+        filename = getattr(s.rh.container, "basename", "")
         return member, block, filename
 
     def _members_effective_inputs(self):
         """The list of effective sections representing input data."""
-        return sorted(self.context.sequence.effective_inputs(role=self._INPUTS_ROLE),
-                      key=self._members_sorting_key)
+        return sorted(
+            self.context.sequence.effective_inputs(role=self._INPUTS_ROLE),
+            key=self._members_sorting_key,
+        )
 
     def _members_all_inputs(self):
         """The list of sections representing input data."""
-        return sorted(self.context.sequence.filtered_inputs(role=self._INPUTS_ROLE),
-                      key=self._members_sorting_key)
+        return sorted(
+            self.context.sequence.filtered_inputs(role=self._INPUTS_ROLE),
+            key=self._members_sorting_key,
+        )
 
     def _check_members_list_numbering(self, rh, mlist, mformats):
         """Check if, for the **mlist** members list, some renaming id needed."""
         if len(set(mlist)) != len(mlist):
-            logger.warning("Some members are duplicated. That's very strange...")
+            logger.warning(
+                "Some members are duplicated. That's very strange..."
+            )
         if self.nbmember is None:
-            self.algoassert(len(mformats) <= 1, 'Mixed formats are not allowed !')
+            self.algoassert(
+                len(mformats) <= 1, "Mixed formats are not allowed !"
+            )
         elif self.nbmember and len(mformats) > 1:
-            logger.info('%s have mixed formats... please correct that.', self._INPUTS_ROLE)
+            logger.info(
+                "%s have mixed formats... please correct that.",
+                self._INPUTS_ROLE,
+            )
         if mlist and self.nbmember is not None:
             # Consistency check
             if len(mlist) != self.nbmember:
-                logger.warning('Discrepancy between *nbmember* and effective input files...' +
-                               ' sticking with *nbmember*')
+                logger.warning(
+                    "Discrepancy between *nbmember* and effective input files..."
+                    + " sticking with *nbmember*"
+                )
             else:
                 logger.info("The input files member numbers checks out !")
             return False  # Ok, apparently the user knows what she/he is doing
         elif self.nbmember and not mlist:
             return False  # Ok, apparently the user knows what she/he is doing
         elif mlist and self.nbmember is None:
-            innc = self.naming_convention(kind='edainput', variant=self.kind, rh=rh,
-                                          totalnumber=self.actual_totalnumber,
-                                          actualfmt=mformats.pop())
-            checkfiles = [m for m in range(1, len(mlist) + 1)
-                          if self.system.path.exists(innc(number=m))]
+            innc = self.naming_convention(
+                kind="edainput",
+                variant=self.kind,
+                rh=rh,
+                totalnumber=self.actual_totalnumber,
+                actualfmt=mformats.pop(),
+            )
+            checkfiles = [
+                m
+                for m in range(1, len(mlist) + 1)
+                if self.system.path.exists(innc(number=m))
+            ]
             if len(checkfiles) == len(mlist):
                 logger.info("The input files numbering checks out !")
-                return False  # Ok, apparently the user knows what she/he is doing
+                return (
+                    False  # Ok, apparently the user knows what she/he is doing
+                )
             elif len(checkfiles) == 0:
                 return True
             else:
-                raise AlgoComponentError('Members renumbering is needed but some ' +
-                                         'files are blocking the way !')
+                raise AlgoComponentError(
+                    "Members renumbering is needed but some "
+                    + "files are blocking the way !"
+                )
         elif len(mlist) == 0 and self.nbmember is None:
-            raise AlgoComponentError('No input files where found !')
+            raise AlgoComponentError("No input files where found !")
 
     def modelstate_needs_renumbering(self, rh):
         """Check if, for the **mlist** members list, some renaming id needed."""
@@ -160,35 +187,46 @@ class IFSEdaEnsembleAbstractAlgo(IFSEdaAbstractAlgo):
     def modelstate_renumbering(self, rh, mlist):
         """Actualy rename the effective inputs."""
         eff_format = mlist[0].rh.container.actualfmt
-        innc = self.naming_convention(kind='edainput', variant=self.kind, rh=rh,
-                                      totalnumber=self.actual_totalnumber,
-                                      actualfmt=eff_format)
+        innc = self.naming_convention(
+            kind="edainput",
+            variant=self.kind,
+            rh=rh,
+            totalnumber=self.actual_totalnumber,
+            actualfmt=eff_format,
+        )
         for i, s in enumerate(mlist, start=1):
-            logger.info("Soft-Linking %s to %s",
-                        s.rh.container.localpath(), innc(number=i))
+            logger.info(
+                "Soft-Linking %s to %s",
+                s.rh.container.localpath(),
+                innc(number=i),
+            )
             self.system.softlink(s.rh.container.localpath(), innc(number=i))
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         """Update the namelists with EDA related macros."""
-        nam_updated = super(IFSEdaAbstractAlgo, self).prepare_namelist_delta(rh,
-                                                                             namcontents,
-                                                                             namlocal)
+        nam_updated = super(IFSEdaAbstractAlgo, self).prepare_namelist_delta(
+            rh, namcontents, namlocal
+        )
         if self.actual_nbe is not None:
-            self._set_nam_macro(namcontents, namlocal, 'NBE', self.actual_nbe)
+            self._set_nam_macro(namcontents, namlocal, "NBE", self.actual_nbe)
             nam_updated = True
         return nam_updated
 
     def prepare(self, rh, opts):
         """Check the input files and act on it."""
-        self.system.subtitle('Solving the input files nightmare...')
+        self.system.subtitle("Solving the input files nightmare...")
         if self.modelstate_needs_renumbering(rh):
             eff_sections = self._members_effective_inputs()
             if len(eff_sections) < self.actual_nbmin:
-                raise AlgoComponentError('Not enough input files to continue...')
-            logger.info("Starting input files renumbering. %d effective members found",
-                        len(eff_sections))
+                raise AlgoComponentError(
+                    "Not enough input files to continue..."
+                )
+            logger.info(
+                "Starting input files renumbering. %d effective members found",
+                len(eff_sections),
+            )
             self.modelstate_renumbering(rh, eff_sections)
-        self.system.subtitle('Other IFS related settings')
+        self.system.subtitle("Other IFS related settings")
         super().prepare(rh, opts)
 
 
@@ -200,24 +238,24 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
     able to deal with missing members).
     """
 
-    _PADDING_ROLE = 'PaddingModelState'
+    _PADDING_ROLE = "PaddingModelState"
 
     _abstract = True
     _footprint = dict(
-        info='Base class for any EDA related task',
+        info="Base class for any EDA related task",
         attr=dict(
-            nblag = dict(
-                info = "The number of lagged dates (auto-detected if omitted)",
-                type = int,
-                optional = True,
+            nblag=dict(
+                info="The number of lagged dates (auto-detected if omitted)",
+                type=int,
+                optional=True,
             ),
-            padding = dict(
-                info = "Fill the gaps with some kind of climatological data",
-                type = bool,
-                optional = True,
-                default = False,
-            )
-        )
+            padding=dict(
+                info="Fill the gaps with some kind of climatological data",
+                type=bool,
+                optional=True,
+                default=False,
+            ),
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -232,7 +270,11 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
     @property
     def actual_totalnumber(self):
         """The total number of members."""
-        return self.actual_nbe * self.actual_nresx if self.padding else self.actual_nbe
+        return (
+            self.actual_nbe * self.actual_nresx
+            if self.padding
+            else self.actual_nbe
+        )
 
     @property
     def actual_nbmin(self):
@@ -242,7 +284,7 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
     def _members_sorting_key(self, s):
         """Return the sorting key for the **s** section."""
         stuple = list(super()._members_sorting_key(s))
-        rdate = getattr(s.rh.resource, 'date')
+        rdate = getattr(s.rh.resource, "date")
         stuple.insert(0, rdate)
         return tuple(stuple)
 
@@ -256,8 +298,10 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
         if all_dates and self.nblag is not None:
             # Consistency check
             if len(all_dates) != self.nblag:
-                logger.warning('Discrepancy between *nblag* and input files...' +
-                               ' sticking with *nblag*')
+                logger.warning(
+                    "Discrepancy between *nblag* and input files..."
+                    + " sticking with *nblag*"
+                )
         elif all_dates and self.nblag is None:
             self._actual_nresx = len(all_dates)
 
@@ -266,18 +310,30 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
             # For each date, check the member's list
             d_blocks = dict()
             for a_date in all_dates:
-                d_sections = [sec for sec in all_sections if sec.rh.resource.date == a_date]
-                d_members = sorted([sec.rh.provider.member for sec in d_sections])
+                d_sections = [
+                    sec
+                    for sec in all_sections
+                    if sec.rh.resource.date == a_date
+                ]
+                d_members = sorted(
+                    [sec.rh.provider.member for sec in d_sections]
+                )
                 d_formats = {sec.rh.container.actualfmt for sec in d_sections}
                 d_blocks[a_date] = (d_members, d_formats)
             ref_date, (eff_members, eff_formats) = d_blocks.popitem()
             for a_date, a_data in d_blocks.items():
-                self.algoassert(a_data[0] == eff_members,
-                                "Inconsistent members list (date={!s} vs {!s})."
-                                .format(a_date, ref_date))
-                self.algoassert(a_data[1] == eff_formats,
-                                "Inconsistent formats list (date={!s} vs {!s})."
-                                .format(a_date, ref_date))
+                self.algoassert(
+                    a_data[0] == eff_members,
+                    "Inconsistent members list (date={!s} vs {!s}).".format(
+                        a_date, ref_date
+                    ),
+                )
+                self.algoassert(
+                    a_data[1] == eff_formats,
+                    "Inconsistent formats list (date={!s} vs {!s}).".format(
+                        a_date, ref_date
+                    ),
+                )
             d_blocks[ref_date] = (eff_members, eff_formats)
             if eff_members and self.nbmember is None:
                 # Here, NBE is the number of members for one date
@@ -288,8 +344,10 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
                 for member in a_data[0]:
                     eff_members.append((a_date, member))
         else:
-            eff_members = [(sec.rh.resource.date, sec.rh.provider.member)
-                           for sec in eff_sections]
+            eff_members = [
+                (sec.rh.resource.date, sec.rh.provider.member)
+                for sec in eff_sections
+            ]
             eff_formats = {sec.rh.container.actualfmt for sec in eff_sections}
             if eff_members and self.nbmember is None:
                 # Here, NBE is the number of members for all dates
@@ -301,37 +359,64 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
         """Actualy rename the effective inputs."""
         if self.padding:
             eff_format = mlist[0].rh.container.actualfmt
-            innc = self.naming_convention(kind='edainput', variant=self.kind, rh=rh,
-                                          totalnumber=self.actual_totalnumber,
-                                          actualfmt=eff_format)
+            innc = self.naming_convention(
+                kind="edainput",
+                variant=self.kind,
+                rh=rh,
+                totalnumber=self.actual_totalnumber,
+                actualfmt=eff_format,
+            )
             all_sections = self._members_all_inputs()
-            paddingstuff = self.context.sequence.effective_inputs(role=self._PADDING_ROLE)
+            paddingstuff = self.context.sequence.effective_inputs(
+                role=self._PADDING_ROLE
+            )
             for i, s in enumerate(all_sections, start=1):
-                if s.stage == 'get' and s.rh.container.exists():
-                    logger.info("Soft-Linking %s to %s", s.rh.container.localpath(),
-                                innc(number=i))
-                    self.system.softlink(s.rh.container.localpath(), innc(number=i))
+                if s.stage == "get" and s.rh.container.exists():
+                    logger.info(
+                        "Soft-Linking %s to %s",
+                        s.rh.container.localpath(),
+                        innc(number=i),
+                    )
+                    self.system.softlink(
+                        s.rh.container.localpath(), innc(number=i)
+                    )
                 else:
                     mypadding = None
                     for p in paddingstuff:
-                        if getattr(p.rh.resource, 'ipert',
-                                   getattr(p.rh.resource, 'number', None)) == i:
+                        if (
+                            getattr(
+                                p.rh.resource,
+                                "ipert",
+                                getattr(p.rh.resource, "number", None),
+                            )
+                            == i
+                        ):
                             mypadding = p
                             break
                         else:
-                            if (getattr(p.rh.resource, 'date', None) == s.rh.resource.date and
-                                    getattr(p.rh.provider, 'member', None) == s.rh.provider.member):
+                            if (
+                                getattr(p.rh.resource, "date", None)
+                                == s.rh.resource.date
+                                and getattr(p.rh.provider, "member", None)
+                                == s.rh.provider.member
+                            ):
                                 mypadding = p
                                 break
                     if mypadding is not None:
-                        logger.warning("Soft-Linking Padding data %s to %s",
-                                       mypadding.rh.container.localpath(),
-                                       innc(number=i))
-                        self.system.softlink(mypadding.rh.container.localpath(),
-                                             innc(number=i))
+                        logger.warning(
+                            "Soft-Linking Padding data %s to %s",
+                            mypadding.rh.container.localpath(),
+                            innc(number=i),
+                        )
+                        self.system.softlink(
+                            mypadding.rh.container.localpath(), innc(number=i)
+                        )
                     else:
-                        raise AlgoComponentError('No padding data where found for i= {:d}: {!s}'
-                                                 .format(i, s))
+                        raise AlgoComponentError(
+                            "No padding data where found for i= {:d}: {!s}".format(
+                                i, s
+                            )
+                        )
         else:
             super().modelstate_renumbering(rh, mlist)
 
@@ -339,7 +424,9 @@ class IFSEdaLaggedEnsembleAbstractAlgo(IFSEdaEnsembleAbstractAlgo):
         """Update the namelists with EDA related macros."""
         nam_updated = super().prepare_namelist_delta(rh, namcontents, namlocal)
         if self.actual_nresx is not None:
-            self._set_nam_macro(namcontents, namlocal, 'NRESX', self.actual_nresx)
+            self._set_nam_macro(
+                namcontents, namlocal, "NRESX", self.actual_nresx
+            )
             nam_updated = True
         return nam_updated
 
@@ -348,17 +435,17 @@ class IFSEdaFemars(IFSEdaAbstractAlgo):
     """Convert some FA file in ECMWF-GRIB files. PLEASE DO NOT USE !"""
 
     _footprint = dict(
-        info='Convert some FA file in ECMWF-GRIB files.',
+        info="Convert some FA file in ECMWF-GRIB files.",
         attr=dict(
             kind=dict(
-                values=['femars'],
+                values=["femars"],
             ),
-            rawfiles = dict(
-                type = bool,
-                optional = True,
-                default = False,
+            rawfiles=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
-        )
+        ),
     )
 
     def postfix(self, rh, opts):
@@ -366,31 +453,36 @@ class IFSEdaFemars(IFSEdaAbstractAlgo):
         sh = self.system
         # Gather rawfiles in folders
         if self.rawfiles:
-            flist = sh.glob('tmprawfile_D000_L*')
-            dest = 'rawfiles'
-            logger.info('Creating a rawfiles pack: %s', dest)
+            flist = sh.glob("tmprawfile_D000_L*")
+            dest = "rawfiles"
+            logger.info("Creating a rawfiles pack: %s", dest)
             sh.mkdir(dest)
             for fic in flist:
-                sh.mv(fic, dest, fmt='grib')
+                sh.mv(fic, dest, fmt="grib")
         super().postfix(rh, opts)
 
 
 class IFSInflationLike(IFSEdaAbstractAlgo):
     """Apply the inflation scheme on a given modelstate."""
 
-    _RUNSTORE = 'RUNOUT'
-    _USELESS_MATCH = re.compile(r'^(?P<target>\w+)\+term\d+:\d+$')
+    _RUNSTORE = "RUNOUT"
+    _USELESS_MATCH = re.compile(r"^(?P<target>\w+)\+term\d+:\d+$")
 
     _footprint = dict(
-        info='Operations around the background error covariance matrix',
+        info="Operations around the background error covariance matrix",
         attr=dict(
             kind=dict(
-                values=['infl', 'pert', ],
+                values=[
+                    "infl",
+                    "pert",
+                ],
             ),
             conf=dict(
-                values=[701, ]
-            )
-        )
+                values=[
+                    701,
+                ]
+            ),
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -400,35 +492,57 @@ class IFSInflationLike(IFSEdaAbstractAlgo):
     def _check_effective_terms(self, roles):
         eff_terms = None
         for role in roles:
-            eterm = {sec.rh.resource.term
-                     for sec in self.context.sequence.effective_inputs(role=role)}
+            eterm = {
+                sec.rh.resource.term
+                for sec in self.context.sequence.effective_inputs(role=role)
+            }
             if eterm:
                 if eff_terms is None:
                     eff_terms = eterm
                 else:
                     if eff_terms != eterm:
-                        raise AlgoComponentError("Inconsistencies between inputs effective terms.")
+                        raise AlgoComponentError(
+                            "Inconsistencies between inputs effective terms."
+                        )
         return sorted(eff_terms)
 
-    def _link_stuff_in(self, role, actualterm, targetnc, targetintent='in', wastebasket=None):
-        estuff = [sec
-                  for sec in self.context.sequence.effective_inputs(role=role)
-                  if sec.rh.resource.term == actualterm]
+    def _link_stuff_in(
+        self, role, actualterm, targetnc, targetintent="in", wastebasket=None
+    ):
+        estuff = [
+            sec
+            for sec in self.context.sequence.effective_inputs(role=role)
+            if sec.rh.resource.term == actualterm
+        ]
         if len(estuff) > 1:
-            logger.warning('Multiple %s  for the same date ! Going on...', role)
+            logger.warning(
+                "Multiple %s  for the same date ! Going on...", role
+            )
         elif len(estuff) == 1:
             # Detect the inputs format
             actfmt = estuff[0].rh.container.actualfmt
             nconv = self.naming_convention(actualfmt=actfmt, **targetnc)
             targetname = nconv(**targetnc)
             if self.system.path.exists(targetname):
-                logger.info("%s: %s already exists. Hopping for the best...",
-                            role, targetname)
+                logger.info(
+                    "%s: %s already exists. Hopping for the best...",
+                    role,
+                    targetname,
+                )
             else:
-                logger.info("%s: copying (intent=%s) %s to %s", role, targetintent,
-                            estuff[0].rh.container.localpath(), targetname)
-                self.system.cp(estuff[0].rh.container.localpath(), targetname,
-                               fmt=actfmt, intent=targetintent)
+                logger.info(
+                    "%s: copying (intent=%s) %s to %s",
+                    role,
+                    targetintent,
+                    estuff[0].rh.container.localpath(),
+                    targetname,
+                )
+                self.system.cp(
+                    estuff[0].rh.container.localpath(),
+                    targetname,
+                    fmt=actfmt,
+                    intent=targetintent,
+                )
                 if wastebasket is not None:
                     wastebasket.append((targetname, actfmt))
             return nconv, targetname, estuff[0]
@@ -437,92 +551,152 @@ class IFSInflationLike(IFSEdaAbstractAlgo):
     def execute(self, rh, opts):
         """Loop on the various terms provided."""
 
-        eff_terms = self._check_effective_terms(['ModelState',
-                                                 'EnsembleMean',
-                                                 'Guess'])
-        fix_curclim = self.do_climfile_fixer(rh, convkind='modelclim')
-        fix_clclim = self.do_climfile_fixer(rh, convkind='closest_modelclim')
+        eff_terms = self._check_effective_terms(
+            ["ModelState", "EnsembleMean", "Guess"]
+        )
+        fix_curclim = self.do_climfile_fixer(rh, convkind="modelclim")
+        fix_clclim = self.do_climfile_fixer(rh, convkind="closest_modelclim")
 
         if eff_terms:
             for actualterm in eff_terms:
                 wastebasket = list()
-                self.system.title('Loop on term {!s}'.format(actualterm))
-                self.system.subtitle('Solving the input files nightmare...')
+                self.system.title("Loop on term {!s}".format(actualterm))
+                self.system.subtitle("Solving the input files nightmare...")
                 # Ensemble Mean ?
-                mean_number = 2 if self.model == 'arome' else 0
-                targetnc = dict(kind='edainput', variant='infl', rh=rh, number=mean_number)
-                self._link_stuff_in('EnsembleMean', actualterm, targetnc,
-                                    wastebasket=wastebasket)
+                mean_number = 2 if self.model == "arome" else 0
+                targetnc = dict(
+                    kind="edainput", variant="infl", rh=rh, number=mean_number
+                )
+                self._link_stuff_in(
+                    "EnsembleMean",
+                    actualterm,
+                    targetnc,
+                    wastebasket=wastebasket,
+                )
                 # Model State ?
-                targetnc = dict(kind='edainput', variant='infl', rh=rh, number=1)
-                _, _, mstate = self._link_stuff_in('ModelState', actualterm, targetnc,
-                                                   wastebasket=wastebasket)
+                targetnc = dict(
+                    kind="edainput", variant="infl", rh=rh, number=1
+                )
+                _, _, mstate = self._link_stuff_in(
+                    "ModelState", actualterm, targetnc, wastebasket=wastebasket
+                )
                 # Control ?
-                control_number = 0 if self.model == 'arome' else 2
-                targetnc = dict(kind='edainput', variant='infl', rh=rh, number=control_number)
-                self._link_stuff_in('Control', actualterm, targetnc,
-                                    wastebasket=wastebasket)
+                control_number = 0 if self.model == "arome" else 2
+                targetnc = dict(
+                    kind="edainput",
+                    variant="infl",
+                    rh=rh,
+                    number=control_number,
+                )
+                self._link_stuff_in(
+                    "Control", actualterm, targetnc, wastebasket=wastebasket
+                )
                 # Guess ?
-                targetnc = dict(kind='edaoutput', variant='infl', rh=rh, number=1, term=Time(0))
-                outnc, _, _ = self._link_stuff_in('Guess', actualterm, targetnc,
-                                                  targetintent='inout')
+                targetnc = dict(
+                    kind="edaoutput",
+                    variant="infl",
+                    rh=rh,
+                    number=1,
+                    term=Time(0),
+                )
+                outnc, _, _ = self._link_stuff_in(
+                    "Guess", actualterm, targetnc, targetintent="inout"
+                )
                 if outnc is None:
-                    outnc = self.naming_convention(kind='edaoutput', variant='infl', rh=rh)
+                    outnc = self.naming_convention(
+                        kind="edaoutput", variant="infl", rh=rh
+                    )
                 # Fix clim !
                 if fix_curclim and mstate:
                     month = Month((mstate.rh.resource.date + actualterm).ymdh)
-                    self.climfile_fixer(rh=rh, convkind='modelclim', month=month,
-                                        inputrole=('GlobalClim', 'InitialClim'),
-                                        inputkind='clim_model')
+                    self.climfile_fixer(
+                        rh=rh,
+                        convkind="modelclim",
+                        month=month,
+                        inputrole=("GlobalClim", "InitialClim"),
+                        inputkind="clim_model",
+                    )
                 if fix_clclim and mstate:
-                    closestmonth = Month((mstate.rh.resource.date + actualterm).ymdh + ':closest')
-                    self.climfile_fixer(rh=rh, convkind='closest_modelclim', month=closestmonth,
-                                        inputrole=('GlobalClim', 'InitialClim'),
-                                        inputkind='clim_model')
+                    closestmonth = Month(
+                        (mstate.rh.resource.date + actualterm).ymdh
+                        + ":closest"
+                    )
+                    self.climfile_fixer(
+                        rh=rh,
+                        convkind="closest_modelclim",
+                        month=closestmonth,
+                        inputrole=("GlobalClim", "InitialClim"),
+                        inputkind="clim_model",
+                    )
                 # Deal with useless stuff... SADLY !
-                useless = [sec
-                           for sec in self.context.sequence.effective_inputs(role='Useless')
-                           if (sec.rh.resource.term == actualterm and
-                               self._USELESS_MATCH.match(sec.rh.container.localpath()))]
+                useless = [
+                    sec
+                    for sec in self.context.sequence.effective_inputs(
+                        role="Useless"
+                    )
+                    if (
+                        sec.rh.resource.term == actualterm
+                        and self._USELESS_MATCH.match(
+                            sec.rh.container.localpath()
+                        )
+                    )
+                ]
                 for a_useless in useless:
-                    targetname = self._USELESS_MATCH.match(a_useless.rh.container.localpath()).group('target')
+                    targetname = self._USELESS_MATCH.match(
+                        a_useless.rh.container.localpath()
+                    ).group("target")
                     if self.system.path.exists(targetname):
-                        logger.warning("Some useless stuff is already here: %s. I don't care...",
-                                       targetname)
+                        logger.warning(
+                            "Some useless stuff is already here: %s. I don't care...",
+                            targetname,
+                        )
                     else:
-                        logger.info("Dealing with useless stuff: %s -> %s",
-                                    a_useless.rh.container.localpath(), targetname)
-                        self.system.cp(a_useless.rh.container.localpath(), targetname,
-                                       fmt=a_useless.rh.container.actualfmt, intent='in')
-                        wastebasket.append((targetname, a_useless.rh.container.actualfmt))
+                        logger.info(
+                            "Dealing with useless stuff: %s -> %s",
+                            a_useless.rh.container.localpath(),
+                            targetname,
+                        )
+                        self.system.cp(
+                            a_useless.rh.container.localpath(),
+                            targetname,
+                            fmt=a_useless.rh.container.actualfmt,
+                            intent="in",
+                        )
+                        wastebasket.append(
+                            (targetname, a_useless.rh.container.actualfmt)
+                        )
 
                 # Standard execution
                 super().execute(rh, opts)
 
                 # The concatenated listing
-                self.system.cat('NODE.001_01', output='NODE.all')
+                self.system.cat("NODE.001_01", output="NODE.all")
 
                 # prepares the next execution
                 if len(eff_terms) > 1:
                     self.system.mkdir(self._RUNSTORE)
                     # Freeze the current output
-                    shelf_label = self.system.path.join(self._RUNSTORE, outnc(number=1, term=actualterm))
-                    self.system.move(outnc(number=1, term=Time(0)), shelf_label, fmt='fa')
+                    shelf_label = self.system.path.join(
+                        self._RUNSTORE, outnc(number=1, term=actualterm)
+                    )
+                    self.system.move(
+                        outnc(number=1, term=Time(0)), shelf_label, fmt="fa"
+                    )
                     self._outputs_shelf.append(shelf_label)
                     # Some cleaning
                     for afile in wastebasket:
                         self.system.remove(afile[0], fmt=afile[1])
-                    self.system.rmall('ncf927', 'dirlst')
+                    self.system.rmall("ncf927", "dirlst")
         else:
             # We should not be here but whatever... some task are poorly written !
             super().execute(rh, opts)
 
     def postfix(self, rh, opts):
         """Post-processing cleaning."""
-        self.system.title('Finalising the execution...')
+        self.system.title("Finalising the execution...")
         for afile in self._outputs_shelf:
             logger.info("Output found: %s", self.system.path.basename(afile))
-            self.system.move(afile, self.system.path.basename(afile), fmt='fa')
+            self.system.move(afile, self.system.path.basename(afile), fmt="fa")
         super().postfix(rh, opts)
 
 
@@ -530,12 +704,14 @@ class IFSInflationFactor(IFSEdaEnsembleAbstractAlgo):
     """Compute an inflation factor based on individual members."""
 
     _footprint = dict(
-        info='Compute an inflation factor based on individual members',
+        info="Compute an inflation factor based on individual members",
         attr=dict(
             kind=dict(
-                values=['infl_factor', ],
+                values=[
+                    "infl_factor",
+                ],
             ),
-        )
+        ),
     )
 
 
@@ -546,15 +722,17 @@ class IFSInflationFactorLegacy(IFSInflationFactor):
     """
 
     _footprint = dict(
-        info='Compute an inflation factor based on individual members',
+        info="Compute an inflation factor based on individual members",
         attr=dict(
             kind=dict(
-                values=['infl', 'pert'],
+                values=["infl", "pert"],
             ),
             conf=dict(
-                outcast=[701, ]
-            )
-        )
+                outcast=[
+                    701,
+                ]
+            ),
+        ),
     )
 
 
@@ -562,12 +740,14 @@ class IFSEnsembleMean(IFSEdaEnsembleAbstractAlgo):
     """Apply the inflation scheme on a given modelstate."""
 
     _footprint = dict(
-        info='Operations around the background error covariance matrix',
+        info="Operations around the background error covariance matrix",
         attr=dict(
             kind=dict(
-                values=['mean', ],
+                values=[
+                    "mean",
+                ],
             ),
-        )
+        ),
     )
 
 
@@ -575,20 +755,22 @@ class IFSCovB(IFSEdaLaggedEnsembleAbstractAlgo):
     """Operations around the background error covariance matrix."""
 
     _footprint = dict(
-        info='Operations around the background error covariance matrix',
+        info="Operations around the background error covariance matrix",
         attr=dict(
             kind=dict(
-                values=['covb', ],
+                values=[
+                    "covb",
+                ],
             ),
-            hybrid = dict(
-                type = bool,
-                optional = True,
-                default = False,
+            hybrid=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
-        )
+        ),
     )
 
-    _HYBRID_CLIM_ROLE = 'ClimatologicalModelState'
+    _HYBRID_CLIM_ROLE = "ClimatologicalModelState"
 
     @property
     def actual_totalnumber(self):
@@ -600,33 +782,59 @@ class IFSCovB(IFSEdaLaggedEnsembleAbstractAlgo):
         """Default pre-link for the initial condition file"""
         super().prepare(rh, opts)
         # Legacy...
-        for num, sec in enumerate(sorted(self.context.sequence.effective_inputs(role='Rawfiles'),
-                                         key=self._members_sorting_key),
-                                  start=1):
+        for num, sec in enumerate(
+            sorted(
+                self.context.sequence.effective_inputs(role="Rawfiles"),
+                key=self._members_sorting_key,
+            ),
+            start=1,
+        ):
             repname = sec.rh.container.localpath()
-            radical = repname.split('_')[0] + '_D{:03d}_L{:s}'
+            radical = repname.split("_")[0] + "_D{:03d}_L{:s}"
             for filename in self.system.listdir(repname):
-                level = re.search(r'_L(\d+)$', filename)
+                level = re.search(r"_L(\d+)$", filename)
                 if level is not None:
-                    self.system.softlink(self.system.path.join(repname, filename),
-                                         radical.format(num, level.group(1)))
+                    self.system.softlink(
+                        self.system.path.join(repname, filename),
+                        radical.format(num, level.group(1)),
+                    )
         # Legacy...
-        for num, sec in enumerate(sorted(self.context.sequence.effective_inputs(role='LaggedEnsemble'),
-                                         key=self._members_sorting_key),
-                                  start=1):
+        for num, sec in enumerate(
+            sorted(
+                self.context.sequence.effective_inputs(role="LaggedEnsemble"),
+                key=self._members_sorting_key,
+            ),
+            start=1,
+        ):
             repname = sec.rh.container.localpath()
-            radical = repname.split('_')[0] + '_{:03d}'
+            radical = repname.split("_")[0] + "_{:03d}"
             self.system.softlink(repname, radical.format(num))
         # Requesting Hybrid computations ?
         if self.hybrid:
-            hybstuff = self.context.sequence.effective_inputs(role=self._HYBRID_CLIM_ROLE)
+            hybstuff = self.context.sequence.effective_inputs(
+                role=self._HYBRID_CLIM_ROLE
+            )
             hybformat = hybstuff[0].rh.container.actualfmt
-            totalnumber = self.actual_nbe * self.actual_nresx if self.padding else self.actual_nbe
-            for i, tnum in enumerate(range(totalnumber + 1, 2 * totalnumber + 1)):
-                innc = self.naming_convention(kind='edainput', variant=self.kind,
-                                              totalnumber=self.actual_totalnumber,
-                                              rh=rh, actualfmt=hybformat)
-                logger.info("Soft-Linking %s to %s",
-                            hybstuff[i].rh.container.localpath(), innc(number=tnum))
-                self.system.softlink(hybstuff[i].rh.container.localpath(),
-                                     innc(number=tnum))
+            totalnumber = (
+                self.actual_nbe * self.actual_nresx
+                if self.padding
+                else self.actual_nbe
+            )
+            for i, tnum in enumerate(
+                range(totalnumber + 1, 2 * totalnumber + 1)
+            ):
+                innc = self.naming_convention(
+                    kind="edainput",
+                    variant=self.kind,
+                    totalnumber=self.actual_totalnumber,
+                    rh=rh,
+                    actualfmt=hybformat,
+                )
+                logger.info(
+                    "Soft-Linking %s to %s",
+                    hybstuff[i].rh.container.localpath(),
+                    innc(number=tnum),
+                )
+                self.system.softlink(
+                    hybstuff[i].rh.container.localpath(), innc(number=tnum)
+                )

--- a/src/vortex/nwp/algo/eps.py
+++ b/src/vortex/nwp/algo/eps.py
@@ -29,27 +29,27 @@ class Svect(IFSParallel):
     """Singular vectors computation."""
 
     _footprint = dict(
-        info='Computation of the singular vectors.',
-        attr = dict(
-            kind = dict(
-                values   = ['svectors', 'svector', 'sv', 'svect', 'svarpe'],
-                remap    = dict(autoremap='first'),
+        info="Computation of the singular vectors.",
+        attr=dict(
+            kind=dict(
+                values=["svectors", "svector", "sv", "svect", "svarpe"],
+                remap=dict(autoremap="first"),
             ),
-            conf = dict(
-                type     = int,
-                optional = True,
-                default  = 601,
+            conf=dict(
+                type=int,
+                optional=True,
+                default=601,
             ),
-            xpname = dict(
-                optional = True,
-                default  = 'SVEC',
+            xpname=dict(
+                optional=True,
+                default="SVEC",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'svector'
+        return "svector"
 
 
 class Combi(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
@@ -59,7 +59,7 @@ class Combi(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
 
     def execute(self, rh, opts):
         """Standard Combi execution."""
-        namsec = self.setlink(initrole='Namelist', initkind='namelist')
+        namsec = self.setlink(initrole="Namelist", initkind="namelist")
         namsec[0].rh.container.cat()
         super().execute(rh, opts)
 
@@ -68,28 +68,44 @@ class Combi(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
         raise NotImplementedError("Abstract property")
 
     def _addNmod(self, namrh, msg):
-        namrh.contents['NAMMOD']['NMOD'] = self.nmod
+        namrh.contents["NAMMOD"]["NMOD"] = self.nmod
         logger.info("NMOD set to %d: %s.", self.nmod, msg)
 
     def _analysis_cp(self, nb, msg):
         # Copy the analysis
-        initsec = self.setlink(initkind='analysis')
-        radical = re.sub(r'^(.*?)\d+$', r'\1', initsec[0].rh.container.localpath())
+        initsec = self.setlink(initkind="analysis")
+        radical = re.sub(
+            r"^(.*?)\d+$", r"\1", initsec[0].rh.container.localpath()
+        )
         for num in footprints.util.rangex(1, nb):
-            self.system.cp(initsec[0].rh.container.localpath(),
-                           radical + '{:03d}'.format(num),
-                           fmt=initsec[0].rh.container.actualfmt, intent=intent.INOUT)
+            self.system.cp(
+                initsec[0].rh.container.localpath(),
+                radical + "{:03d}".format(num),
+                fmt=initsec[0].rh.container.actualfmt,
+                intent=intent.INOUT,
+            )
         logger.info("Copy the analysis for the %d %s.", nb, msg)
 
     def _coeff_picking(self, kind, msg):
         # Pick up the coeff in the namelist
-        for namsec in self.context.sequence.effective_inputs(kind='namelist'):
+        for namsec in self.context.sequence.effective_inputs(kind="namelist"):
             namsec.rh.reset_contents()
-            if 'NAMCOEF' + kind.upper() in namsec.rh.contents:
-                logger.info("Extract the " + msg + " coefficient from the updated namelist.")
-                coeff = {'rcoef' + kind:
-                         float(namsec.rh.contents['NAMCOEF' + kind.upper()]['RCOEF' + kind.upper()])}
-                self.system.json_dump(coeff, 'coeff' + kind + '.out', indent=4, cls=ShellEncoder)
+            if "NAMCOEF" + kind.upper() in namsec.rh.contents:
+                logger.info(
+                    "Extract the "
+                    + msg
+                    + " coefficient from the updated namelist."
+                )
+                coeff = {
+                    "rcoef" + kind: float(
+                        namsec.rh.contents["NAMCOEF" + kind.upper()][
+                            "RCOEF" + kind.upper()
+                        ]
+                    )
+                }
+                self.system.json_dump(
+                    coeff, "coeff" + kind + ".out", indent=4, cls=ShellEncoder
+                )
 
 
 class CombiPert(Combi):
@@ -97,9 +113,9 @@ class CombiPert(Combi):
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            nbpert = dict(
-                type = int,
+        attr=dict(
+            nbpert=dict(
+                type=int,
             ),
         )
     )
@@ -109,15 +125,18 @@ class CombiPert(Combi):
         super().prepare(rh, opts)
 
         # Tweak the namelists
-        for namsec in self.context.sequence.effective_inputs(role=re.compile('Namelist'),
-                                                             kind='namelist'):
-            logger.info("Add the NBPERT coefficient to the NAMENS namelist entry")
-            namsec.rh.contents['NAMENS']['NBPERT'] = self.nbpert
+        for namsec in self.context.sequence.effective_inputs(
+            role=re.compile("Namelist"), kind="namelist"
+        ):
+            logger.info(
+                "Add the NBPERT coefficient to the NAMENS namelist entry"
+            )
+            namsec.rh.contents["NAMENS"]["NBPERT"] = self.nbpert
             namsec.rh.save()
 
 
 #: Definition of a named tuple that holds informations on SV for a given zone
-_SvInfoTuple = collections.namedtuple('SvInfoTuple', ['available', 'expected'])
+_SvInfoTuple = collections.namedtuple("SvInfoTuple", ["available", "expected"])
 
 
 class CombiSV(CombiPert):
@@ -125,10 +144,10 @@ class CombiSV(CombiPert):
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            info_fname = dict(
-                default  = 'singular_vectors_info.json',
-                optional = True,
+        attr=dict(
+            info_fname=dict(
+                default="singular_vectors_info.json",
+                optional=True,
             ),
         )
     )
@@ -140,76 +159,111 @@ class CombiSV(CombiPert):
         # Check the number of singular vectors and link them in succession
         nbVectTmp = collections.OrderedDict()
         totalVects = 0
-        svec_sections = self.context.sequence.filtered_inputs(role='SingularVectors', kind='svector')
+        svec_sections = self.context.sequence.filtered_inputs(
+            role="SingularVectors", kind="svector"
+        )
         for svecsec in svec_sections:
-            c_match = re.match(r'^([^+,.]+)[+,.][^+,.]+[+,.][^+,.]+(.*)$',
-                               svecsec.rh.container.localpath())
+            c_match = re.match(
+                r"^([^+,.]+)[+,.][^+,.]+[+,.][^+,.]+(.*)$",
+                svecsec.rh.container.localpath(),
+            )
             if c_match is None:
-                logger.critical("The SV name is not formated correctly: %s",
-                                svecsec.rh.container.actualpath())
+                logger.critical(
+                    "The SV name is not formated correctly: %s",
+                    svecsec.rh.container.actualpath(),
+                )
             (radical, suffix) = c_match.groups()
             zone = svecsec.rh.resource.zone
             nbVectTmp.setdefault(zone, [0, 0])
             nbVectTmp[zone][1] += 1  # Expected
-            if svecsec.stage == 'get':
+            if svecsec.stage == "get":
                 totalVects += 1
                 nbVectTmp[zone][0] += 1  # Available
-                self.system.softlink(svecsec.rh.container.localpath(),
-                                     radical + '{:03d}'.format(totalVects) + suffix)
+                self.system.softlink(
+                    svecsec.rh.container.localpath(),
+                    radical + "{:03d}".format(totalVects) + suffix,
+                )
         # Convert the temporary dictionary to a dictionary of tuples
         nbVect = collections.OrderedDict()
         for k, v in nbVectTmp.items():
             nbVect[k] = _SvInfoTuple(*v)
-        logger.info("Number of vectors :\n" +
-                    '\n'.join(['- {0:8s}: {1.available:3d} ({1.expected:3d} expected).'.format(z, n)
-                               for z, n in nbVect.items()]))
+        logger.info(
+            "Number of vectors :\n"
+            + "\n".join(
+                [
+                    "- {0:8s}: {1.available:3d} ({1.expected:3d} expected).".format(
+                        z, n
+                    )
+                    for z, n in nbVect.items()
+                ]
+            )
+        )
         # Writing the singular vectors per areas in a json file
         self.system.json_dump(nbVect, self.info_fname)
 
         # Tweak the namelists
-        namsecs = self.context.sequence.effective_inputs(role=re.compile('Namelist'), kind='namelist')
+        namsecs = self.context.sequence.effective_inputs(
+            role=re.compile("Namelist"), kind="namelist"
+        )
         for namsec in namsecs:
-            namsec.rh.contents['NAMMOD']['LVS'] = True
-            namsec.rh.contents['NAMMOD']['LANAP'] = False
-            namsec.rh.contents['NAMMOD']['LBRED'] = False
+            namsec.rh.contents["NAMMOD"]["LVS"] = True
+            namsec.rh.contents["NAMMOD"]["LANAP"] = False
+            namsec.rh.contents["NAMMOD"]["LBRED"] = False
             logger.info("Added to NVSZONE namelist entry")
-            namsec.rh.contents['NAMOPTI']['NVSZONE'] = [
+            namsec.rh.contents["NAMOPTI"]["NVSZONE"] = [
                 v.available for v in nbVect.values() if v.available
             ]  # Zones with 0 vectors are discarded
 
-            nbVectNam = namsec.rh.contents['NAMENS']['NBVECT']
+            nbVectNam = namsec.rh.contents["NAMENS"]["NBVECT"]
             if int(nbVectNam) != totalVects:
-                logger.warning("%s singular vectors expected but only %d accounted for.",
-                               nbVectNam, totalVects)
-                logger.info("Update the total number of vectors in the NBVECT namelist entry")
-                namsec.rh.contents['NAMENS']['NBVECT'] = totalVects
+                logger.warning(
+                    "%s singular vectors expected but only %d accounted for.",
+                    nbVectNam,
+                    totalVects,
+                )
+                logger.info(
+                    "Update the total number of vectors in the NBVECT namelist entry"
+                )
+                namsec.rh.contents["NAMENS"]["NBVECT"] = totalVects
 
-            actualZones = [k for k, v in nbVect.items() if v.available]  # Zones with 0 vectors are discarded
+            actualZones = [
+                k for k, v in nbVect.items() if v.available
+            ]  # Zones with 0 vectors are discarded
             nbzone = len(actualZones)
-            namsec.rh.contents['NAMOPTI']['NBZONE'] = nbzone
-            namsec.rh.contents['NAMOPTI']['CNOMZONE'] = actualZones
-            nbrc = len(namsec.rh.contents['NAMOPTI'].RC)
+            namsec.rh.contents["NAMOPTI"]["NBZONE"] = nbzone
+            namsec.rh.contents["NAMOPTI"]["CNOMZONE"] = actualZones
+            nbrc = len(namsec.rh.contents["NAMOPTI"].RC)
             if nbrc != nbzone:
-                logger.critical("%d zones but NAMOPTI/RC has length %d" % (nbzone, nbrc))
-            nbrl = len(namsec.rh.contents['NAMOPTI'].RL)
+                logger.critical(
+                    "%d zones but NAMOPTI/RC has length %d" % (nbzone, nbrc)
+                )
+            nbrl = len(namsec.rh.contents["NAMOPTI"].RL)
             if nbrl != nbzone:
-                logger.critical("%d zones but NAMOPTI/RL has length %d" % (nbzone, nbrl))
+                logger.critical(
+                    "%d zones but NAMOPTI/RL has length %d" % (nbzone, nbrl)
+                )
 
             self._addNmod(namsec.rh, "combination of the SV")
             namsec.rh.save()
 
         # Copy the analysis to give all the perturbations a basis
-        self._analysis_cp(self.nbpert, 'perturbations')
+        self._analysis_cp(self.nbpert, "perturbations")
 
 
 class CombiSVunit(CombiSV):
     """Combine the unit SV to create the raw perturbations by gaussian sampling."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['sv2unitpert', 'init', 'combi_init', ],
-                remap  = dict(combi_init='init',),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "sv2unitpert",
+                    "init",
+                    "combi_init",
+                ],
+                remap=dict(
+                    combi_init="init",
+                ),
             ),
         )
     )
@@ -226,10 +280,14 @@ class CombiSVnorm(CombiSV):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['sv2normedpert', 'optim', 'combi_optim', ],
-                remap  = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "sv2normedpert",
+                    "optim",
+                    "combi_optim",
+                ],
+                remap=dict(autoremap="first"),
             ),
         )
     )
@@ -237,7 +295,7 @@ class CombiSVnorm(CombiSV):
     def postfix(self, rh, opts):
         """Post processing cleaning."""
         # Pick up the coeff in the namelist
-        self._coeff_picking('vs', 'SV')
+        self._coeff_picking("vs", "SV")
         super().postfix(rh, opts)
 
     @property
@@ -249,19 +307,23 @@ class CombiIC(Combi):
     """Combine the SV and AE or breeding perturbations to create the initial conditions."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values   = ['pert2ic', 'sscales', 'combi_sscales', ],
-                remap    = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "pert2ic",
+                    "sscales",
+                    "combi_sscales",
+                ],
+                remap=dict(autoremap="first"),
             ),
-            nbic = dict(
-                alias    = ('nbruns',),
-                type     = int,
+            nbic=dict(
+                alias=("nbruns",),
+                type=int,
             ),
-            nbpert = dict(
-                type     = int,
-                optional = True,
-                default  = 0,
+            nbpert=dict(
+                type=int,
+                optional=True,
+                default=0,
             ),
         )
     )
@@ -275,80 +337,121 @@ class CombiIC(Combi):
         super().prepare(rh, opts)
 
         # Tweak the namelist
-        namsec = self.setlink(initrole='Namelist', initkind='namelist')
-        nammod = namsec[0].rh.contents['NAMMOD']
+        namsec = self.setlink(initrole="Namelist", initkind="namelist")
+        nammod = namsec[0].rh.contents["NAMMOD"]
 
         # The footprint's value is always preferred to the calculated one
         nbPert = self.nbpert
 
         # Dealing with singular vectors
-        sv_sections = self.context.sequence.effective_inputs(role='CoeffSV')
-        nammod['LVS'] = bool(sv_sections)
+        sv_sections = self.context.sequence.effective_inputs(role="CoeffSV")
+        nammod["LVS"] = bool(sv_sections)
         if sv_sections:
-            logger.info("Add the SV coefficient to the NAMCOEFVS namelist entry.")
-            namcoefvs = namsec[0].rh.contents.newblock('NAMCOEFVS')
-            namcoefvs['RCOEFVS'] = sv_sections[0].rh.contents['rcoefvs']
+            logger.info(
+                "Add the SV coefficient to the NAMCOEFVS namelist entry."
+            )
+            namcoefvs = namsec[0].rh.contents.newblock("NAMCOEFVS")
+            namcoefvs["RCOEFVS"] = sv_sections[0].rh.contents["rcoefvs"]
             # The mean value may be present among the SV inputs: remove it
-            svsecs = [sec for sec in self.context.sequence.effective_inputs(role='SVPerturbedState') or
-                      [sec for sec in self.context.sequence.effective_inputs(role='PerturbedState')
-                       if 'ICHR' in sec.rh.container.filename] if sec.rh.resource.number]
+            svsecs = [
+                sec
+                for sec in self.context.sequence.effective_inputs(
+                    role="SVPerturbedState"
+                )
+                or [
+                    sec
+                    for sec in self.context.sequence.effective_inputs(
+                        role="PerturbedState"
+                    )
+                    if "ICHR" in sec.rh.container.filename
+                ]
+                if sec.rh.resource.number
+            ]
             nbPert = nbPert or len(svsecs)
 
         # Dealing with breeding method's inputs
-        bd_sections = self.context.sequence.effective_inputs(role='CoeffBreeding')
-        nammod['LBRED'] = bool(bd_sections)
+        bd_sections = self.context.sequence.effective_inputs(
+            role="CoeffBreeding"
+        )
+        nammod["LBRED"] = bool(bd_sections)
         if bd_sections:
-            logger.info("Add the breeding coefficient to the NAMCOEFBM namelist entry.")
-            namcoefbm = namsec[0].rh.contents.newblock('NAMCOEFBM')
-            namcoefbm['RCOEFBM'] = bd_sections[0].rh.contents['rcoefbm']
+            logger.info(
+                "Add the breeding coefficient to the NAMCOEFBM namelist entry."
+            )
+            namcoefbm = namsec[0].rh.contents.newblock("NAMCOEFBM")
+            namcoefbm["RCOEFBM"] = bd_sections[0].rh.contents["rcoefbm"]
             nbBd = len(
-                self.context.sequence.effective_inputs(role='BreedingPerturbedState')
+                self.context.sequence.effective_inputs(
+                    role="BreedingPerturbedState"
+                )
                 or [
                     sec
-                    for sec in self.context.sequence.effective_inputs(role='PerturbedState')
-                    if 'BMHR' in sec.rh.container.filename
+                    for sec in self.context.sequence.effective_inputs(
+                        role="PerturbedState"
+                    )
+                    if "BMHR" in sec.rh.container.filename
                 ]
             )
             # symmetric perturbations except if analysis: one more file
             # or zero if one control ic (hypothesis: odd nbic)
-            nbPert = nbPert or (nbBd - 1 if nbBd == self.nbic + 1 or
-                                (nbBd == self.nbic and self.nbic % 2 != 0)
-                                else self.nbic // 2)
+            nbPert = nbPert or (
+                nbBd - 1
+                if nbBd == self.nbic + 1
+                or (nbBd == self.nbic and self.nbic % 2 != 0)
+                else self.nbic // 2
+            )
 
         # Dealing with initial conditions from the assimilation ensemble
         # the mean value may be present among the AE inputs: remove it
-        aesecs = [sec for sec in self.context.sequence.effective_inputs(
-            role=('AEPerturbedState', 'ModelState')) if sec.rh.resource.number]
-        nammod['LANAP'] = bool(aesecs)
+        aesecs = [
+            sec
+            for sec in self.context.sequence.effective_inputs(
+                role=("AEPerturbedState", "ModelState")
+            )
+            if sec.rh.resource.number
+        ]
+        nammod["LANAP"] = bool(aesecs)
         nbAe = len(aesecs)
         nbPert = nbPert or nbAe
         # If less AE members (but nor too less) than ic to build
         if nbAe < nbPert <= 2 * nbAe:
-            logger.info("%d AE perturbations needed, %d AE members available: the first ones are duplicated.",
-                        nbPert, nbAe)
-            prefix = aesecs[0].rh.container.filename.split('_')[0]
+            logger.info(
+                "%d AE perturbations needed, %d AE members available: the first ones are duplicated.",
+                nbPert,
+                nbAe,
+            )
+            prefix = aesecs[0].rh.container.filename.split("_")[0]
             for num in range(nbAe, nbPert):
-                self.system.softlink(aesecs[num - nbAe].rh.container.filename,
-                                     prefix + '_{:03d}'.format(num + 1))
+                self.system.softlink(
+                    aesecs[num - nbAe].rh.container.filename,
+                    prefix + "_{:03d}".format(num + 1),
+                )
 
-        logger.info("NAMMOD namelist summary: LANAP=%s, LVS=%s, LBRED=%s.",
-                    *[nammod[k] for k in ('LANAP', 'LVS', 'LBRED')])
-        logger.info("Add the NBPERT=%d coefficient to the NAMENS namelist entry.", nbPert)
-        namsec[0].rh.contents['NAMENS']['NBPERT'] = nbPert
+        logger.info(
+            "NAMMOD namelist summary: LANAP=%s, LVS=%s, LBRED=%s.",
+            *[nammod[k] for k in ("LANAP", "LVS", "LBRED")],
+        )
+        logger.info(
+            "Add the NBPERT=%d coefficient to the NAMENS namelist entry.",
+            nbPert,
+        )
+        namsec[0].rh.contents["NAMENS"]["NBPERT"] = nbPert
 
         # symmectric perturbations ?
         if nbPert < self.nbic - 1:
-            namsec[0].rh.contents['NAMENS']['LMIRROR'] = True
+            namsec[0].rh.contents["NAMENS"]["LMIRROR"] = True
             logger.info("Add LMIRROR=.TRUE. to the NAMENS namelist entry.")
-        elif nbPert != 1:  # 1 pert, 2 ic is possible without mirror adding the control
-            namsec[0].rh.contents['NAMENS']['LMIRROR'] = False
+        elif (
+            nbPert != 1
+        ):  # 1 pert, 2 ic is possible without mirror adding the control
+            namsec[0].rh.contents["NAMENS"]["LMIRROR"] = False
             logger.info("Add LMIRROR=.FALSE. to the NAMENS namelist entry.")
 
         self._addNmod(namsec[0].rh, "final combination of the perturbations")
         namsec[0].rh.save()
 
         # Copy the analysis to give all the members a basis
-        self._analysis_cp(self.nbic - 1, 'perturbed states')
+        self._analysis_cp(self.nbic - 1, "perturbed states")
 
 
 class CombiBreeding(CombiPert):
@@ -358,10 +461,14 @@ class CombiBreeding(CombiPert):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['fc2bredpert', 'breeding', 'combi_breeding', ],
-                remap  = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "fc2bredpert",
+                    "breeding",
+                    "combi_breeding",
+                ],
+                remap=dict(autoremap="first"),
             ),
         )
     )
@@ -375,25 +482,31 @@ class CombiBreeding(CombiPert):
         super().prepare(rh, opts)
 
         # Consistent naming with the Fortran execution
-        hst_sections = self.context.sequence.effective_inputs(kind=('pert', 'historic'))
+        hst_sections = self.context.sequence.effective_inputs(
+            kind=("pert", "historic")
+        )
         for num, hst in enumerate(hst_sections):
-            self.system.softlink(hst.rh.container.localpath(),
-                                 re.sub(r'^(.*?)\d+$', r'\1', hst.rh.container.localpath()) +
-                                 '{:03d}.grb'.format(num + 1))
+            self.system.softlink(
+                hst.rh.container.localpath(),
+                re.sub(r"^(.*?)\d+$", r"\1", hst.rh.container.localpath())
+                + "{:03d}.grb".format(num + 1),
+            )
             logger.info("Rename the %d grib files consecutively.", num)
 
         # Tweak the namelist
-        namsec = self.setlink(initrole='Namelist', initkind='namelist')
-        namsec[0].rh.contents['NAMMOD']['LBRED'] = True
-        namsec[0].rh.contents['NAMMOD']['LANAP'] = False
-        namsec[0].rh.contents['NAMMOD']['LVS'] = False
-        self._addNmod(namsec[0].rh, "compute the coefficient of the bred modes")
+        namsec = self.setlink(initrole="Namelist", initkind="namelist")
+        namsec[0].rh.contents["NAMMOD"]["LBRED"] = True
+        namsec[0].rh.contents["NAMMOD"]["LANAP"] = False
+        namsec[0].rh.contents["NAMMOD"]["LVS"] = False
+        self._addNmod(
+            namsec[0].rh, "compute the coefficient of the bred modes"
+        )
         namsec[0].rh.save()
 
     def postfix(self, rh, opts):
         """Post processing cleaning."""
         # Pick up the coeff in the namelist
-        self._coeff_picking('bm', 'breeding')
+        self._coeff_picking("bm", "breeding")
         super().postfix(rh, opts)
 
 
@@ -404,13 +517,16 @@ class SurfCombiIC(BlindRun):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['surf_pert2ic', 'surf2ic', ],
-                remap  = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "surf_pert2ic",
+                    "surf2ic",
+                ],
+                remap=dict(autoremap="first"),
             ),
-            member = dict(
-                type   = int,
+            member=dict(
+                type=int,
             ),
         )
     )
@@ -419,15 +535,17 @@ class SurfCombiIC(BlindRun):
         """Set some variables according to target definition."""
         super().prepare(rh, opts)
 
-        icsec = self.setlink(initrole=('SurfaceAnalysis', 'SurfaceInitialCondition'),
-                             initkind='ic')
+        icsec = self.setlink(
+            initrole=("SurfaceAnalysis", "SurfaceInitialCondition"),
+            initkind="ic",
+        )
         actualdate = icsec[0].rh.resource.date
         seed = int(actualdate.ymdh) + (actualdate.hour + 1) * (self.member + 1)
 
         # Tweak the namelist
-        namsec = self.setlink(initrole='Namelist', initkind='namelist')
+        namsec = self.setlink(initrole="Namelist", initkind="namelist")
         logger.info("ISEED added to NAMSFC namelist entry: %d", seed)
-        namsec[0].rh.contents['NAMSFC']['ISEED'] = seed
+        namsec[0].rh.contents["NAMSFC"]["ISEED"] = seed
         namsec[0].rh.save()
 
 
@@ -435,27 +553,30 @@ class Clustering(BlindRun, EcGribDecoMixin):
     """Select by clustering a sample of members among the whole set."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values   = ['clustering', 'clust', ],
-                remap    = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "clustering",
+                    "clust",
+                ],
+                remap=dict(autoremap="first"),
             ),
-            fileoutput = dict(
-                optional = True,
-                default  = '_griblist',
+            fileoutput=dict(
+                optional=True,
+                default="_griblist",
             ),
-            nbclust = dict(
-                type     = int,
+            nbclust=dict(
+                type=int,
             ),
-            nbmembers = dict(
-                type     = int,
-                optional = True,
-                access   = 'rwx',
+            nbmembers=dict(
+                type=int,
+                optional=True,
+                access="rwx",
             ),
-            gribfilter_tasks = dict(
-                type     = int,
-                optional = True,
-                default  = 8,
+            gribfilter_tasks=dict(
+                type=int,
+                optional=True,
+                default=8,
             ),
         )
     )
@@ -464,34 +585,49 @@ class Clustering(BlindRun, EcGribDecoMixin):
         """Set some variables according to target definition."""
         super().prepare(rh, opts)
 
-        grib_sections = self.context.sequence.effective_inputs(role='ModelState',
-                                                               kind='gridpoint')
-        avail_json = self.context.sequence.effective_inputs(role='AvailableMembers',
-                                                            kind='mbpopulation')
+        grib_sections = self.context.sequence.effective_inputs(
+            role="ModelState", kind="gridpoint"
+        )
+        avail_json = self.context.sequence.effective_inputs(
+            role="AvailableMembers", kind="mbpopulation"
+        )
 
         # If no population file is here, just do a sort on the file list,
         # otherwise use the population list
         if avail_json:
-            population = avail_json[0].rh.contents.data['population']
+            population = avail_json[0].rh.contents.data["population"]
             self.nbmembers = len(population)
             file_list = list()
             terms_set = set()
             for elt in population:
                 sublist_ids = list()
-                for (i, grib) in enumerate(grib_sections):
+                for i, grib in enumerate(grib_sections):
                     # If the grib file matches, let's go
-                    if all([grib.rh.wide_key_lookup(key, exports=True) == value
-                            for (key, value) in elt.items()]):
+                    if all(
+                        [
+                            grib.rh.wide_key_lookup(key, exports=True) == value
+                            for (key, value) in elt.items()
+                        ]
+                    ):
                         sublist_ids.append(i)
                 # Stack the gribs in file_list
-                file_list.extend(sorted([str(grib_sections[i].rh.container.localpath())
-                                         for i in sublist_ids]))
-                terms_set.update([grib_sections[i].rh.resource.term for i in sublist_ids])
+                file_list.extend(
+                    sorted(
+                        [
+                            str(grib_sections[i].rh.container.localpath())
+                            for i in sublist_ids
+                        ]
+                    )
+                )
+                terms_set.update(
+                    [grib_sections[i].rh.resource.term for i in sublist_ids]
+                )
                 for i in reversed(sublist_ids):
                     del grib_sections[i]
         else:
-            file_list = sorted([str(grib.rh.container.localpath())
-                                for grib in grib_sections])
+            file_list = sorted(
+                [str(grib.rh.container.localpath()) for grib in grib_sections]
+            )
             terms_set = {grib.rh.resource.term for grib in grib_sections}
 
         # determine what terms are available to the clustering algorithm
@@ -501,86 +637,120 @@ class Clustering(BlindRun, EcGribDecoMixin):
             cluststep = delta.pop().hour
         else:
             cluststep = -999
-            logger.error('Terms are not evenly spaced. What should we do ?')
-            logger.error('Terms=' + str(terms) + 'delta=' + str(delta))
-            logger.error('Continuing with little hope and cluststep = %d', cluststep)
+            logger.error("Terms are not evenly spaced. What should we do ?")
+            logger.error("Terms=" + str(terms) + "delta=" + str(delta))
+            logger.error(
+                "Continuing with little hope and cluststep = %d", cluststep
+            )
         clustdeb = terms[0].hour
         clustfin = terms[-1].hour
-        logger.info('clustering deb=%d fin=%d step=%d', clustdeb, clustfin, cluststep)
+        logger.info(
+            "clustering deb=%d fin=%d step=%d", clustdeb, clustfin, cluststep
+        )
 
         # Deal with xGribs
-        file_list_cat = [f + '.concatenated' for f in file_list]
-        parallel_grib_filter(self.context, file_list, file_list_cat,
-                             cat=True, nthreads=self.gribfilter_tasks)
+        file_list_cat = [f + ".concatenated" for f in file_list]
+        parallel_grib_filter(
+            self.context,
+            file_list,
+            file_list_cat,
+            cat=True,
+            nthreads=self.gribfilter_tasks,
+        )
 
         if self.nbmembers is None or self.nbmembers > self.nbclust:
-
             # Tweak the namelist
-            namsec = self.setlink(initrole='Namelist', initkind='namelist')
-            logger.info("NBRCLUST added to NAMCLUST namelist entry: %d", self.nbclust)
-            namsec[0].rh.contents['NAMCLUST']['NBRCLUST'] = self.nbclust
+            namsec = self.setlink(initrole="Namelist", initkind="namelist")
+            logger.info(
+                "NBRCLUST added to NAMCLUST namelist entry: %d", self.nbclust
+            )
+            namsec[0].rh.contents["NAMCLUST"]["NBRCLUST"] = self.nbclust
             if self.nbmembers is not None:
-                logger.info("NBRMB added to NAMCLUST namelist entry: %d", self.nbmembers)
-                namsec[0].rh.contents['NAMCLUST']['NBRMB'] = self.nbmembers
-            logger.info('Setting namelist macros ECHDEB=%d ECHFIN=%d ECHSTEP=%d',
-                        clustdeb, clustfin, cluststep)
-            namsec[0].rh.contents.setmacro('ECHDEB', clustdeb)
-            namsec[0].rh.contents.setmacro('ECHFIN', clustfin)
-            namsec[0].rh.contents.setmacro('ECHSTEP', cluststep)
+                logger.info(
+                    "NBRMB added to NAMCLUST namelist entry: %d",
+                    self.nbmembers,
+                )
+                namsec[0].rh.contents["NAMCLUST"]["NBRMB"] = self.nbmembers
+            logger.info(
+                "Setting namelist macros ECHDEB=%d ECHFIN=%d ECHSTEP=%d",
+                clustdeb,
+                clustfin,
+                cluststep,
+            )
+            namsec[0].rh.contents.setmacro("ECHDEB", clustdeb)
+            namsec[0].rh.contents.setmacro("ECHFIN", clustfin)
+            namsec[0].rh.contents.setmacro("ECHSTEP", cluststep)
             namsec[0].rh.save()
             namsec[0].rh.container.cat()
 
-            with open(self.fileoutput, 'w') as optFile:
-                optFile.write('\n'.join(file_list_cat))
+            with open(self.fileoutput, "w") as optFile:
+                optFile.write("\n".join(file_list_cat))
 
     def execute(self, rh, opts):
         # If the number of members is big enough -> normal processing
         if self.nbmembers is None or self.nbmembers > self.nbclust:
-            logger.info("Normal clustering run (%d members, %d clusters)",
-                        self.nbmembers, self.nbclust)
+            logger.info(
+                "Normal clustering run (%d members, %d clusters)",
+                self.nbmembers,
+                self.nbclust,
+            )
             super().execute(rh, opts)
         # if not, generate face outputs
         else:
-            logger.info("Generating fake outputs with %d members", self.nbmembers)
-            with open('ASCII_CLUST', 'w') as fdcl:
-                fdcl.write("\n".join(['{0:3d} {1:3d} {0:3d}'.format(i, 1)
-                                      for i in range(1, self.nbmembers + 1)]))
-            with open('ASCII_RMCLUST', 'w') as fdrm:
-                fdrm.write("\n".join([str(i) for i in range(1, self.nbmembers + 1)]))
-            with open('ASCII_POPCLUST', 'w') as fdpop:
-                fdpop.write("\n".join(['1'] * self.nbmembers))
+            logger.info(
+                "Generating fake outputs with %d members", self.nbmembers
+            )
+            with open("ASCII_CLUST", "w") as fdcl:
+                fdcl.write(
+                    "\n".join(
+                        [
+                            "{0:3d} {1:3d} {0:3d}".format(i, 1)
+                            for i in range(1, self.nbmembers + 1)
+                        ]
+                    )
+                )
+            with open("ASCII_RMCLUST", "w") as fdrm:
+                fdrm.write(
+                    "\n".join([str(i) for i in range(1, self.nbmembers + 1)])
+                )
+            with open("ASCII_POPCLUST", "w") as fdpop:
+                fdpop.write("\n".join(["1"] * self.nbmembers))
 
     def postfix(self, rh, opts):
         """Create a JSON with all the clustering informations."""
-        avail_json = self.context.sequence.effective_inputs(role='AvailableMembers',
-                                                            kind='mbpopulation')
+        avail_json = self.context.sequence.effective_inputs(
+            role="AvailableMembers", kind="mbpopulation"
+        )
         # If no population file is here, does nothing
         if avail_json:
             logger.info("Creating a JSON output...")
             # Read the clustering information
-            if self.system.path.exists('ASCII_CLUST'):
+            if self.system.path.exists("ASCII_CLUST"):
                 # New format for clustering outputs
-                with open('ASCII_CLUST') as fdcl:
+                with open("ASCII_CLUST") as fdcl:
                     cluster_members = list()
                     cluster_sizes = list()
                     for l in [l.split() for l in fdcl.readlines()]:
                         cluster_members.append(int(l[0]))
                         cluster_sizes.append(int(l[1]))
             else:
-                with open('ASCII_RMCLUST') as fdrm:
+                with open("ASCII_RMCLUST") as fdrm:
                     cluster_members = [int(m) for m in fdrm.readlines()]
-                with open('ASCII_POPCLUST') as fdpop:
+                with open("ASCII_POPCLUST") as fdpop:
                     cluster_sizes = [int(s) for s in fdpop.readlines()]
             # Update the population JSON
             mycontent = copy.deepcopy(avail_json[0].rh.contents)
-            mycontent.data['resource_kind'] = 'mbsample'
-            mycontent.data['drawing'] = list()
+            mycontent.data["resource_kind"] = "mbsample"
+            mycontent.data["drawing"] = list()
             for member_no, cluster_size in zip(cluster_members, cluster_sizes):
-                mycontent.data['drawing'].append(copy.copy(mycontent.data['population'][member_no - 1]))
-                mycontent.data['drawing'][-1]['cluster_size'] = cluster_size
+                mycontent.data["drawing"].append(
+                    copy.copy(mycontent.data["population"][member_no - 1])
+                )
+                mycontent.data["drawing"][-1]["cluster_size"] = cluster_size
             # Create a clustering output file
-            new_container = footprints.proxy.container(filename='clustering_output.json',
-                                                       actualfmt='json')
+            new_container = footprints.proxy.container(
+                filename="clustering_output.json", actualfmt="json"
+            )
             mycontent.rewrite(new_container)
 
         super().postfix(rh, opts)
@@ -590,13 +760,15 @@ class Addpearp(BlindRun):
     """Add the selected PEARP perturbations to the deterministic AROME initial conditions."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['addpearp', ],
-                remap  = dict(autoremap='first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "addpearp",
+                ],
+                remap=dict(autoremap="first"),
             ),
-            nbpert = dict(
-                type   = int,
+            nbpert=dict(
+                type=int,
             ),
         )
     )
@@ -606,8 +778,8 @@ class Addpearp(BlindRun):
         super().prepare(rh, opts)
 
         # Tweak the namelist
-        namsec = self.setlink(initrole='Namelist', initkind='namelist')
+        namsec = self.setlink(initrole="Namelist", initkind="namelist")
         logger.info("NBE added to NAMIC namelist entry: %d", self.nbpert)
-        namsec[0].rh.contents['NAMIC']['NBPERT'] = self.nbpert
+        namsec[0].rh.contents["NAMIC"]["NBPERT"] = self.nbpert
         namsec[0].rh.save()
         namsec[0].rh.container.cat()

--- a/src/vortex/nwp/algo/fpserver.py
+++ b/src/vortex/nwp/algo/fpserver.py
@@ -29,7 +29,7 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-fullpos_server_flypoll_pickle = '.fullpos_server_flypoll'
+fullpos_server_flypoll_pickle = ".fullpos_server_flypoll"
 
 
 class FullPosServerFlyPollPersistantState:
@@ -40,7 +40,9 @@ class FullPosServerFlyPollPersistantState:
         self.found = collections.defaultdict(list)
 
 
-def fullpos_server_flypoll(sh, outputprefix, termfile, directories=('.', ), **kwargs):  # @UnusedVariable
+def fullpos_server_flypoll(
+    sh, outputprefix, termfile, directories=(".",), **kwargs
+):  # @UnusedVariable
     """Check sub-**directories** to determine wether new output files are available or not."""
     new = list()
     for directory in directories:
@@ -52,25 +54,41 @@ def fullpos_server_flypoll(sh, outputprefix, termfile, directories=('.', ), **kw
             try:
                 if sh.path.exists(termfile):
                     with open(termfile) as wfh:
-                        rawcursor = wfh.readline().rstrip('\n')
+                        rawcursor = wfh.readline().rstrip("\n")
                     try:
                         cursor = Time(rawcursor)
                     except TypeError:
-                        logger.warning('Unable to convert "%s" to a Time object', rawcursor)
+                        logger.warning(
+                            'Unable to convert "%s" to a Time object',
+                            rawcursor,
+                        )
                         return new
-                    pre = re.compile(r'^{:s}\w*\+(\d+(?::\d\d)?)(?:\.\w+)?$'.format(outputprefix))
+                    pre = re.compile(
+                        r"^{:s}\w*\+(\d+(?::\d\d)?)(?:\.\w+)?$".format(
+                            outputprefix
+                        )
+                    )
                     candidates = [pre.match(f) for f in sh.listdir()]
                     lnew = list()
-                    for candidate in filterfalse(lambda c: c is None, candidates):
-                        if candidate.group(0).endswith('.d'):
+                    for candidate in filterfalse(
+                        lambda c: c is None, candidates
+                    ):
+                        if candidate.group(0).endswith(".d"):
                             continue
                         ctime = Time(candidate.group(1))
-                        if ctime > fpoll_st.cursor[outputprefix] and ctime <= cursor:
+                        if (
+                            ctime > fpoll_st.cursor[outputprefix]
+                            and ctime <= cursor
+                        ):
                             lnew.append(candidate.group(0))
                     fpoll_st.cursor[outputprefix] = cursor
                     fpoll_st.found[outputprefix].extend(lnew)
-                    new.extend([sh.path.normpath(sh.path.join(directory, anew))
-                                for anew in lnew])
+                    new.extend(
+                        [
+                            sh.path.normpath(sh.path.join(directory, anew))
+                            for anew in lnew
+                        ]
+                    )
             finally:
                 sh.pickle_dump(fpoll_st, fullpos_server_flypoll_pickle)
     return new
@@ -92,8 +110,7 @@ class FullposServerDiscoveredInputs:
         """Find out the required suffixlen."""
         if minlen is None:
             minlen = self.inputsminlen
-        return max(minlen,
-                   int(math.floor(math.log10(len(self.tododata)))))
+        return max(minlen, int(math.floor(math.log10(len(self.tododata)))))
 
 
 class FullPosServer(IFSParallel):
@@ -141,16 +158,16 @@ class FullPosServer(IFSParallel):
 
     """
 
-    _INITIALCONDITION_ROLE = re.compile(r'InitialCondition((?:\w+)?)')
-    _INPUTDATA_ROLE_STR = 'ModelState'
-    _INPUTDATA_ROLE = re.compile(r'ModelState((?:\w+)?)')
-    _OUTPUTGUESS_ROLE = 'OutputGuess'
+    _INITIALCONDITION_ROLE = re.compile(r"InitialCondition((?:\w+)?)")
+    _INPUTDATA_ROLE_STR = "ModelState"
+    _INPUTDATA_ROLE = re.compile(r"ModelState((?:\w+)?)")
+    _OUTPUTGUESS_ROLE = "OutputGuess"
 
-    _MODELSIDE_INPUTPREFIX0 = 'ICM'
-    _MODELSIDE_INPUTPREFIX1 = 'SH'
-    _MODELSIDE_OUTPUTPREFIX = 'PF'
-    _MODELSIDE_OUTPUTPREFIX_GRIB = 'GRIBPF'
-    _MODELSIDE_TERMFILE = './ECHFP'
+    _MODELSIDE_INPUTPREFIX0 = "ICM"
+    _MODELSIDE_INPUTPREFIX1 = "SH"
+    _MODELSIDE_OUTPUTPREFIX = "PF"
+    _MODELSIDE_OUTPUTPREFIX_GRIB = "GRIBPF"
+    _MODELSIDE_TERMFILE = "./ECHFP"
     _MODELSIDE_OUT_SUFFIXLEN_MIN = 4
     _MODELSIDE_IND_SUFFIXLEN_MIN = 4
     _MODELSIDE_INE_SUFFIXLEN_MIN = dict(grib=6)
@@ -162,77 +179,83 @@ class FullPosServer(IFSParallel):
     _footprint = [
         outputid_deco,
         dict(
-            attr = dict(
-                kind = dict(
-                    values   = ['fpserver', ],
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "fpserver",
+                    ],
                 ),
-                outdirectories = dict(
-                    info     = "The list of possible output directories.",
-                    type     = footprints.stdtypes.FPList,
-                    default  = footprints.stdtypes.FPList(['.', ]),
-                    optional = True,
+                outdirectories=dict(
+                    info="The list of possible output directories.",
+                    type=footprints.stdtypes.FPList,
+                    default=footprints.stdtypes.FPList(
+                        [
+                            ".",
+                        ]
+                    ),
+                    optional=True,
                 ),
-                append_domain = dict(
-                    info     = ("If defined, the output file for domain append_domain " +
-                                "will be made a copy of the input file (prior to the " +
-                                "server run"),
-                    optional = True,
+                append_domain=dict(
+                    info=(
+                        "If defined, the output file for domain append_domain "
+                        + "will be made a copy of the input file (prior to the "
+                        + "server run"
+                    ),
+                    optional=True,
                 ),
                 basedate=dict(
-                    info     = "The run date of the coupling generating process",
-                    type     = Date,
-                    optional = True
+                    info="The run date of the coupling generating process",
+                    type=Date,
+                    optional=True,
                 ),
-                xpname = dict(
-                    default  = 'FPOS'
-                ),
-                conf = dict(
-                    default  = 903,
+                xpname=dict(default="FPOS"),
+                conf=dict(
+                    default=903,
                 ),
                 timestep=dict(
-                    default  = 1.,
+                    default=1.0,
                 ),
-                timeout = dict(
-                    type     = int,
-                    optional = True,
-                    default  = 300,
+                timeout=dict(
+                    type=int,
+                    optional=True,
+                    default=300,
                 ),
-                refreshtime = dict(
-                    info     = "How frequently are the expected input files looked for ? (seconds)",
-                    type     = int,
-                    optional = True,
-                    default  = 20,
+                refreshtime=dict(
+                    info="How frequently are the expected input files looked for ? (seconds)",
+                    type=int,
+                    optional=True,
+                    default=20,
                 ),
-                server_run = dict(
+                server_run=dict(
                     # This is a rw attribute: it will be managed internally
-                    values   = [True, False]
+                    values=[True, False]
                 ),
-                serversync_method = dict(
-                    default  = 'simple_socket',
+                serversync_method=dict(
+                    default="simple_socket",
                 ),
-                serversync_medium = dict(
-                    default  = 'nextfile_wait',
+                serversync_medium=dict(
+                    default="nextfile_wait",
                 ),
-                maxpollingthreads = dict(
-                    type     = int,
-                    optional = True,
-                    default  = 8,
+                maxpollingthreads=dict(
+                    type=int,
+                    optional=True,
+                    default=8,
                 ),
-                flypoll = dict(
-                    default  = 'internal',
+                flypoll=dict(
+                    default="internal",
                 ),
-                defaultformat = dict(
-                    info = "Format for the legacy output files.",
-                    default = 'fa',
-                    optional = True
-                )
+                defaultformat=dict(
+                    info="Format for the legacy output files.",
+                    default="fa",
+                    optional=True,
+                ),
             )
-        )
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'fullpos'
+        return "fullpos"
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -244,10 +267,15 @@ class FullPosServer(IFSParallel):
         for out_re, data in self._flyput_mapping_d.items():
             m_re = out_re.match(sh.path.basename(item))
             if m_re:
-                return (sh.path.join(sh.path.dirname(item),
-                                     data[0].format(m_re.group('fpdom'),
-                                                    m_re.group('suffix'))),
-                        data[1])
+                return (
+                    sh.path.join(
+                        sh.path.dirname(item),
+                        data[0].format(
+                            m_re.group("fpdom"), m_re.group("suffix")
+                        ),
+                    ),
+                    data[1],
+                )
 
     @cached_property
     def inputs(self):
@@ -255,108 +283,174 @@ class FullPosServer(IFSParallel):
         discovered = FullposServerDiscoveredInputs()
 
         # Initial conditions
-        inisec = self.context.sequence.effective_inputs(role=self._INITIALCONDITION_ROLE)
+        inisec = self.context.sequence.effective_inputs(
+            role=self._INITIALCONDITION_ROLE
+        )
         if inisec:
             for s in inisec:
-                iprefix = (self._INITIALCONDITION_ROLE.match(s.alternate
-                                                             if s.role is None else
-                                                             s.role).group(1) or
-                           self._MODELSIDE_INPUTPREFIX1)
+                iprefix = (
+                    self._INITIALCONDITION_ROLE.match(
+                        s.alternate if s.role is None else s.role
+                    ).group(1)
+                    or self._MODELSIDE_INPUTPREFIX1
+                )
                 fprefix = self._MODELSIDE_INPUTPREFIX0 + iprefix
                 if fprefix in discovered.inidata:
-                    raise AlgoComponentError('Only one Initial Condition is allowed.')
+                    raise AlgoComponentError(
+                        "Only one Initial Condition is allowed."
+                    )
                 else:
                     discovered.inidata[fprefix] = s
 
         # Model states
-        todosec0 = self.context.sequence.effective_inputs(role=self._INPUTDATA_ROLE)
+        todosec0 = self.context.sequence.effective_inputs(
+            role=self._INPUTDATA_ROLE
+        )
         todosec1 = collections.defaultdict(list)
-        discovered.anyexpected = any([isec.rh.is_expected() for isec in todosec0])
-        hasterms = all([hasattr(isec.rh.resource, 'term') for isec in todosec0])
+        discovered.anyexpected = any(
+            [isec.rh.is_expected() for isec in todosec0]
+        )
+        hasterms = all(
+            [hasattr(isec.rh.resource, "term") for isec in todosec0]
+        )
         # Sort things up (if possible)
         if hasterms:
-            logger.info('Sorting input data based on the actual term.')
+            logger.info("Sorting input data based on the actual term.")
             todosec0 = sorted(todosec0, key=lambda s: self._actual_term(s.rh))
         if todosec0:
             for iseq, s in enumerate(todosec0):
-                rprefix = (self._INPUTDATA_ROLE.match(s.alternate
-                                                      if s.role is None else
-                                                      s.role).group(1) or
-                           self._MODELSIDE_INPUTPREFIX1)
+                rprefix = (
+                    self._INPUTDATA_ROLE.match(
+                        s.alternate if s.role is None else s.role
+                    ).group(1)
+                    or self._MODELSIDE_INPUTPREFIX1
+                )
                 todosec1[rprefix].append(s)
                 if iseq == 0:
                     # Find the "default" prefix and suffix len based on the first section
                     discovered.firstprefix = rprefix
-                    discovered.inputsminlen = self._MODELSIDE_INE_SUFFIXLEN_MIN.get(
-                        s.rh.container.actualfmt, self._MODELSIDE_IND_SUFFIXLEN_MIN
+                    discovered.inputsminlen = (
+                        self._MODELSIDE_INE_SUFFIXLEN_MIN.get(
+                            s.rh.container.actualfmt,
+                            self._MODELSIDE_IND_SUFFIXLEN_MIN,
+                        )
                     )
             iprefixes = sorted(todosec1.keys())
             if len(iprefixes) == 1:
                 for s in todosec0:
-                    discovered.tododata.append({self._MODELSIDE_INPUTPREFIX0 + iprefixes[0]: s})
+                    discovered.tododata.append(
+                        {self._MODELSIDE_INPUTPREFIX0 + iprefixes[0]: s}
+                    )
             else:
                 if len({len(secs) for secs in todosec1.values()}) > 1:
-                    raise AlgoComponentError('Inconsistent number of input data.')
-                for sections in zip(* [iter(todosec1[i]) for i in iprefixes]):
-                    discovered.tododata.append({self._MODELSIDE_INPUTPREFIX0 + k: v
-                                                for k, v in zip(iprefixes, sections)})
+                    raise AlgoComponentError(
+                        "Inconsistent number of input data."
+                    )
+                for sections in zip(*[iter(todosec1[i]) for i in iprefixes]):
+                    discovered.tododata.append(
+                        {
+                            self._MODELSIDE_INPUTPREFIX0 + k: v
+                            for k, v in zip(iprefixes, sections)
+                        }
+                    )
 
         # Detect the number of terms based on the firstprefix
         if hasterms:
             for sections in discovered.tododata:
-                act_term = self._actual_term(sections[self._MODELSIDE_INPUTPREFIX0 +
-                                                      discovered.firstprefix].rh)
+                act_term = self._actual_term(
+                    sections[
+                        self._MODELSIDE_INPUTPREFIX0 + discovered.firstprefix
+                    ].rh
+                )
                 discovered.termscount[act_term] += 1
 
         # Look for guesses of output files
         guesses_sec0 = collections.defaultdict(list)
-        guess_entry = collections.namedtuple('guess_entry', ('sdir', 'prefix', 'domain', 'suffix', 'sec'))
-        for sec in self.context.sequence.effective_inputs(role=self._OUTPUTGUESS_ROLE):
+        guess_entry = collections.namedtuple(
+            "guess_entry", ("sdir", "prefix", "domain", "suffix", "sec")
+        )
+        for sec in self.context.sequence.effective_inputs(
+            role=self._OUTPUTGUESS_ROLE
+        ):
             s_lpath = sec.rh.container.localpath()
             s_match = self._o_algo_re.match(self.system.path.basename(s_lpath))
             if s_match:
-                guesses_sec0[s_match.group('base')].append(guess_entry(
-                    self.system.path.dirname(s_lpath),
-                    self._o_auto_prefix('grib' if s_match.group('grib') else self.defaultformat),
-                    s_match.group('fpdom'),
-                    s_match.group('suffix'),
-                    sec
-                ))
-                discovered.anyexpected = discovered.anyexpected or sec.rh.is_expected()
+                guesses_sec0[s_match.group("base")].append(
+                    guess_entry(
+                        self.system.path.dirname(s_lpath),
+                        self._o_auto_prefix(
+                            "grib"
+                            if s_match.group("grib")
+                            else self.defaultformat
+                        ),
+                        s_match.group("fpdom"),
+                        s_match.group("suffix"),
+                        sec,
+                    )
+                )
+                discovered.anyexpected = (
+                    discovered.anyexpected or sec.rh.is_expected()
+                )
             else:
-                logger.warning('Improper name for the following output guess < %s >. Ignoring it.', s_lpath)
+                logger.warning(
+                    "Improper name for the following output guess < %s >. Ignoring it.",
+                    s_lpath,
+                )
         # Pair them with input file (based on their name)
         for iinput in discovered.tododata:
-            isec = iinput[self._MODELSIDE_INPUTPREFIX0 + discovered.firstprefix]
+            isec = iinput[
+                self._MODELSIDE_INPUTPREFIX0 + discovered.firstprefix
+            ]
             discovered.guessdata.append(
-                guesses_sec0.pop(self.system.path.basename(isec.rh.container.localpath()), ())
+                guesses_sec0.pop(
+                    self.system.path.basename(isec.rh.container.localpath()),
+                    (),
+                )
             )
         if guesses_sec0:
-            logger.warning('Some input data were left unsed: < %s >', guesses_sec0)
-            logger.info('discovered guessdata are: < %s >', discovered.guessdata)
+            logger.warning(
+                "Some input data were left unsed: < %s >", guesses_sec0
+            )
+            logger.info(
+                "discovered guessdata are: < %s >", discovered.guessdata
+            )
 
         return discovered
 
     @cached_property
     def object_namelists(self):
         """The list of object's namelists."""
-        namrhs = [isec.rh
-                  for isec in self.context.sequence.effective_inputs(role='ObjectNamelist')
-                  if isec.rh.resource.realkind == 'namelist_fpobject']
+        namrhs = [
+            isec.rh
+            for isec in self.context.sequence.effective_inputs(
+                role="ObjectNamelist"
+            )
+            if isec.rh.resource.realkind == "namelist_fpobject"
+        ]
         # Update the object's content
         for namrh in namrhs:
             namsave = False
             if namrh.resource.fp_cmodel is not None:
-                self._set_nam_macro(namrh.contents, namrh.container.localpath(),
-                                    'FP_CMODEL', namrh.resource.fp_cmodel)
+                self._set_nam_macro(
+                    namrh.contents,
+                    namrh.container.localpath(),
+                    "FP_CMODEL",
+                    namrh.resource.fp_cmodel,
+                )
                 namsave = True
             if namrh.resource.fp_lextern is not None:
-                self._set_nam_macro(namrh.contents, namrh.container.localpath(),
-                                    'FP_LEXTERN', namrh.resource.fp_lextern)
+                self._set_nam_macro(
+                    namrh.contents,
+                    namrh.container.localpath(),
+                    "FP_LEXTERN",
+                    namrh.resource.fp_lextern,
+                )
                 namsave = True
             if namrh.resource.fp_terms is not None:
                 if not self.inputs.termscount:
-                    raise AlgoComponentError('In this use case, all input data must have a term attribute')
+                    raise AlgoComponentError(
+                        "In this use case, all input data must have a term attribute"
+                    )
                 active_terms = {Time(t) for t in namrh.resource.fp_terms}
                 # Generate the list of NFPOSTS
                 global_i = 0
@@ -367,23 +461,34 @@ class FullPosServer(IFSParallel):
                     global_i += n_term
                 # Get the NAMFPC block
                 try:
-                    nfpc = namrh.contents['NAMFPC']
+                    nfpc = namrh.contents["NAMFPC"]
                 except KeyError:
-                    raise AlgoComponentError('NAMFPC should be defined in {:s}'
-                                             .format(namrh.container.localpath()))
+                    raise AlgoComponentError(
+                        "NAMFPC should be defined in {:s}".format(
+                            namrh.container.localpath()
+                        )
+                    )
                 # Sanity check
                 for k in nfpc.keys():
-                    if k.startswith('NFPOSTS'):
-                        raise AlgoComponentError('&NAMFPC NFPOSTS*(*) / entries should not be defined in {:s}'
-                                                 .format(namrh.container.localpath()))
+                    if k.startswith("NFPOSTS"):
+                        raise AlgoComponentError(
+                            "&NAMFPC NFPOSTS*(*) / entries should not be defined in {:s}".format(
+                                namrh.container.localpath()
+                            )
+                        )
                 # Write NFPOSTS to NAMFPC
-                nfpc['NFPOSTS(0)'] = - len(nfposts)
+                nfpc["NFPOSTS(0)"] = -len(nfposts)
                 for i, v in enumerate(nfposts):
-                    nfpc['NFPOSTS({:d})'.format(i + 1)] = - v
-                logger.info("The NAMFPC namelist in %s was updated.",
-                            namrh.container.localpath())
-                logger.debug("The updated NAMFPC namelist in %s is:\n%s",
-                             namrh.container.localpath(), nfpc)
+                    nfpc["NFPOSTS({:d})".format(i + 1)] = -v
+                logger.info(
+                    "The NAMFPC namelist in %s was updated.",
+                    namrh.container.localpath(),
+                )
+                logger.debug(
+                    "The updated NAMFPC namelist in %s is:\n%s",
+                    namrh.container.localpath(),
+                    nfpc,
+                )
                 namsave = True
             if namsave:
                 namrh.save()
@@ -393,53 +498,81 @@ class FullPosServer(IFSParallel):
     def xxtmapping(self):
         """A handy dictionary about selection namelists."""
         namxxrh = collections.defaultdict(dict)
-        for isec in self.context.sequence.effective_inputs(role='FullPosSelection',
-                                                           kind='namselect'):
+        for isec in self.context.sequence.effective_inputs(
+            role="FullPosSelection", kind="namselect"
+        ):
             dpath = self.system.path.dirname(isec.rh.container.localpath())
             namxxrh[dpath][isec.rh.resource.term] = isec.rh
         if namxxrh and not self.inputs.termscount:
-            raise AlgoComponentError('In this use case, all input data must have a term attribute')
+            raise AlgoComponentError(
+                "In this use case, all input data must have a term attribute"
+            )
         return namxxrh
 
     @cached_property
     def _i_fmt(self):
         """The input files format (as expected by the c903)."""
-        return ('{:s}' + '{:s}+'.format(self.xpname) +
-                '{:0' + str(self.inputs.actual_suffixlen()) + 'd}')
+        return (
+            "{:s}"
+            + "{:s}+".format(self.xpname)
+            + "{:0"
+            + str(self.inputs.actual_suffixlen())
+            + "d}"
+        )
 
     @cached_property
     def _o_raw_fmt(self):
         """The output files format (as imposed by the c903)."""
-        return ('{:s}' + '{:s}'.format(self.xpname) + '{:s}+' +
-                '{:0' + str(self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN)) + 'd}{:s}')
+        return (
+            "{:s}"
+            + "{:s}".format(self.xpname)
+            + "{:s}+"
+            + "{:0"
+            + str(
+                self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN)
+            )
+            + "d}{:s}"
+        )
 
     @cached_property
     def _o_re_fmt(self):
         """The output files regex (as imposed by the c903)."""
-        return ('^{:s}' + '{:s}'.format(self.xpname) + r'(?P<fpdom>\w+)\+' +
-                '{:0' + str(self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN)) +
-                r'd}(?P<suffix>(?:\.sfx)?)$')
+        return (
+            "^{:s}"
+            + "{:s}".format(self.xpname)
+            + r"(?P<fpdom>\w+)\+"
+            + "{:0"
+            + str(
+                self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN)
+            )
+            + r"d}(?P<suffix>(?:\.sfx)?)$"
+        )
 
     @cached_property
     def _o_init_re_fmt(self):
         """The output files regex (as imposed by the c903)."""
-        return ('^{:s}' + '{:s}'.format(self.xpname) +
-                r'(?P<fpdom>\w+){:s}(?P<suffix>(?:\.sfx)?)$')
+        return (
+            "^{:s}"
+            + "{:s}".format(self.xpname)
+            + r"(?P<fpdom>\w+){:s}(?P<suffix>(?:\.sfx)?)$"
+        )
 
     @cached_property
     def _o_algo_re(self):
         """The regex for any output (as imposed by our AlgoComponent)."""
-        return re.compile(r'(?P<base>.+)\.(?P<fpdom>\w+)(?P<suffix>(?:\.sfx)?)(?P<grib>(?:\.grib)?)\.out$')
+        return re.compile(
+            r"(?P<base>.+)\.(?P<fpdom>\w+)(?P<suffix>(?:\.sfx)?)(?P<grib>(?:\.grib)?)\.out$"
+        )
 
     @cached_property
     def _o_suffix(self):
         """The FAs output suffix (as imposed by our AlgoComponent)."""
-        return '.{:s}{:s}.out'
+        return ".{:s}{:s}.out"
 
     @cached_property
     def _o_grb_suffix(self):
         """The GRIBs output suffix (as imposed by our AlgoComponent)."""
-        return '.{:s}{:s}.grib.out'
+        return ".{:s}{:s}.grib.out"
 
     def _o_auto_prefix(self, fmt):
         """Return the appropriate output files prefix (as imposed by the c903)."""
@@ -462,80 +595,132 @@ class FullPosServer(IFSParallel):
         outputs_mapping[re.compile(re_default)] = what_default
         # GRIB files
         re_grib = out_re.format(self._MODELSIDE_OUTPUTPREFIX_GRIB, i)
-        what_grib = (out_fname + self._o_grb_suffix, 'grib')
+        what_grib = (out_fname + self._o_grb_suffix, "grib")
         outputs_mapping[re.compile(re_grib)] = what_grib
-        logger.info('Output %s mapped as %s. Output %s mapped as %s.',
-                    re_default, what_default[0], re_grib, what_grib[0])
+        logger.info(
+            "Output %s mapped as %s. Output %s mapped as %s.",
+            re_default,
+            what_default[0],
+            re_grib,
+            what_grib[0],
+        )
 
     def _link_input(self, iprefix, irh, i, inputs_mapping, outputs_mapping):
         """Link an input file and update the mappings dictionaries."""
         sourcepath = irh.container.localpath()
         inputs_mapping[sourcepath] = self._i_fmt.format(iprefix, i)
-        self.system.cp(sourcepath, inputs_mapping[sourcepath], intent='in', fmt=irh.container.actualfmt)
-        logger.info('%s copied as %s.', sourcepath, inputs_mapping[sourcepath])
+        self.system.cp(
+            sourcepath,
+            inputs_mapping[sourcepath],
+            intent="in",
+            fmt=irh.container.actualfmt,
+        )
+        logger.info("%s copied as %s.", sourcepath, inputs_mapping[sourcepath])
         if iprefix == self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix:
-            self._add_output_mapping(outputs_mapping, i, self._o_re_fmt,
-                                     self.system.path.basename(sourcepath))
+            self._add_output_mapping(
+                outputs_mapping,
+                i,
+                self._o_re_fmt,
+                self.system.path.basename(sourcepath),
+            )
             if self.append_domain:
                 outputpath = self._o_raw_fmt.format(
-                    self._o_auto_prefix(irh.container.actualfmt), self.append_domain, i, ''
+                    self._o_auto_prefix(irh.container.actualfmt),
+                    self.append_domain,
+                    i,
+                    "",
                 )
 
                 if self.outdirectories:
-                    todo = [self.system.path.join(d, outputpath) for d in self.outdirectories]
+                    todo = [
+                        self.system.path.join(d, outputpath)
+                        for d in self.outdirectories
+                    ]
                 else:
-                    todo = [outputpath, ]
+                    todo = [
+                        outputpath,
+                    ]
                 for a_outputpath in todo:
-                    self.system.cp(sourcepath, a_outputpath, intent='inout', fmt=irh.container.actualfmt)
-                    logger.info('output file prepared: %s copied (rw) to %s.', sourcepath, a_outputpath)
+                    self.system.cp(
+                        sourcepath,
+                        a_outputpath,
+                        intent="inout",
+                        fmt=irh.container.actualfmt,
+                    )
+                    logger.info(
+                        "output file prepared: %s copied (rw) to %s.",
+                        sourcepath,
+                        a_outputpath,
+                    )
 
     def _move_output_guess(self, iguess, i):
         """Move the output file guesses to their final location."""
         sourcepath = iguess.sec.rh.container.localpath()
         destpath = self.system.path.join(
             iguess.sdir,
-            self._o_raw_fmt.format(iguess.prefix, iguess.domain, i, iguess.suffix)
+            self._o_raw_fmt.format(
+                iguess.prefix, iguess.domain, i, iguess.suffix
+            ),
         )
-        self.system.mv(sourcepath, destpath, fmt=iguess.sec.rh.container.actualfmt)
-        logger.info('output guess %s was moved to %s.', sourcepath, destpath)
+        self.system.mv(
+            sourcepath, destpath, fmt=iguess.sec.rh.container.actualfmt
+        )
+        logger.info("output guess %s was moved to %s.", sourcepath, destpath)
 
     def _link_xxt(self, todorh, i):
         """If necessary, link in the appropriate xxtNNNNNNMM file."""
         for sdir, tdict in self.xxtmapping.items():
             xxtrh = tdict.get(self._actual_term(todorh), None)
             if xxtrh is not None:
-                xxtsource = self.system.path.relpath(xxtrh.container.abspath,
-                                                     sdir)
+                xxtsource = self.system.path.relpath(
+                    xxtrh.container.abspath, sdir
+                )
                 # The file is expected to follow the xxtDDDDHHMM syntax where DDDD
                 # is the number of days
                 days_hours = (i // 24) * 100 + i % 24
-                xxttarget = 'xxt{:06d}00'.format(days_hours)
+                xxttarget = "xxt{:06d}00".format(days_hours)
                 xxttarget = self.system.path.join(sdir, xxttarget)
                 self.system.symlink(xxtsource, xxttarget)
-                logger.info('XXT %s linked in as %s.', xxtsource, xxttarget)
+                logger.info("XXT %s linked in as %s.", xxtsource, xxttarget)
 
     def _init_poll_and_move(self, outputs_mapping):
         """Deal with the PF*INIT file."""
         sh = self.system
-        candidates = self.system.glob('{:s}{:s}*INIT'.format(self._MODELSIDE_OUTPUTPREFIX, self.xpname))
+        candidates = self.system.glob(
+            "{:s}{:s}*INIT".format(self._MODELSIDE_OUTPUTPREFIX, self.xpname)
+        )
         outputnames = list()
         for thisdata in candidates:
             mappeddata = None
             for out_re, data in outputs_mapping.items():
                 m_re = out_re.match(thisdata)
                 if m_re:
-                    mappeddata = (sh.path.join(sh.path.dirname(thisdata),
-                                               data[0].format(m_re.group('fpdom'),
-                                                              m_re.group('suffix'))),
-                                  data[1])
+                    mappeddata = (
+                        sh.path.join(
+                            sh.path.dirname(thisdata),
+                            data[0].format(
+                                m_re.group("fpdom"), m_re.group("suffix")
+                            ),
+                        ),
+                        data[1],
+                    )
                     break
             if mappeddata is None:
-                raise AlgoComponentError('The mapping failed for {:s}.'.format(thisdata))
+                raise AlgoComponentError(
+                    "The mapping failed for {:s}.".format(thisdata)
+                )
             # Already dealt with ?
             if not self.system.path.exists(mappeddata[0]):
-                logger.info('Linking <%s> to <%s> (fmt=%s).', thisdata, mappeddata[0], mappeddata[1])
+                logger.info(
+                    "Linking <%s> to <%s> (fmt=%s).",
+                    thisdata,
+                    mappeddata[0],
+                    mappeddata[1],
+                )
                 outputnames.append(mappeddata[0])
-                self.system.cp(thisdata, mappeddata[0], intent='in', fmt=mappeddata[1])
+                self.system.cp(
+                    thisdata, mappeddata[0], intent="in", fmt=mappeddata[1]
+                )
         return outputnames
 
     def _poll_and_move(self, outputs_mapping):
@@ -548,26 +733,44 @@ class FullPosServer(IFSParallel):
             for out_re, data in outputs_mapping.items():
                 m_re = out_re.match(sh.path.basename(thisdata))
                 if m_re:
-                    mappeddata = (sh.path.join(sh.path.dirname(thisdata),
-                                               data[0].format(m_re.group('fpdom'),
-                                                              m_re.group('suffix'))),
-                                  data[1])
+                    mappeddata = (
+                        sh.path.join(
+                            sh.path.dirname(thisdata),
+                            data[0].format(
+                                m_re.group("fpdom"), m_re.group("suffix")
+                            ),
+                        ),
+                        data[1],
+                    )
                     break
             if mappeddata is None:
-                raise AlgoComponentError('The mapping failed for {:s}.'.format(thisdata))
-            logger.info('Linking <%s> to <%s> (fmt=%s).', thisdata, mappeddata[0], mappeddata[1])
+                raise AlgoComponentError(
+                    "The mapping failed for {:s}.".format(thisdata)
+                )
+            logger.info(
+                "Linking <%s> to <%s> (fmt=%s).",
+                thisdata,
+                mappeddata[0],
+                mappeddata[1],
+            )
             outputnames.append(mappeddata[0])
-            self.system.cp(thisdata, mappeddata[0], intent='in', fmt=mappeddata[1])
+            self.system.cp(
+                thisdata, mappeddata[0], intent="in", fmt=mappeddata[1]
+            )
         return outputnames
 
     def _deal_with_promises(self, outputs_mapping, pollingcb):
         if self.promises:
             seen = pollingcb(outputs_mapping)
             for afile in seen:
-                candidates = [x for x in self.promises
-                              if x.rh.container.abspath == self.system.path.abspath(afile)]
+                candidates = [
+                    x
+                    for x in self.promises
+                    if x.rh.container.abspath
+                    == self.system.path.abspath(afile)
+                ]
                 if candidates:
-                    logger.info('The output data is promised <%s>', afile)
+                    logger.info("The output data is promised <%s>", afile)
                     bingo = candidates.pop()
                     bingo.put(incache=True)
 
@@ -576,129 +779,214 @@ class FullPosServer(IFSParallel):
         super().prepare(rh, opts)
 
         if self.object_namelists:
-            self.system.subtitle('Object Namelists customisation')
+            self.system.subtitle("Object Namelists customisation")
         for o_nam in self.object_namelists:
             # a/c cy44: &NAMFPIOS NFPDIGITS=__SUFFIXLEN__, /
-            self._set_nam_macro(o_nam.contents, o_nam.container.localpath(), 'SUFFIXLEN',
-                                self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN))
+            self._set_nam_macro(
+                o_nam.contents,
+                o_nam.container.localpath(),
+                "SUFFIXLEN",
+                self.inputs.actual_suffixlen(
+                    self._MODELSIDE_OUT_SUFFIXLEN_MIN
+                ),
+            )
             if o_nam.contents.dumps_needs_update:
-                logger.info('Rewritting the %s namelists file.', o_nam.container.actualpath())
+                logger.info(
+                    "Rewritting the %s namelists file.",
+                    o_nam.container.actualpath(),
+                )
                 o_nam.save()
 
-        self.system.subtitle('Dealing with various input files')
+        self.system.subtitle("Dealing with various input files")
 
         # Sanity check over climfiles and geometries
-        input_geo = {sec.rh.resource.geometry
-                     for sdict in self.inputs.tododata for sec in sdict.values()}
+        input_geo = {
+            sec.rh.resource.geometry
+            for sdict in self.inputs.tododata
+            for sec in sdict.values()
+        }
         if len(input_geo) == 0:
-            raise AlgoComponentError('No input data are provided, ...')
+            raise AlgoComponentError("No input data are provided, ...")
         elif len(input_geo) > 1:
-            raise AlgoComponentError('Multiple geometries are not allowed for input data.')
+            raise AlgoComponentError(
+                "Multiple geometries are not allowed for input data."
+            )
         else:
             input_geo = input_geo.pop()
 
-        input_climgeo = {x.rh.resource.geometry
-                         for x in self.context.sequence.effective_inputs(role=('InputClim',
-                                                                               'InitialClim'))}
+        input_climgeo = {
+            x.rh.resource.geometry
+            for x in self.context.sequence.effective_inputs(
+                role=("InputClim", "InitialClim")
+            )
+        }
         if len(input_climgeo) == 0:
-            logger.info('No input clim provided. Going on without it...')
+            logger.info("No input clim provided. Going on without it...")
         elif len(input_climgeo) > 1:
-            raise AlgoComponentError('Multiple geometries are not allowed for input climatology.')
+            raise AlgoComponentError(
+                "Multiple geometries are not allowed for input climatology."
+            )
         else:
             if input_climgeo.pop() != input_geo:
-                raise AlgoComponentError('The input data and input climatology geometries does not match.')
+                raise AlgoComponentError(
+                    "The input data and input climatology geometries does not match."
+                )
 
         # Initial Condition geometry sanity check
-        if self.inputs.inidata and any([sec.rh.resource.geometry != input_geo
-                                        for sec in self.inputs.inidata.values()]):
-            raise AlgoComponentError('The Initial Condition geometry differs from other input data.')
+        if self.inputs.inidata and any(
+            [
+                sec.rh.resource.geometry != input_geo
+                for sec in self.inputs.inidata.values()
+            ]
+        ):
+            raise AlgoComponentError(
+                "The Initial Condition geometry differs from other input data."
+            )
 
         # Sanity check on target climatology files
-        target_climgeos = {x.rh.resource.geometry
-                           for x in self.context.sequence.effective_inputs(role='TargetClim')}
+        target_climgeos = {
+            x.rh.resource.geometry
+            for x in self.context.sequence.effective_inputs(role="TargetClim")
+        }
         if len(target_climgeos) == 0:
-            logger.info('No target clim are provided. Going on without it...')
+            logger.info("No target clim are provided. Going on without it...")
 
         # Sanity check on selection namelists
         if self.xxtmapping:
             for tdict in self.xxtmapping.values():
-                if ({self._actual_term(sec.rh)
-                     for sdict in self.inputs.tododata
-                     for sec in sdict.values()} < set(tdict.keys())):
-                    raise AlgoComponentError("The list of terms between input data and selection namelists differs")
+                if {
+                    self._actual_term(sec.rh)
+                    for sdict in self.inputs.tododata
+                    for sec in sdict.values()
+                } < set(tdict.keys()):
+                    raise AlgoComponentError(
+                        "The list of terms between input data and selection namelists differs"
+                    )
         else:
             logger.info("No selection namelists detected. That's fine")
 
         # Link in the initial condition file (if necessary)
         for iprefix, isec in self.inputs.inidata.items():
-            i_init = '{:s}{:s}INIT'.format(iprefix, self.xpname)
+            i_init = "{:s}{:s}INIT".format(iprefix, self.xpname)
             if isec.rh.container.basename != i_init:
-                self.system.cp(isec.rh.container.localpath(), i_init,
-                               intent='in', fmt=isec.rh.container.actualfmt)
-                logger.info('Initial condition file %s copied as %s.',
-                            isec.rh.container.localpath(), i_init)
+                self.system.cp(
+                    isec.rh.container.localpath(),
+                    i_init,
+                    intent="in",
+                    fmt=isec.rh.container.actualfmt,
+                )
+                logger.info(
+                    "Initial condition file %s copied as %s.",
+                    isec.rh.container.localpath(),
+                    i_init,
+                )
 
     def find_namelists(self, opts=None):
         """Find any namelists candidates in actual context inputs."""
-        return [x.rh
-                for x in self.context.sequence.effective_inputs(role='Namelist',
-                                                                kind='namelist')]
+        return [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role="Namelist", kind="namelist"
+            )
+        ]
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         super().prepare_namelist_delta(rh, namcontents, namlocal)
         # With cy43: &NAMCT0 CSCRIPT_PPSERVER=__SERVERSYNC_SCRIPT__, /
         if self.inputs.anyexpected:
-            self._set_nam_macro(namcontents, namlocal, 'SERVERSYNC_SCRIPT',
-                                self.system.path.join('.', self.serversync_medium))
+            self._set_nam_macro(
+                namcontents,
+                namlocal,
+                "SERVERSYNC_SCRIPT",
+                self.system.path.join(".", self.serversync_medium),
+            )
         else:
             # Do not harass the filesystem...
-            self._set_nam_macro(namcontents, namlocal, 'SERVERSYNC_SCRIPT', ' ')
+            self._set_nam_macro(
+                namcontents, namlocal, "SERVERSYNC_SCRIPT", " "
+            )
         # With cy43: &NAMCT0 CFPNCF=__IOPOLL_WHITNESSFILE__, /
-        self._set_nam_macro(namcontents, namlocal, 'IOPOLL_WHITNESSFILE', self._MODELSIDE_TERMFILE)
+        self._set_nam_macro(
+            namcontents,
+            namlocal,
+            "IOPOLL_WHITNESSFILE",
+            self._MODELSIDE_TERMFILE,
+        )
         # With cy43: No matching namelist key
         # a/c cy44: &NAMFPIOS NFPDIGITS=__SUFFIXLEN__, /
-        self._set_nam_macro(namcontents, namlocal, 'SUFFIXLEN',
-                            self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN))
+        self._set_nam_macro(
+            namcontents,
+            namlocal,
+            "SUFFIXLEN",
+            self.inputs.actual_suffixlen(self._MODELSIDE_OUT_SUFFIXLEN_MIN),
+        )
         # No matching namelist yet
-        self._set_nam_macro(namcontents, namlocal, 'INPUT_SUFFIXLEN',
-                            self.inputs.actual_suffixlen())
+        self._set_nam_macro(
+            namcontents,
+            namlocal,
+            "INPUT_SUFFIXLEN",
+            self.inputs.actual_suffixlen(),
+        )
         # With cy43: &NAMCT0 NFRPOS=__INPUTDATALEN__, /
-        self._set_nam_macro(namcontents, namlocal, 'INPUTDATALEN', - len(self.inputs.tododata))
+        self._set_nam_macro(
+            namcontents, namlocal, "INPUTDATALEN", -len(self.inputs.tododata)
+        )
         # Auto generate the list of namelists for the various objects
         if self.object_namelists:
-            if 'NAMFPOBJ' not in namcontents or len(namcontents['NAMFPOBJ']) == 0:
-                nb_o = NamelistBlock('NAMFPOBJ')
-                nb_o['NFPOBJ'] = len(self.object_namelists)
+            if (
+                "NAMFPOBJ" not in namcontents
+                or len(namcontents["NAMFPOBJ"]) == 0
+            ):
+                nb_o = NamelistBlock("NAMFPOBJ")
+                nb_o["NFPOBJ"] = len(self.object_namelists)
                 for i_nam, nam in enumerate(self.object_namelists):
                     if nam.resource.fp_conf:
-                        nb_o['NFPCONF({:d})'.format(i_nam + 1)] = nam.resource.fp_conf
-                    nb_o['CNAMELIST({:d})'.format(i_nam + 1)] = nam.container.localpath()
-                namcontents['NAMFPOBJ'] = nb_o
-                logger.info('The following namelist block has been added to "%s":\n%s',
-                            namlocal, nb_o.dumps())
+                        nb_o["NFPCONF({:d})".format(i_nam + 1)] = (
+                            nam.resource.fp_conf
+                        )
+                    nb_o["CNAMELIST({:d})".format(i_nam + 1)] = (
+                        nam.container.localpath()
+                    )
+                namcontents["NAMFPOBJ"] = nb_o
+                logger.info(
+                    'The following namelist block has been added to "%s":\n%s',
+                    namlocal,
+                    nb_o.dumps(),
+                )
             else:
-                logger.warning('The NAMFPOBJ namelist in "%s" is not empty. Leaving it as it is',
-                               namlocal)
+                logger.warning(
+                    'The NAMFPOBJ namelist in "%s" is not empty. Leaving it as it is',
+                    namlocal,
+                )
         # Just in case FP_CMODEL is defined in the main namelist
-        if self.outputid is not None and any(['FP_CMODEL' in nam_b.macros()
-                                              for nam_b in namcontents.values()]):
-            self._set_nam_macro(namcontents, namlocal, 'FP_CMODEL', self.outputid)
+        if self.outputid is not None and any(
+            ["FP_CMODEL" in nam_b.macros() for nam_b in namcontents.values()]
+        ):
+            self._set_nam_macro(
+                namcontents, namlocal, "FP_CMODEL", self.outputid
+            )
         return True
 
     def spawn_pre_dirlisting(self):
         """Print a directory listing just before run."""
         super().spawn_pre_dirlisting()
         for sdir in self.outdirectories:
-            self.system.subtitle('{:s} : {:s} sub-directory listing (pre-execution)'
-                                 .format(self.realkind, sdir))
+            self.system.subtitle(
+                "{:s} : {:s} sub-directory listing (pre-execution)".format(
+                    self.realkind, sdir
+                )
+            )
             self.system.dir(sdir, output=False, fatal=False)
 
     def spawn_hook(self):
         """Usually a good habit to dump the fort.4 namelist."""
         super().spawn_hook()
         for o_nam in self.object_namelists:
-            self.system.subtitle('{:s} : dump namelist <{:s}>'
-                                 .format(self.realkind, o_nam.container.localpath()))
+            self.system.subtitle(
+                "{:s} : dump namelist <{:s}>".format(
+                    self.realkind, o_nam.container.localpath()
+                )
+            )
             self.system.cat(o_nam.container.localpath(), output=False)
 
     def execute(self, rh, opts):
@@ -716,60 +1004,90 @@ class FullPosServer(IFSParallel):
                 self.grab(isec)
                 # Fix potential links and output mappings
                 sourcepath = isec.rh.container.basename
-                if iprefix == self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix:
-                    self._add_output_mapping(outputs_mapping, 'INIT',
-                                             self._o_init_re_fmt, sourcepath)
-                i_init = '{:s}{:s}INIT'.format(iprefix, self.xpname)
+                if (
+                    iprefix
+                    == self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix
+                ):
+                    self._add_output_mapping(
+                        outputs_mapping,
+                        "INIT",
+                        self._o_init_re_fmt,
+                        sourcepath,
+                    )
+                i_init = "{:s}{:s}INIT".format(iprefix, self.xpname)
                 if isec.rh.container.basename != i_init:
-                    self.system.cp(sourcepath, i_init,
-                                   intent='in', fmt=isec.rh.container.actualfmt)
-                    logger.info('Initial condition file %s copied as %s.',
-                                isec.rh.container.localpath(), i_init)
+                    self.system.cp(
+                        sourcepath,
+                        i_init,
+                        intent="in",
+                        fmt=isec.rh.container.actualfmt,
+                    )
+                    logger.info(
+                        "Initial condition file %s copied as %s.",
+                        isec.rh.container.localpath(),
+                        i_init,
+                    )
         else:
             if self.inputs.tododata:
                 # Just in case the INIT file is transformed
-                fakesource = self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix + self.xpname + 'INIT'
-                self._add_output_mapping(outputs_mapping, 'INIT', self._o_init_re_fmt, fakesource)
+                fakesource = (
+                    self._MODELSIDE_INPUTPREFIX0
+                    + self.inputs.firstprefix
+                    + self.xpname
+                    + "INIT"
+                )
+                self._add_output_mapping(
+                    outputs_mapping, "INIT", self._o_init_re_fmt, fakesource
+                )
 
         # Initialise the flying stuff
         self.flyput = False  # Do not use flyput every time...
         flyprefixes = set()
         for s in self.promises:
             lpath = s.rh.container.localpath()
-            if lpath.endswith('.grib.out'):
+            if lpath.endswith(".grib.out"):
                 flyprefixes.add(self._MODELSIDE_OUTPUTPREFIX_GRIB)
-            elif lpath.endswith('.out'):
+            elif lpath.endswith(".out"):
                 flyprefixes.add(self._MODELSIDE_OUTPUTPREFIX)
         self.io_poll_args = tuple(flyprefixes)
         self.io_poll_kwargs = dict(directories=tuple(set(self.outdirectories)))
         for directory in set(self.outdirectories):
             sh.mkdir(directory)  # Create possible output directories
-        if self.flypoll == 'internal':
+        if self.flypoll == "internal":
             self.io_poll_method = functools.partial(fullpos_server_flypoll, sh)
-            self.io_poll_kwargs['termfile'] = sh.path.basename(self._MODELSIDE_TERMFILE)
+            self.io_poll_kwargs["termfile"] = sh.path.basename(
+                self._MODELSIDE_TERMFILE
+            )
         self.flymapping = True
         self._flyput_mapping_d = outputs_mapping
 
         # Deal with XXT files
         if self.xxtmapping:
             for i, istuff in enumerate(self.inputs.tododata):
-                self._link_xxt(istuff[self._MODELSIDE_INPUTPREFIX0 +
-                                      self.inputs.firstprefix].rh, i)
+                self._link_xxt(
+                    istuff[
+                        self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix
+                    ].rh,
+                    i,
+                )
 
         if self.inputs.anyexpected:
             # Some server sync here...
             self.server_run = True
-            self.system.subtitle('Starting computation with server_run=T')
+            self.system.subtitle("Starting computation with server_run=T")
 
             # Process the data in chronological order ?
-            ordered_processing = (self.xxtmapping or
-                                  any([o_rh.resource.fp_terms is not None
-                                       for o_rh in self.object_namelists]))
+            ordered_processing = self.xxtmapping or any(
+                [
+                    o_rh.resource.fp_terms is not None
+                    for o_rh in self.object_namelists
+                ]
+            )
             if ordered_processing:
-                logger.info('Input data will be processed chronologicaly.')
+                logger.info("Input data will be processed chronologicaly.")
 
             # IO poll settings
-            self.io_poll_kwargs['nthreads'] = self.maxpollingthreads
+            self.io_poll_kwargs["nthreads"] = self.maxpollingthreads
 
             # Is there already an Initial Condition file ?
             # If so, start the binary...
@@ -779,7 +1097,9 @@ class FullPosServer(IFSParallel):
                 if not self.server_alive():
                     logger.error("Server initialisation failed.")
                     return
-                self._deal_with_promises(outputs_mapping, self._init_poll_and_move)
+                self._deal_with_promises(
+                    outputs_mapping, self._init_poll_and_move
+                )
 
             # Setup the InputMonitor
             all_entries = set()
@@ -787,14 +1107,23 @@ class FullPosServer(IFSParallel):
             cur_term = None
             cur_term_gangs = set()
             prev_term_gangs = set()
-            for istuff, iguesses in zip(self.inputs.tododata, self.inputs.guessdata):
-                iinputs = {_lmonitor.InputMonitorEntry(s) for s in istuff.values()}
-                iinputs |= {_lmonitor.InputMonitorEntry(g.sec) for g in iguesses}
-                iterm = self._actual_term(istuff[self._MODELSIDE_INPUTPREFIX0 +
-                                                 self.inputs.firstprefix].rh)
+            for istuff, iguesses in zip(
+                self.inputs.tododata, self.inputs.guessdata
+            ):
+                iinputs = {
+                    _lmonitor.InputMonitorEntry(s) for s in istuff.values()
+                }
+                iinputs |= {
+                    _lmonitor.InputMonitorEntry(g.sec) for g in iguesses
+                }
+                iterm = self._actual_term(
+                    istuff[
+                        self._MODELSIDE_INPUTPREFIX0 + self.inputs.firstprefix
+                    ].rh
+                )
                 all_entries.update(iinputs)
                 bgang = _lmonitor.BasicGang()
-                bgang.add_member(* iinputs)
+                bgang.add_member(*iinputs)
                 igang = _lmonitor.MetaGang()
                 igang.info = (istuff, iguesses, iterm)
                 igang.add_member(bgang)
@@ -806,13 +1135,16 @@ class FullPosServer(IFSParallel):
                         cur_term_gangs = set()
                     if prev_term_gangs:
                         # Wait for the gangs of the previous terms
-                        igang.add_member(* prev_term_gangs)
+                        igang.add_member(*prev_term_gangs)
                     # Save things up for the next time
                     cur_term_gangs.add(igang)
                     cur_term = iterm
                 metagang.add_member(igang)
-            bm = _lmonitor.ManualInputMonitor(self.context, all_entries,
-                                              caching_freq=self.refreshtime,)
+            bm = _lmonitor.ManualInputMonitor(
+                self.context,
+                all_entries,
+                caching_freq=self.refreshtime,
+            )
 
             # Start the InputMonitor
             tmout = False
@@ -820,52 +1152,76 @@ class FullPosServer(IFSParallel):
             server_stopped = False
             with bm:
                 while not bm.all_done or len(bm.available) > 0:
-
                     # Fetch available inputs and sort them
                     ibatch = list()
                     while metagang.has_collectable():
                         thegang = metagang.pop_collectable()
                         ibatch.append(thegang.info)
-                    ibatch.sort(key=lambda item: item[2])  # Sort according to the term
+                    ibatch.sort(
+                        key=lambda item: item[2]
+                    )  # Sort according to the term
 
                     # Deal with the various available inputs
-                    for (istuff, iguesses, iterm) in ibatch:
-                        sh.highlight("The Fullpos Server is triggered (step={:d})..."
-                                     .format(current_i))
+                    for istuff, iguesses, iterm in ibatch:
+                        sh.highlight(
+                            "The Fullpos Server is triggered (step={:d})...".format(
+                                current_i
+                            )
+                        )
 
                         # Link for the init file (if needed)
                         if current_i == 0 and not self.inputs.inidata:
                             for iprefix, isec in istuff.items():
-                                i_init = '{:s}{:s}INIT'.format(iprefix, self.xpname)
+                                i_init = "{:s}{:s}INIT".format(
+                                    iprefix, self.xpname
+                                )
                                 if not sh.path.exists(i_init):
-                                    sh.cp(isec.rh.container.localpath(), i_init,
-                                          intent='in', fmt=isec.rh.container.actualfmt)
-                                    logger.info('%s copied as %s. For initialisation purposes only.',
-                                                isec.rh.container.localpath(), i_init)
+                                    sh.cp(
+                                        isec.rh.container.localpath(),
+                                        i_init,
+                                        intent="in",
+                                        fmt=isec.rh.container.actualfmt,
+                                    )
+                                    logger.info(
+                                        "%s copied as %s. For initialisation purposes only.",
+                                        isec.rh.container.localpath(),
+                                        i_init,
+                                    )
                             super().execute(rh, opts)
                             # Did the server stopped ?
                             if not self.server_alive():
                                 logger.error("Server initialisation failed.")
                                 return
-                            self._deal_with_promises(outputs_mapping, self._init_poll_and_move)
+                            self._deal_with_promises(
+                                outputs_mapping, self._init_poll_and_move
+                            )
 
                         # Link input files
                         for iprefix, isec in istuff.items():
-                            self._link_input(iprefix, isec.rh, current_i,
-                                             inputs_mapping, outputs_mapping)
+                            self._link_input(
+                                iprefix,
+                                isec.rh,
+                                current_i,
+                                inputs_mapping,
+                                outputs_mapping,
+                            )
                         for iguess in iguesses:
                             self._move_output_guess(iguess, current_i)
 
                         # Let's go...
                         super().execute(rh, opts)
-                        self._deal_with_promises(outputs_mapping, self._poll_and_move)
+                        self._deal_with_promises(
+                            outputs_mapping, self._poll_and_move
+                        )
                         current_i += 1
 
                         # Did the server stopped ?
                         if not self.server_alive():
                             server_stopped = True
                             if not bm.all_done:
-                                logger.error("The server stopped but everything wasn't processed...")
+                                logger.error(
+                                    "The server stopped but everything wasn't processed..."
+                                )
                             break
 
                     if server_stopped:
@@ -880,12 +1236,18 @@ class FullPosServer(IFSParallel):
                         time.sleep(1)
                         bm.health_check(interval=30)
 
-            for failed_file in [e.section.rh.container.localpath()
-                                for e in bm.failed.values()]:
-                logger.error("We were unable to fetch the following file: %s", failed_file)
+            for failed_file in [
+                e.section.rh.container.localpath() for e in bm.failed.values()
+            ]:
+                logger.error(
+                    "We were unable to fetch the following file: %s",
+                    failed_file,
+                )
                 if self.fatal:
-                    self.delayed_exception_add(IOError("Unable to fetch {:s}".format(failed_file)),
-                                               traceback=False)
+                    self.delayed_exception_add(
+                        IOError("Unable to fetch {:s}".format(failed_file)),
+                        traceback=False,
+                    )
 
             if tmout:
                 raise OSError("The waiting loop timed out")
@@ -893,23 +1255,33 @@ class FullPosServer(IFSParallel):
         else:
             # Direct Run !
             self.server_run = False
-            self.system.subtitle('Starting computation with server_run=F')
+            self.system.subtitle("Starting computation with server_run=F")
 
             # Link for the inifile (if needed)
             if not self.inputs.inidata:
                 for iprefix, isec in self.inputs.tododata[0].items():
-                    i_init = '{:s}{:s}INIT'.format(iprefix, self.xpname)
+                    i_init = "{:s}{:s}INIT".format(iprefix, self.xpname)
                     if not sh.path.exists(i_init):
-                        sh.cp(isec.rh.container.localpath(), i_init,
-                              intent='in', fmt=isec.rh.container.actualfmt)
-                        logger.info('%s copied as %s. For initialisation purposes only.',
-                                    isec.rh.container.localpath(), i_init)
+                        sh.cp(
+                            isec.rh.container.localpath(),
+                            i_init,
+                            intent="in",
+                            fmt=isec.rh.container.actualfmt,
+                        )
+                        logger.info(
+                            "%s copied as %s. For initialisation purposes only.",
+                            isec.rh.container.localpath(),
+                            i_init,
+                        )
 
             # Create all links well in advance
-            for i, (iinputs, iguesses) in enumerate(zip(self.inputs.tododata,
-                                                        self.inputs.guessdata)):
+            for i, (iinputs, iguesses) in enumerate(
+                zip(self.inputs.tododata, self.inputs.guessdata)
+            ):
                 for iprefix, isec in iinputs.items():
-                    self._link_input(iprefix, isec.rh, i, inputs_mapping, outputs_mapping)
+                    self._link_input(
+                        iprefix, isec.rh, i, inputs_mapping, outputs_mapping
+                    )
                 for iguess in iguesses:
                     self._move_output_guess(iguess, i)
 
@@ -921,7 +1293,11 @@ class FullPosServer(IFSParallel):
             super().execute(rh, opts)
 
         # Map all outputs to destination (using io_poll)
-        self.io_poll_args = tuple([self._MODELSIDE_OUTPUTPREFIX,
-                                   self._MODELSIDE_OUTPUTPREFIX_GRIB, ])
+        self.io_poll_args = tuple(
+            [
+                self._MODELSIDE_OUTPUTPREFIX,
+                self._MODELSIDE_OUTPUTPREFIX_GRIB,
+            ]
+        )
         self._init_poll_and_move(outputs_mapping)
         self._poll_and_move(outputs_mapping)

--- a/src/vortex/nwp/algo/ifsnaming.py
+++ b/src/vortex/nwp/algo/ifsnaming.py
@@ -38,33 +38,32 @@ __all__ = []
 # Base & Generic classes
 # ##############################################################################
 
+
 class IFSNamingConvention(footprints.FootprintBase):
     """Abstract class for any object representing an IFS/Arpege naming scheme."""
 
     _abstract = True
-    _collector = ('ifsnamingconv', )
+    _collector = ("ifsnamingconv",)
     _footprint = [
         model,
         actualfmt,
         arpifs_cycle,
         dict(
-            attr = dict(
-                kind = dict(
-                    info = 'The type of targeted input/output file'
+            attr=dict(
+                kind=dict(info="The type of targeted input/output file"),
+                conf=dict(
+                    info="IFS/Arpege configuration number",
+                    type=int,
                 ),
-                conf = dict(
-                    info = 'IFS/Arpege configuration number',
-                    type = int,
+                xpname=dict(
+                    info="IFS/Arpege experiment name",
                 ),
-                xpname = dict(
-                    info = 'IFS/Arpege experiment name',
+                actualfmt=dict(
+                    info="The target file format",
+                    optional=True,
                 ),
-                actualfmt = dict(
-                    info = 'The target file format',
-                    optional = True,
-                )
             )
-        )
+        ),
     ]
 
     def _naming_format_string(self, **kwargs):
@@ -72,16 +71,18 @@ class IFSNamingConvention(footprints.FootprintBase):
         raise NotImplementedError()
 
     def __call__(self, **kwargs):
-        return self._naming_format_string(** kwargs).format(xpname=self.xpname,
-                                                            conf=self.conf,
-                                                            fmt=self.actualfmt,
-                                                            model=self.model,
-                                                            ** kwargs)
+        return self._naming_format_string(**kwargs).format(
+            xpname=self.xpname,
+            conf=self.conf,
+            fmt=self.actualfmt,
+            model=self.model,
+            **kwargs,
+        )
 
 
 # Activate the footprint's fasttrack on the ifsnamingconv collector
-ncollect = footprints.collectors.get(tag='ifsnamingconv')
-ncollect.fasttrack = ('kind', )
+ncollect = footprints.collectors.get(tag="ifsnamingconv")
+ncollect.fasttrack = ("kind",)
 del ncollect
 
 
@@ -92,12 +93,10 @@ class IFSHardWiredNamingConvention(IFSNamingConvention):
     """
 
     _footprint = dict(
-        attr = dict(
-            namingformat = dict()
+        attr=dict(namingformat=dict()),
+        priority=dict(
+            level=footprints.priorities.top.TOOLBOX  # @UndefinedVariable
         ),
-        priority = dict(
-            level = footprints.priorities.top.TOOLBOX  # @UndefinedVariable
-        )
     )
 
     def _naming_format_string(self, **kwargs):
@@ -107,203 +106,245 @@ class IFSHardWiredNamingConvention(IFSNamingConvention):
 # Climatology files names
 # ##############################################################################
 
+
 class ModelClimName(IFSNamingConvention):
     """An IFS/Arpege model clim."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['modelclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "modelclim",
+                ],
             ),
-            conf = dict(
-                outcast = [701, ],
+            conf=dict(
+                outcast=[
+                    701,
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'Const.Clim'
+        return "Const.Clim"
 
 
 class SurfexClimName(IFSNamingConvention):
     """A Surfex model clim."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['modelclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "modelclim",
+                ],
             ),
-            model = dict(
-                values = ['surfex', ]
-            )
+            model=dict(
+                values=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'Const.Clim.sfx'
+        return "Const.Clim.sfx"
 
 
 class TargetClimName(IFSNamingConvention):
     """A BDAP clim file or a target domain IFS/Arpege clim file."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['targetclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "targetclim",
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'const.clim.{area:s}'
+        return "const.clim.{area:s}"
 
 
 class SurfexTargetClimName(IFSNamingConvention):
     """A target domain Surfex clim file."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['targetclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "targetclim",
+                ],
             ),
-            model = dict(
-                values = ['surfex', ]
-            )
+            model=dict(
+                values=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'const.clim.sfx.{area:s}'
+        return "const.clim.sfx.{area:s}"
 
 
 class CanariModelClimName(IFSNamingConvention):
     """An IFS/Arpege model clim (specific naming for Canari)."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['modelclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "modelclim",
+                ],
             ),
-            conf = dict(
-                values = [701, ],
+            conf=dict(
+                values=[
+                    701,
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICMSH{xpname:s}CLIM'
+        return "ICMSH{xpname:s}CLIM"
 
 
 class CanariClosestModelClimName(CanariModelClimName):
     """An IFS/Arpege model clim for the closest month (specific naming for Canari)."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['closest_modelclim', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "closest_modelclim",
+                ],
             ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICMSH{xpname:s}CLI2'
+        return "ICMSH{xpname:s}CLI2"
 
 
 # Initial conditions file names
 # ##############################################################################
 
-class InitialContionsName(IFSNamingConvention):
 
+class InitialContionsName(IFSNamingConvention):
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['ic', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ic",
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICMSH{xpname:s}INIT'
+        return "ICMSH{xpname:s}INIT"
 
 
 class SurfexInitialContionsName(IFSNamingConvention):
-
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['ic', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ic",
+                ],
             ),
-            model = dict(
-                values = ['surfex', ]
-            )
+            model=dict(
+                values=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICMSH{xpname:s}INIT.sfx'
+        return "ICMSH{xpname:s}INIT.sfx"
 
 
 class IauAnalysisName(IFSNamingConvention):
-
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['iau_analysis', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "iau_analysis",
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICIAU{xpname:s}IN{number:02d}'
+        return "ICIAU{xpname:s}IN{number:02d}"
 
 
 class IauBackgroundName(IFSNamingConvention):
-
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['iau_background', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "iau_background",
+                ],
             ),
-            model = dict(
-                outcast = ['surfex', ]
-            )
+            model=dict(
+                outcast=[
+                    "surfex",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICIAU{xpname:s}BK{number:02d}'
+        return "ICIAU{xpname:s}BK{number:02d}"
 
 
 # Lateral Boundary Conditions Files
 # ##############################################################################
 
-class LAMBoundaryConditionsName(IFSNamingConvention):
 
+class LAMBoundaryConditionsName(IFSNamingConvention):
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['lbc', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "lbc",
+                ],
             ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ELSCF{xpname:s}ALBC{number:03d}'
+        return "ELSCF{xpname:s}ALBC{number:03d}"
 
 
 # Strange files used in the EDA
@@ -311,20 +352,26 @@ class LAMBoundaryConditionsName(IFSNamingConvention):
 
 
 class IfsEdaInputName(IFSNamingConvention):
-
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['edainput', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "edainput",
+                ],
             ),
-            variant = dict(
-                values = ['infl', 'infl_factor', 'mean', 'covb', ],
+            variant=dict(
+                values=[
+                    "infl",
+                    "infl_factor",
+                    "mean",
+                    "covb",
+                ],
             ),
-            totalnumber = dict(
-                info = 'The total number of input files',
-                type = int,
-                optional = True,
+            totalnumber=dict(
+                info="The total number of input files",
+                type=int,
+                optional=True,
             ),
         )
     )
@@ -335,69 +382,82 @@ class IfsEdaInputName(IFSNamingConvention):
             ndigits = max(int(math.floor(math.log10(self.totalnumber))) + 1, 3)
         else:
             ndigits = 3
-        return '{number:0' + str(ndigits) + 'd}'
+        return "{number:0" + str(ndigits) + "d}"
 
 
 class IfsEdaArpegeFaInputName(IfsEdaInputName):
-
     _footprint = dict(
-        attr = dict(
-            model = dict(
-                values = ['arpege', ]
+        attr=dict(
+            model=dict(
+                values=[
+                    "arpege",
+                ]
             ),
-            actualfmt = dict(
-                values = ['fa', ]
-            )
+            actualfmt=dict(
+                values=[
+                    "fa",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'FAMEMBER_' + self._number_fmt
+        return "FAMEMBER_" + self._number_fmt
 
 
 class IfsEdaArpegeGribInputName(IfsEdaInputName):
-
     _footprint = dict(
-        attr = dict(
-            model = dict(
-                values = ['arpege', ]
+        attr=dict(
+            model=dict(
+                values=[
+                    "arpege",
+                ]
             ),
-            actualfmt = dict(
-                values = ['grib', ]
-            )
+            actualfmt=dict(
+                values=[
+                    "grib",
+                ]
+            ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'GRIBERm' + self._number_fmt
+        return "GRIBERm" + self._number_fmt
 
 
 class IfsEdaAromeInputName(IfsEdaInputName):
-
     _footprint = dict(
-        attr = dict(
-            model = dict(
-                values = ['arome', ]
+        attr=dict(
+            model=dict(
+                values=[
+                    "arome",
+                ]
             ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ELSCF{xpname:s}ALBC' + self._number_fmt
+        return "ELSCF{xpname:s}ALBC" + self._number_fmt
 
 
 class IfsEdaOutputName(IFSNamingConvention):
-
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['edaoutput', ],
+        attr=dict(
+            kind=dict(
+                values=[
+                    "edaoutput",
+                ],
             ),
-            variant = dict(
-                values = ['infl', 'infl_factor', 'mean', 'covb', ],
+            variant=dict(
+                values=[
+                    "infl",
+                    "infl_factor",
+                    "mean",
+                    "covb",
+                ],
             ),
         )
     )
 
     def _naming_format_string(self, **kwargs):
-        return 'ICMSH{xpname:s}+{term.fmth}_m{number:03d}'
+        return "ICMSH{xpname:s}+{term.fmth}_m{number:03d}"

--- a/src/vortex/nwp/algo/ifsroot.py
+++ b/src/vortex/nwp/algo/ifsroot.py
@@ -13,7 +13,9 @@ from vortex.algo.components import (
 from vortex.syntax.stdattrs import model
 from vortex.tools import grib
 
-from . import ifsnaming  # @UnusedImport
+# footprints import
+from . import ifsnaming as ifsnaming
+
 from ..syntax.stdattrs import algo_member
 from ..tools import satrad, drhook
 

--- a/src/vortex/nwp/algo/ifsroot.py
+++ b/src/vortex/nwp/algo/ifsroot.py
@@ -5,7 +5,11 @@ Abstract base class for any AlgoComponent leveraging the Arpege/IFS code.
 from bronx.fancies import loggers
 import footprints
 
-from vortex.algo.components import Parallel, ParallelIoServerMixin, AlgoComponentError
+from vortex.algo.components import (
+    Parallel,
+    ParallelIoServerMixin,
+    AlgoComponentError,
+)
 from vortex.syntax.stdattrs import model
 from vortex.tools import grib
 
@@ -19,105 +23,122 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-class IFSParallel(Parallel, ParallelIoServerMixin,
-                  satrad.SatRadDecoMixin, drhook.DrHookDecoMixin, grib.EcGribDecoMixin):
+class IFSParallel(
+    Parallel,
+    ParallelIoServerMixin,
+    satrad.SatRadDecoMixin,
+    drhook.DrHookDecoMixin,
+    grib.EcGribDecoMixin,
+):
     """Abstract IFSModel parallel algo components."""
 
     _abstract = True
     _footprint = [
-        model, algo_member,
+        model,
+        algo_member,
         dict(
-            info = 'Abstract AlgoComponent for anything based on Arpege/IFS.',
-            attr = dict(
-                kind = dict(
-                    info            = 'The kind of processing we want the Arpege/IFS binary to perform.',
-                    default         = 'ifsrun',
-                    doc_zorder      = 90,
+            info="Abstract AlgoComponent for anything based on Arpege/IFS.",
+            attr=dict(
+                kind=dict(
+                    info="The kind of processing we want the Arpege/IFS binary to perform.",
+                    default="ifsrun",
+                    doc_zorder=90,
                 ),
-                model = dict(
-                    values  = ['arpege', 'arp', 'arp_court', 'aladin', 'ald',
-                               'arome', 'aro', 'aearp', 'pearp', 'ifs', 'alaro', 'harmoniearome']
+                model=dict(
+                    values=[
+                        "arpege",
+                        "arp",
+                        "arp_court",
+                        "aladin",
+                        "ald",
+                        "arome",
+                        "aro",
+                        "aearp",
+                        "pearp",
+                        "ifs",
+                        "alaro",
+                        "harmoniearome",
+                    ]
                 ),
-                ioname = dict(
-                    default = 'nwpioserv',
+                ioname=dict(
+                    default="nwpioserv",
                 ),
-                binarysingle = dict(
-                    default = 'basicnwp',
+                binarysingle=dict(
+                    default="basicnwp",
                 ),
-                conf = dict(
-                    info = 'The configuration number given to Arpege/IFS.',
-                    type            = int,
-                    optional        = True,
-                    default         = 1,
-                    doc_visibility  = footprints.doc.visibility.ADVANCED,
+                conf=dict(
+                    info="The configuration number given to Arpege/IFS.",
+                    type=int,
+                    optional=True,
+                    default=1,
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
                 ),
-                timescheme = dict(
-                    info = 'The timescheme that will be used by Arpege/IFS model.',
-                    optional        = True,
-                    default         = 'sli',
-                    values          = ['eul', 'eulerian', 'sli', 'semilag'],
-                    remap           = dict(
-                        eulerian = 'eul',
-                        semilag  = 'sli'
+                timescheme=dict(
+                    info="The timescheme that will be used by Arpege/IFS model.",
+                    optional=True,
+                    default="sli",
+                    values=["eul", "eulerian", "sli", "semilag"],
+                    remap=dict(eulerian="eul", semilag="sli"),
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
+                ),
+                timestep=dict(
+                    info="The timestep of the Arpege/IFS model.",
+                    type=float,
+                    optional=True,
+                    default=600.0,
+                ),
+                fcterm=dict(
+                    info="The forecast term of the Arpege/IFS model.",
+                    type=int,
+                    optional=True,
+                    default=0,
+                ),
+                fcunit=dict(
+                    info="The unit used in the *fcterm* attribute.",
+                    optional=True,
+                    default="h",
+                    values=["h", "hour", "t", "step", "timestep"],
+                    remap=dict(
+                        hour="h",
+                        step="t",
+                        timestep="t",
                     ),
-                    doc_visibility  = footprints.doc.visibility.ADVANCED,
                 ),
-                timestep = dict(
-                    info     = 'The timestep of the Arpege/IFS model.',
-                    type     = float,
-                    optional = True,
-                    default  = 600.,
+                xpname=dict(
+                    info="The default labelling of files used in Arpege/IFS model.",
+                    optional=True,
+                    default="XPVT",
+                    doc_visibility=footprints.doc.visibility.ADVANCED,
                 ),
-                fcterm = dict(
-                    info     = 'The forecast term of the Arpege/IFS model.',
-                    type     = int,
-                    optional = True,
-                    default  = 0,
-                ),
-                fcunit = dict(
-                    info     = 'The unit used in the *fcterm* attribute.',
-                    optional = True,
-                    default  = 'h',
-                    values   = ['h', 'hour', 't', 'step', 'timestep'],
-                    remap = dict(
-                        hour = 'h',
-                        step = 't',
-                        timestep = 't',
-                    )
-                ),
-                xpname = dict(
-                    info = 'The default labelling of files used in Arpege/IFS model.',
-                    optional        = True,
-                    default         = 'XPVT',
-                    doc_visibility  = footprints.doc.visibility.ADVANCED,
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     def fstag(self):
         """Extend default tag with ``kind`` value."""
-        return super().fstag() + '.' + self.kind
+        return super().fstag() + "." + self.kind
 
     def valid_executable(self, rh):
         """Be sure that the specifed executable is ifsmodel compatible."""
         valid = super().valid_executable(rh)
         try:
-            return valid and bool(rh.resource.realkind == 'ifsmodel')
+            return valid and bool(rh.resource.realkind == "ifsmodel")
         except (ValueError, TypeError):
             return False
 
     def spawn_hook(self):
         """Usually a good habit to dump the fort.4 namelist."""
         super().spawn_hook()
-        if self.system.path.exists('fort.4'):
-            self.system.subtitle('{:s} : dump namelist <fort.4>'.format(self.realkind))
-            self.system.cat('fort.4', output=False)
+        if self.system.path.exists("fort.4"):
+            self.system.subtitle(
+                "{:s} : dump namelist <fort.4>".format(self.realkind)
+            )
+            self.system.cat("fort.4", output=False)
 
     def spawn_command_options(self):
         """Dictionary provided for command line factory."""
         return dict(
-            name=(self.xpname + 'xxxx')[:4].upper(),
+            name=(self.xpname + "xxxx")[:4].upper(),
             conf=self.conf,
             timescheme=self.timescheme,
             timestep=self.timestep,
@@ -133,19 +154,18 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
         :param actualfmt: The format of the target file.
         :param dict kwargs: Any argument you may see fit.
         """
-        nc_args = dict(model=self.model,
-                       conf=self.conf,
-                       xpname=self.xpname)
+        nc_args = dict(model=self.model, conf=self.conf, xpname=self.xpname)
         nc_args.update(kwargs)
-        nc = footprints.proxy.ifsnamingconv(kind=kind,
-                                            actualfmt=actualfmt,
-                                            cycle=rh.resource.cycle,
-                                            **nc_args)
+        nc = footprints.proxy.ifsnamingconv(
+            kind=kind, actualfmt=actualfmt, cycle=rh.resource.cycle, **nc_args
+        )
         if nc is None:
             raise AlgoComponentError("No IFSNamingConvention was found.")
         return nc
 
-    def do_climfile_fixer(self, rh, convkind, actualfmt=None, geo=None, **kwargs):
+    def do_climfile_fixer(
+        self, rh, convkind, actualfmt=None, geo=None, **kwargs
+    ):
         """Is it necessary to fix the climatology file ? (i.e link in the appropriate file).
 
         :param rh: The binary's ResourceHandler.
@@ -155,16 +175,27 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
         :param dict kwargs: Any argument you may see fit (used to create and call
                             the IFSNamingConvention object.
         """
-        nc = self.naming_convention(kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs)
+        nc = self.naming_convention(
+            kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs
+        )
         nc_args = dict()
         if geo:
-            nc_args['area'] = geo.area
+            nc_args["area"] = geo.area
         nc_args.update(kwargs)
-        return not self.system.path.exists(nc(** nc_args))
+        return not self.system.path.exists(nc(**nc_args))
 
-    def climfile_fixer(self, rh, convkind,
-                       month, geo=None, notgeo=None, actualfmt=None,
-                       inputrole=None, inputkind=None, **kwargs):
+    def climfile_fixer(
+        self,
+        rh,
+        convkind,
+        month,
+        geo=None,
+        notgeo=None,
+        actualfmt=None,
+        inputrole=None,
+        inputkind=None,
+        **kwargs,
+    ):
         """Fix the climatology files (by choosing the appropriate month, geometry, ...)
 
         :param rh: The binary's ResourceHandler.
@@ -179,19 +210,25 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
                             the IFSNamingConvention object).
         """
         if geo is not None and notgeo is not None:
-            raise ValueError('*geo* and *notgeo* cannot be provided together.')
+            raise ValueError("*geo* and *notgeo* cannot be provided together.")
 
         def check_month(actualrh):
-            return bool(hasattr(actualrh.resource, 'month') and
-                        actualrh.resource.month == month)
+            return bool(
+                hasattr(actualrh.resource, "month")
+                and actualrh.resource.month == month
+            )
 
         def check_month_and_geo(actualrh):
-            return (check_month(actualrh) and
-                    actualrh.resource.geometry.tag == geo.tag)
+            return (
+                check_month(actualrh)
+                and actualrh.resource.geometry.tag == geo.tag
+            )
 
         def check_month_and_notgeo(actualrh):
-            return (check_month(actualrh) and
-                    actualrh.resource.geometry.tag != notgeo.tag)
+            return (
+                check_month(actualrh)
+                and actualrh.resource.geometry.tag != notgeo.tag
+            )
 
         if geo:
             checker = check_month_and_geo
@@ -200,23 +237,41 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
         else:
             checker = check_month
 
-        nc = self.naming_convention(kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs)
+        nc = self.naming_convention(
+            kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs
+        )
         nc_args = dict()
         if geo:
-            nc_args['area'] = geo.area
+            nc_args["area"] = geo.area
         nc_args.update(kwargs)
-        target_name = nc(** nc_args)
+        target_name = nc(**nc_args)
 
         self.system.remove(target_name)
 
-        logger.info("Linking in the %s file (%s) for month %s.", convkind, target_name, month)
-        rc = self.setlink(initrole=inputrole, initkind=inputkind, inittest=checker,
-                          initname=target_name)
+        logger.info(
+            "Linking in the %s file (%s) for month %s.",
+            convkind,
+            target_name,
+            month,
+        )
+        rc = self.setlink(
+            initrole=inputrole,
+            initkind=inputkind,
+            inittest=checker,
+            initname=target_name,
+        )
         return target_name if rc else None
 
-    def all_localclim_fixer(self, rh, month, convkind='targetclim', actualfmt=None,
-                            inputrole=('LocalClim', 'TargetClim', 'BDAPClim'),
-                            inputkind='clim_bdap', **kwargs):
+    def all_localclim_fixer(
+        self,
+        rh,
+        month,
+        convkind="targetclim",
+        actualfmt=None,
+        inputrole=("LocalClim", "TargetClim", "BDAPClim"),
+        inputkind="clim_bdap",
+        **kwargs,
+    ):
         """Fix all the local/BDAP climatology files (by choosing the appropriate month)
 
         :param rh: The binary's ResourceHandler.
@@ -231,19 +286,33 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
         """
 
         def check_month(actualrh):
-            return bool(hasattr(actualrh.resource, 'month') and
-                        actualrh.resource.month == month)
+            return bool(
+                hasattr(actualrh.resource, "month")
+                and actualrh.resource.month == month
+            )
 
-        nc = self.naming_convention(kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs)
+        nc = self.naming_convention(
+            kind=convkind, rh=rh, actualfmt=actualfmt, **kwargs
+        )
         dealtwith = list()
 
-        for tclimrh in [x.rh for x in self.context.sequence.effective_inputs(
-                role=inputrole, kind=inputkind,
-        ) if x.rh.resource.month == month]:
+        for tclimrh in [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role=inputrole,
+                kind=inputkind,
+            )
+            if x.rh.resource.month == month
+        ]:
             thisclim = tclimrh.container.localpath()
             thisname = nc(area=tclimrh.resource.geometry.area)
             if thisclim != thisname:
-                logger.info("Linking in the %s to %s for month %s.", thisclim, thisname, month)
+                logger.info(
+                    "Linking in the %s to %s for month %s.",
+                    thisclim,
+                    thisname,
+                    month,
+                )
                 self.system.symlink(thisclim, thisname)
                 dealtwith.append(thisname)
 
@@ -251,13 +320,17 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
 
     def find_namelists(self, opts=None):
         """Find any namelists candidates in actual context inputs."""
-        return [x.rh
-                for x in self.context.sequence.effective_inputs(kind=('namelist', 'namelistfp'))]
+        return [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                kind=("namelist", "namelistfp")
+            )
+        ]
 
     def _set_nam_macro(self, namcontents, namlocal, macro, value):
         """Set a namelist macro and log it!"""
         namcontents.setmacro(macro, value)
-        logger.info('Setup macro %s=%s in %s', macro, str(value), namlocal)
+        logger.info("Setup macro %s=%s in %s", macro, str(value), namlocal)
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         """Apply a namelist delta depending on the cycle of the binary."""
@@ -268,34 +341,47 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
         nam_updated = False
         # For cy41 onward, replace some namelist macros with the command line
         # arguments
-        if rh.resource.cycle >= 'cy41':
-            if 'NAMARG' in namcontents:
+        if rh.resource.cycle >= "cy41":
+            if "NAMARG" in namcontents:
                 opts_arg = self.spawn_command_options()
-                self._set_nam_macro(namcontents, namlocal, 'CEXP', opts_arg['name'])
-                self._set_nam_macro(namcontents, namlocal, 'TIMESTEP', opts_arg['timestep'])
-                fcstop = '{:s}{:d}'.format(opts_arg['fcunit'], opts_arg['fcterm'])
-                self._set_nam_macro(namcontents, namlocal, 'FCSTOP', fcstop)
+                self._set_nam_macro(
+                    namcontents, namlocal, "CEXP", opts_arg["name"]
+                )
+                self._set_nam_macro(
+                    namcontents, namlocal, "TIMESTEP", opts_arg["timestep"]
+                )
+                fcstop = "{:s}{:d}".format(
+                    opts_arg["fcunit"], opts_arg["fcterm"]
+                )
+                self._set_nam_macro(namcontents, namlocal, "FCSTOP", fcstop)
                 nam_updated = True
             else:
-                logger.info('No NAMARG block in %s', namlocal)
+                logger.info("No NAMARG block in %s", namlocal)
 
         if self.member is not None:
-            for macro_name in ('MEMBER', 'PERTURB'):
-                self._set_nam_macro(namcontents, namlocal, macro_name, self.member)
+            for macro_name in ("MEMBER", "PERTURB"):
+                self._set_nam_macro(
+                    namcontents, namlocal, macro_name, self.member
+                )
             nam_updated = True
         return nam_updated
 
     def prepare_namelists(self, rh, opts=None):
         """Update each of the namelists."""
         namcandidates = self.find_namelists(opts)
-        self.system.subtitle('Namelist candidates')
+        self.system.subtitle("Namelist candidates")
         for nam in namcandidates:
             nam.quickview()
         for namrh in namcandidates:
             namc = namrh.contents
-            if self.prepare_namelist_delta(rh, namc, namrh.container.actualpath()):
+            if self.prepare_namelist_delta(
+                rh, namc, namrh.container.actualpath()
+            ):
                 if namc.dumps_needs_update:
-                    logger.info('Rewritting the %s namelists file.', namrh.container.actualpath())
+                    logger.info(
+                        "Rewritting the %s namelists file.",
+                        namrh.container.actualpath(),
+                    )
                     namc.rewrite(namrh.container)
 
     def prepare(self, rh, opts):
@@ -306,6 +392,6 @@ class IFSParallel(Parallel, ParallelIoServerMixin,
 
     def execute_single(self, rh, opts):
         """Standard IFS-Like execution parallel execution."""
-        if rh.resource.cycle < 'cy46':
-            self.system.ls(output='dirlst')
+        if rh.resource.cycle < "cy46":
+            self.system.ls(output="dirlst")
         super().execute_single(rh, opts)

--- a/src/vortex/nwp/algo/monitoring.py
+++ b/src/vortex/nwp/algo/monitoring.py
@@ -14,43 +14,45 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
+class OdbMonitoring(
+    Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin
+):
     """Compute monitoring statistics."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['monitoring'],
+        attr=dict(
+            kind=dict(
+                values=["monitoring"],
             ),
-            npool = dict(
-                default = 1,
-                optional = True,
+            npool=dict(
+                default=1,
+                optional=True,
             ),
-            obs = dict(
-                values = ['all', 'used'],
+            obs=dict(
+                values=["all", "used"],
             ),
-            date = a_date,
-            model= a_model,
-            cutoff = a_cutoff,
-            start = dict(
-                type  = bool,
-                default = False,
-                optional = True,
+            date=a_date,
+            model=a_model,
+            cutoff=a_cutoff,
+            start=dict(
+                type=bool,
+                default=False,
+                optional=True,
             ),
-            cumul = dict(
-                type = bool,
-                default = True,
-                optional = True,
+            cumul=dict(
+                type=bool,
+                default=True,
+                optional=True,
             ),
-            extend = dict(
-                type = bool,
-                default = False,
-                optional = True,
+            extend=dict(
+                type=bool,
+                default=False,
+                optional=True,
             ),
-            stage = dict(
-                values = ['can', 'surf', 'surface', 'atm', 'atmospheric'],
-                remap = dict(can='surf', surface='surf', atmospheric='atm'),
-                info = 'The processing stage of the ODB base.',
+            stage=dict(
+                values=["can", "surf", "surface", "atm", "atmospheric"],
+                remap=dict(can="surf", surface="surf", atmospheric="atm"),
+                info="The processing stage of the ODB base.",
             ),
         )
     )
@@ -58,7 +60,12 @@ class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin)
     def _fix_nam_macro(self, rh, macro, value):
         """Set a given namelist macro and issue a log message."""
         rh.contents.setmacro(macro, value)
-        logger.info('Setup %s macro to %s in %s', macro, value, rh.container.actualpath())
+        logger.info(
+            "Setup %s macro to %s in %s",
+            macro,
+            value,
+            rh.container.actualpath(),
+        )
 
     def prepare(self, rh, opts):
         """Update some variables in the namelist and check the presence of the accumulated statistics file."""
@@ -69,31 +76,42 @@ class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin)
 
         # Virtual upper-air observations database
         obsatm_virt = [
-            x for x in self.lookupodb(fatal=False)
-            if (x.rh.resource.stage.startswith('matchup') or
-                x.rh.resource.stage.startswith('screening')) and x.rh.resource.part == 'virtual'
+            x
+            for x in self.lookupodb(fatal=False)
+            if (
+                x.rh.resource.stage.startswith("matchup")
+                or x.rh.resource.stage.startswith("screening")
+            )
+            and x.rh.resource.part == "virtual"
         ]
 
         # Single upper-air observations database
         obsatm_single = [
-            x for x in self.lookupodb(fatal=False)
-            if x.rh.resource.stage.startswith('matchup') or x.rh.resource.stage.startswith('screening')
+            x
+            for x in self.lookupodb(fatal=False)
+            if x.rh.resource.stage.startswith("matchup")
+            or x.rh.resource.stage.startswith("screening")
         ]
         if len(obsatm_single) > 1:
             obsatm_single = []
 
         # Surface observations database
         obssurf = [
-            x for x in self.lookupodb(fatal=False)
-            if x.rh.resource.stage.startswith('canari') and (x.rh.resource.part == 'surf' or
-                                                             x.rh.resource.part == 'ground')
+            x
+            for x in self.lookupodb(fatal=False)
+            if x.rh.resource.stage.startswith("canari")
+            and (
+                x.rh.resource.part == "surf" or x.rh.resource.part == "ground"
+            )
         ]
 
         # One database at a time
-        if not (obsatm_virt or obsatm_single) and self.stage == 'atm':
-            raise ValueError('Could not find any ODB matchup or screening ECMA database')
-        if not obssurf and self.stage == 'surf':
-            raise ValueError('Could not find any ODB surface ECMA database')
+        if not (obsatm_virt or obsatm_single) and self.stage == "atm":
+            raise ValueError(
+                "Could not find any ODB matchup or screening ECMA database"
+            )
+        if not obssurf and self.stage == "surf":
+            raise ValueError("Could not find any ODB surface ECMA database")
 
         # Set actual ODB paths
         if obsatm_virt:
@@ -104,8 +122,12 @@ class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin)
             ecma = obssurf.pop(0)
         ecma_path = sh.path.abspath(ecma.rh.container.localpath())
         self.odb.fix_db_path(ecma.rh.resource.layout, ecma_path)
-        self.env.IOASSIGN = sh.path.join(ecma_path, 'IOASSIGN')
-        logger.info('Setting ODB env %s = %s.', 'IOASSIGN', sh.path.join(ecma_path, 'IOASSIGN'))
+        self.env.IOASSIGN = sh.path.join(ecma_path, "IOASSIGN")
+        logger.info(
+            "Setting ODB env %s = %s.",
+            "IOASSIGN",
+            sh.path.join(ecma_path, "IOASSIGN"),
+        )
 
         # Let ancestors handling most of the env setting
         super().prepare(rh, opts)
@@ -113,69 +135,103 @@ class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin)
         # Force to start a new accumulated statistics file if first day and first hour of the month
         mnt_start = self.start
 
-        if not mnt_start and int(self.date.day) == 1 and int(self.date.hh) == 0 and not self.extend:
-            logger.info('First day and first hour of the month : force start attribute to True.')
+        if (
+            not mnt_start
+            and int(self.date.day) == 1
+            and int(self.date.hh) == 0
+            and not self.extend
+        ):
+            logger.info(
+                "First day and first hour of the month : force start attribute to True."
+            )
             mnt_start = True
 
         mnt_cumul = self.cumul
-        if self.cutoff == 'production':
+        if self.cutoff == "production":
             mnt_cumul = False
-            logger.info('No output accumulated statistics file will be produced because '
-                        'cutoff = production : force cumul to False')
+            logger.info(
+                "No output accumulated statistics file will be produced because "
+                "cutoff = production : force cumul to False"
+            )
 
         # Monitoring namelist
         namrh = self.context.sequence.effective_inputs(
-            role='Namelist',
-            kind='namelist',)
+            role="Namelist",
+            kind="namelist",
+        )
         if len(namrh) != 1:
-            logger.critical('There must be exactly one namelist for monitoring. Stop.')
-            raise ValueError('There must be exactly one namelist for monitoring. Stop.')
+            logger.critical(
+                "There must be exactly one namelist for monitoring. Stop."
+            )
+            raise ValueError(
+                "There must be exactly one namelist for monitoring. Stop."
+            )
         namrh = namrh[0].rh
 
         # Cumulated statistics file
         cumulrh = self.context.sequence.effective_inputs(
-            role='Cumulated monitoring statistics',
-            kind='accumulated_stats',
+            role="Cumulated monitoring statistics",
+            kind="accumulated_stats",
         )
 
         if len(cumulrh) > 1:
-            logger.critical('There must be at most one accumulated statistics file.Stop.')
-            raise ValueError('There must be one accumulated statistics file or none.Stop.')
+            logger.critical(
+                "There must be at most one accumulated statistics file.Stop."
+            )
+            raise ValueError(
+                "There must be one accumulated statistics file or none.Stop."
+            )
         else:
             if len(cumulrh) == 0:
                 if not mnt_start:
                     if mnt_cumul:
-                        logger.critical('There must be one input accumulated statistics file. Stop.')
-                        raise ValueError('There must be one input accumulated statistics file. Stop.')
+                        logger.critical(
+                            "There must be one input accumulated statistics file. Stop."
+                        )
+                        raise ValueError(
+                            "There must be one input accumulated statistics file. Stop."
+                        )
                     else:
-                        logger.info('No input accumulated statistics file is necessary.')
-                        logger.info('No output accumulated statistics file will be produced.')
+                        logger.info(
+                            "No input accumulated statistics file is necessary."
+                        )
+                        logger.info(
+                            "No output accumulated statistics file will be produced."
+                        )
                 else:
                     if mnt_cumul:
-                        logger.info('No input accumulated statistics file. It will be created by the binary.')
+                        logger.info(
+                            "No input accumulated statistics file. It will be created by the binary."
+                        )
                     else:
-                        logger.info('No output accumulated statistics file will be produced.')
+                        logger.info(
+                            "No output accumulated statistics file will be produced."
+                        )
             else:
                 cumulrh = cumulrh[0].rh
                 if not mnt_cumul:
-                    logger.info('No input accumulated statistics file is necessary(start=False).')
+                    logger.info(
+                        "No input accumulated statistics file is necessary(start=False)."
+                    )
                     cumulrh.container.clear()
                 else:
                     if mnt_start:
-                        logger.info('No input accumulated statistics file is necessary (start=True)')
+                        logger.info(
+                            "No input accumulated statistics file is necessary (start=True)"
+                        )
                         cumulrh.container.clear()
 
-        self._fix_nam_macro(namrh, 'JOUR', int(self.date.ymd))
-        self._fix_nam_macro(namrh, 'RES', int(self.date.hh))
+        self._fix_nam_macro(namrh, "JOUR", int(self.date.ymd))
+        self._fix_nam_macro(namrh, "RES", int(self.date.hh))
 
-        self._fix_nam_macro(namrh, 'LLADMON', mnt_cumul)
-        self._fix_nam_macro(namrh, 'LLADAJ', mnt_cumul and not mnt_start)
+        self._fix_nam_macro(namrh, "LLADMON", mnt_cumul)
+        self._fix_nam_macro(namrh, "LLADAJ", mnt_cumul and not mnt_start)
 
-        self._fix_nam_macro(namrh, 'LLFLAG', self.obs != 'all')
+        self._fix_nam_macro(namrh, "LLFLAG", self.obs != "all")
 
-        self._fix_nam_macro(namrh, 'LLARO', self.model == 'arome')
-        self._fix_nam_macro(namrh, 'LLVRP', self.model == 'varpack')
-        self._fix_nam_macro(namrh, 'LLCAN', self.stage == 'surf')
+        self._fix_nam_macro(namrh, "LLARO", self.model == "arome")
+        self._fix_nam_macro(namrh, "LLVRP", self.model == "varpack")
+        self._fix_nam_macro(namrh, "LLCAN", self.stage == "surf")
 
         if namrh.contents.dumps_needs_update:
             namrh.contents.rewrite(namrh.container)
@@ -189,13 +245,13 @@ class OdbMonitoring(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin)
         allfiles = sh.ls()
         for f in allfiles:
             if self.system.path.getsize(f) == 0:
-                logger.info('Remove %s because size of %s is zero.', f, f)
+                logger.info("Remove %s because size of %s is zero.", f, f)
                 sh.remove(f)
 
-        obspoint_out = sh.ls('point.*')
+        obspoint_out = sh.ls("point.*")
         if obspoint_out:
-            dest = 'obslocationpack'
-            logger.info('Creating an OBSLOCATION pack: %s', dest)
+            dest = "obslocationpack"
+            logger.info("Creating an OBSLOCATION pack: %s", dest)
             sh.mkdir(dest)
             for fname in obspoint_out:
                 sh.mv(fname, dest)

--- a/src/vortex/nwp/algo/mpitools.py
+++ b/src/vortex/nwp/algo/mpitools.py
@@ -25,93 +25,114 @@ class MpiAuto(mpitools.MpiTool):
     """MpiTools that uses mpiauto as a proxy to several MPI implementations"""
 
     _footprint = dict(
-        attr = dict(
-            mpiname = dict(
-                values = ['mpiauto', ],
+        attr=dict(
+            mpiname=dict(
+                values=[
+                    "mpiauto",
+                ],
             ),
-            mpiopts = dict(
-                default = None
+            mpiopts=dict(default=None),
+            optprefix=dict(default="--"),
+            optmap=dict(
+                default=footprints.FPDict(
+                    nn="nn",
+                    nnp="nnp",
+                    openmp="openmp",
+                    np="np",
+                    prefixcommand="prefix-command",
+                    allowodddist="mpi-allow-odd-dist",
+                )
             ),
-            optprefix = dict(
-                default = '--'
+            timeoutrestart=dict(
+                info="The number of attempts made by mpiauto",
+                optional=True,
+                default=DelayedEnvValue("MPI_INIT_TIMEOUT_RESTART", 2),
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-            optmap = dict(
-                default  = footprints.FPDict(nn='nn', nnp='nnp', openmp='openmp',
-                                             np='np', prefixcommand='prefix-command',
-                                             allowodddist='mpi-allow-odd-dist')
+            sublauncher=dict(
+                info="How to actualy launch the MPI program",
+                values=["srun", "libspecific"],
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
-            timeoutrestart = dict(
-                info            = 'The number of attempts made by mpiauto',
-                optional        = True,
-                default         = DelayedEnvValue('MPI_INIT_TIMEOUT_RESTART', 2),
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            mpiwrapstd=dict(
+                values=[
+                    False,
+                ],
             ),
-            sublauncher = dict(
-                info            = 'How to actualy launch the MPI program',
-                values          = ['srun', 'libspecific'],
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
-            ),
-            mpiwrapstd = dict(
-                values          = [False, ],
-            ),
-            bindingmethod = dict(
-                info            = 'How to bind the MPI processes',
-                values          = ['arch', 'launcherspecific', 'vortex'],
-                optional        = True,
-                doc_visibility  = footprints.doc.visibility.ADVANCED,
-                doc_zorder      = -90,
+            bindingmethod=dict(
+                info="How to bind the MPI processes",
+                values=["arch", "launcherspecific", "vortex"],
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
             ),
         )
     )
 
-    _envelope_wrapper_tpl = '@envelope_wrapper_mpiauto.tpl'
-    _envelope_rank_var = 'MPIAUTORANK'
+    _envelope_wrapper_tpl = "@envelope_wrapper_mpiauto.tpl"
+    _envelope_rank_var = "MPIAUTORANK"
     _needs_mpilib_specific_mpienv = False
 
     def _reshaped_mpiopts(self):
         """Raw list of mpi tool command line options."""
         options = super()._reshaped_mpiopts()
-        options['init-timeout-restart'] = [(self.timeoutrestart, )]
-        if self.sublauncher == 'srun':
-            options['use-slurm-mpi'] = [()]
-        elif self.sublauncher == 'libspecific':
-            options['no-use-slurm-mpi'] = [()]
+        options["init-timeout-restart"] = [(self.timeoutrestart,)]
+        if self.sublauncher == "srun":
+            options["use-slurm-mpi"] = [()]
+        elif self.sublauncher == "libspecific":
+            options["no-use-slurm-mpi"] = [()]
         if self.bindingmethod:
-            for k in ['{:s}use-{:s}-bind'.format(p, t) for p in ('', 'no-')
-                      for t in ('arch', 'slurm', 'intelmpi', 'openmpi')]:
+            for k in [
+                "{:s}use-{:s}-bind".format(p, t)
+                for p in ("", "no-")
+                for t in ("arch", "slurm", "intelmpi", "openmpi")
+            ]:
                 options.pop(k, None)
-            if self.bindingmethod == 'arch':
-                options['use-arch-bind'] = [()]
-            elif self.bindingmethod == 'launcherspecific' and self.sublauncher == 'srun':
-                options['no-use-arch-bind'] = [()]
-                options['use-slurm-bind'] = [()]
-            elif self.bindingmethod == 'launcherspecific':
-                options['no-use-arch-bind'] = [()]
-                for k in ['use-{:s}-bind'.format(t)
-                          for t in ('slurm', 'intelmpi', 'openmpi')]:
+            if self.bindingmethod == "arch":
+                options["use-arch-bind"] = [()]
+            elif (
+                self.bindingmethod == "launcherspecific"
+                and self.sublauncher == "srun"
+            ):
+                options["no-use-arch-bind"] = [()]
+                options["use-slurm-bind"] = [()]
+            elif self.bindingmethod == "launcherspecific":
+                options["no-use-arch-bind"] = [()]
+                for k in [
+                    "use-{:s}-bind".format(t)
+                    for t in ("slurm", "intelmpi", "openmpi")
+                ]:
                     options[k] = [()]
-            elif self.bindingmethod == 'vortex':
-                options['no-use-arch-bind'] = [()]
+            elif self.bindingmethod == "vortex":
+                options["no-use-arch-bind"] = [()]
         return options
 
     def _envelope_fix_envelope_bit(self, e_bit, e_desc):
         """Set the envelope fake binary options."""
-        e_bit.options = {k: v for k, v in e_desc.items()
-                         if k not in ('openmp', )}
-        e_bit.options['prefixcommand'] = self._envelope_wrapper_name
+        e_bit.options = {
+            k: v for k, v in e_desc.items() if k not in ("openmp",)
+        }
+        e_bit.options["prefixcommand"] = self._envelope_wrapper_name
         if self.binaries:
             e_bit.master = self.binaries[0].master
 
     def _set_binaries_hack(self, binaries):
         """Set the list of :class:`MpiBinaryDescription` objects associated with this instance."""
-        if len(binaries) > 1 and self.bindingmethod not in (None, 'arch', 'vortex'):
-            logger.info("The '{:s}' binding method is not working properly with multiple binaries."
-                        .format(self.bindingmethod))
+        if len(binaries) > 1 and self.bindingmethod not in (
+            None,
+            "arch",
+            "vortex",
+        ):
+            logger.info(
+                "The '{:s}' binding method is not working properly with multiple binaries.".format(
+                    self.bindingmethod
+                )
+            )
             logger.warning("Resetting the binding method to 'vortex'.")
-            self.bindingmethod = 'vortex'
+            self.bindingmethod = "vortex"
 
     def _set_binaries_envelope_hack(self, binaries):
         """Tweak the envelope after binaries were setup."""
@@ -122,28 +143,38 @@ class MpiAuto(mpitools.MpiTool):
     def _set_envelope(self, value):
         """Set the envelope description."""
         super()._set_envelope(value)
-        if len(self._envelope) > 1 and self.bindingmethod not in (None, 'arch', 'vortex'):
-            logger.info("The '{:s}' binding method is not working properly with complex envelopes."
-                        .format(self.bindingmethod))
+        if len(self._envelope) > 1 and self.bindingmethod not in (
+            None,
+            "arch",
+            "vortex",
+        ):
+            logger.info(
+                "The '{:s}' binding method is not working properly with complex envelopes.".format(
+                    self.bindingmethod
+                )
+            )
             logger.warning("Resetting the binding method to 'vortex'.")
-            self.bindingmethod = 'vortex'
+            self.bindingmethod = "vortex"
 
     envelope = property(mpitools.MpiTool._get_envelope, _set_envelope)
 
     def _hook_binary_mpiopts(self, binary, options):
         tuned = options.copy()
         # Regular MPI tasks count (the usual...)
-        if 'nnp' in options and 'nn' in options:
-            if options['nn'] * options['nnp'] == options['np']:
+        if "nnp" in options and "nn" in options:
+            if options["nn"] * options["nnp"] == options["np"]:
                 # Remove harmful options
-                del tuned['np']
-                tuned.pop('allowodddist', None)
+                del tuned["np"]
+                tuned.pop("allowodddist", None)
                 # that's the strange MPI distribution...
             else:
-                tuned['allowodddist'] = None  # With this, let mpiauto determine its own partitioning
+                tuned["allowodddist"] = (
+                    None  # With this, let mpiauto determine its own partitioning
+                )
         else:
-            msg = ("The provided mpiopts are insufficient to build the command line: {!s}"
-                   .format(options))
+            msg = "The provided mpiopts are insufficient to build the command line: {!s}".format(
+                options
+            )
             raise mpitools.MpiException(msg)
         return tuned
 
@@ -153,43 +184,50 @@ class MpiAuto(mpitools.MpiTool):
         for bin_obj in self.binaries:
             if bin_obj.options:
                 for mpirank in range(ranksidx, ranksidx + bin_obj.nprocs):
-                    prefix_c = bin_obj.options.get('prefixcommand', None)
+                    prefix_c = bin_obj.options.get("prefixcommand", None)
                     if prefix_c:
-                        todostack[mpirank] = (prefix_c,
-                                              [todostack[mpirank][0], ] + todostack[mpirank][1],
-                                              todostack[mpirank][2])
+                        todostack[mpirank] = (
+                            prefix_c,
+                            [
+                                todostack[mpirank][0],
+                            ]
+                            + todostack[mpirank][1],
+                            todostack[mpirank][2],
+                        )
                 ranksidx += bin_obj.nprocs
         return todostack, ranks_bsize
 
     def _envelope_mkcmdline_extra(self, cmdl):
         """If possible, add an openmp option when the arch binding method is used."""
 
-        if self.bindingmethod != 'vortex':
-            openmps = {b.options.get('openmp', None) for b in self.binaries}
+        if self.bindingmethod != "vortex":
+            openmps = {b.options.get("openmp", None) for b in self.binaries}
             if len(openmps) > 1:
                 if self.bindingmethod is not None:
-                    logger.warning("Non-uniform OpenMP threads number... Not specifying anything.")
+                    logger.warning(
+                        "Non-uniform OpenMP threads number... Not specifying anything."
+                    )
             else:
                 openmp = openmps.pop() or 1
-                cmdl.append(self.optprefix + self.optmap['openmp'])
+                cmdl.append(self.optprefix + self.optmap["openmp"])
                 cmdl.append(str(openmp))
 
     def setup_environment(self, opts):
         """Last minute fixups."""
         super().setup_environment(opts)
-        if self.bindingmethod in ('arch', 'vortex'):
+        if self.bindingmethod in ("arch", "vortex"):
             # Make sure srun does nothing !
-            self._logged_env_set('SLURM_CPU_BIND', 'none')
+            self._logged_env_set("SLURM_CPU_BIND", "none")
 
     def setup(self, opts=None):
         """Ensure that the prefixcommand has the execution rights."""
         for bin_obj in self.binaries:
-            prefix_c = bin_obj.options.get('prefixcommand', None)
+            prefix_c = bin_obj.options.get("prefixcommand", None)
             if prefix_c is not None:
                 if self.system.path.exists(prefix_c):
                     self.system.xperm(prefix_c, force=True)
                 else:
-                    raise OSError('The prefixcommand do not exists.')
+                    raise OSError("The prefixcommand do not exists.")
         super().setup(opts)
 
 
@@ -200,88 +238,106 @@ class MpiAutoDDT(MpiAuto):
     """
 
     _footprint = dict(
-        attr = dict(
-            mpiname = dict(
-                values = ['mpiauto-ddt', ],
+        attr=dict(
+            mpiname=dict(
+                values=[
+                    "mpiauto-ddt",
+                ],
             ),
         )
     )
 
-    _conf_suffix = '-ddt'
+    _conf_suffix = "-ddt"
 
     def _reshaped_mpiopts(self):
         options = super()._reshaped_mpiopts()
-        if 'prefix-mpirun' in options:
-            raise mpitools.MpiException('It is not allowed to start DDT with another ' +
-                                        'prefix_mpirun command defined: "{:s}"'
-                                        .format(options))
+        if "prefix-mpirun" in options:
+            raise mpitools.MpiException(
+                "It is not allowed to start DDT with another "
+                + 'prefix_mpirun command defined: "{:s}"'.format(options)
+            )
         armtool = ArmForgeTool(self.ticket)
-        options['prefix-mpirun'] = [(' '.join(armtool.ddt_prefix_cmd(
-            sources=self.sources,
-            workdir=self.system.path.dirname(self.binaries[0].master)
-        )), )]
+        options["prefix-mpirun"] = [
+            (
+                " ".join(
+                    armtool.ddt_prefix_cmd(
+                        sources=self.sources,
+                        workdir=self.system.path.dirname(
+                            self.binaries[0].master
+                        ),
+                    )
+                ),
+            )
+        ]
         return options
 
 
 # Some IFS/Arpege specific things :
+
 
 def arpifs_obsort_nprocab_binarydeco(cls):
     """Handle usual IFS/Arpege environment tweaking for OBSORT (nproca & nprocb).
 
     Note: This is a class decorator for class somehow based on MpiBinaryDescription
     """
-    orig_setup_env = getattr(cls, 'setup_environment')
+    orig_setup_env = getattr(cls, "setup_environment")
 
     def setup_environment(self, opts):
         orig_setup_env(self, opts)
-        self.env.NPROCA = int(self.env.NPROCA or
-                              self.nprocs)
-        self.env.NPROCB = int(self.env.NPROCB or
-                              self.nprocs // self.env.NPROCA)
-        logger.info("MPI Setup NPROCA=%d and NPROCB=%d", self.env.NPROCA, self.env.NPROCB)
+        self.env.NPROCA = int(self.env.NPROCA or self.nprocs)
+        self.env.NPROCB = int(
+            self.env.NPROCB or self.nprocs // self.env.NPROCA
+        )
+        logger.info(
+            "MPI Setup NPROCA=%d and NPROCB=%d",
+            self.env.NPROCA,
+            self.env.NPROCB,
+        )
 
-    if hasattr(orig_setup_env, '__doc__'):
+    if hasattr(orig_setup_env, "__doc__"):
         setup_environment.__doc__ = orig_setup_env.__doc__
 
-    setattr(cls, 'setup_environment', setup_environment)
+    setattr(cls, "setup_environment", setup_environment)
     return cls
 
 
 class _NWPIoServerMixin:
+    _NWP_IOSERV_PATTERNS = ("io_serv.*.d",)
 
-    _NWP_IOSERV_PATTERNS = ('io_serv.*.d', )
-
-    def _nwp_ioserv_setup_namelist(self, namcontents, namlocal,
-                                   total_iotasks, computed_iodist_value=None):
+    def _nwp_ioserv_setup_namelist(
+        self, namcontents, namlocal, total_iotasks, computed_iodist_value=None
+    ):
         """Applying IO Server profile on local namelist ``namlocal`` with contents namcontents."""
-        if 'NAMIO_SERV' in namcontents:
-            namio = namcontents['NAMIO_SERV']
+        if "NAMIO_SERV" in namcontents:
+            namio = namcontents["NAMIO_SERV"]
         else:
-            namio = namcontents.newblock('NAMIO_SERV')
+            namio = namcontents.newblock("NAMIO_SERV")
 
         namio.nproc_io = total_iotasks
         if computed_iodist_value is not None:
             namio.idistio = computed_iodist_value
 
-        if 'VORTEX_IOSERVER_METHOD' in self.env:
+        if "VORTEX_IOSERVER_METHOD" in self.env:
             namio.nio_serv_method = self.env.VORTEX_IOSERVER_METHOD
 
-        if 'VORTEX_IOSERVER_BUFMAX' in self.env:
+        if "VORTEX_IOSERVER_BUFMAX" in self.env:
             namio.nio_serv_buf_maxsize = self.env.VORTEX_IOSERVER_BUFMAX
 
-        if 'VORTEX_IOSERVER_MLSERVER' in self.env:
+        if "VORTEX_IOSERVER_MLSERVER" in self.env:
             namio.nmsg_level_server = self.env.VORTEX_IOSERVER_MLSERVER
 
-        if 'VORTEX_IOSERVER_MLCLIENT' in self.env:
+        if "VORTEX_IOSERVER_MLCLIENT" in self.env:
             namio.nmsg_level_client = self.env.VORTEX_IOSERVER_MLCLIENT
 
-        if 'VORTEX_IOSERVER_PROCESS' in self.env:
+        if "VORTEX_IOSERVER_PROCESS" in self.env:
             namio.nprocess_level = self.env.VORTEX_IOSERVER_PROCESS
 
-        if 'VORTEX_IOSERVER_PIOMODEL' in self.env:
+        if "VORTEX_IOSERVER_PIOMODEL" in self.env:
             namio.pioprocr_MDL = self.env.VORTEX_IOSERVER_PIOMODEL
 
-        self.system.highlight('Parallel io server namelist for {:s}'.format(namlocal))
+        self.system.highlight(
+            "Parallel io server namelist for {:s}".format(namlocal)
+        )
         print(namio.dumps())
 
         return True
@@ -297,38 +353,46 @@ class _NWPIoServerMixin:
         """Post-execution cleaning for io server."""
 
         # Old fashion way to make clear that some polling is needed.
-        self.system.touch('io_poll.todo')
+        self.system.touch("io_poll.todo")
 
         # Get a look inside io server output directories according to its own pattern
         ioserv_filelist = set()
         ioserv_prefixes = set()
-        iofile_re = re.compile(r'((ICMSH|PF|GRIBPF).*\+\d+(?::\d+)?(?:\.sfx)?)(?:\..+)?$')
-        self.system.highlight('Dealing with IO directories')
+        iofile_re = re.compile(
+            r"((ICMSH|PF|GRIBPF).*\+\d+(?::\d+)?(?:\.sfx)?)(?:\..+)?$"
+        )
+        self.system.highlight("Dealing with IO directories")
         iodirs = self._nwp_ioserv_iodirs()
         if iodirs:
-            logger.info('List of IO directories: %s', ','.join(iodirs))
-            f_summary = collections.defaultdict(lambda: [' '] * len(iodirs))
+            logger.info("List of IO directories: %s", ",".join(iodirs))
+            f_summary = collections.defaultdict(lambda: [" "] * len(iodirs))
             for i, iodir in enumerate(iodirs):
                 for iofile in self.system.listdir(iodir):
                     zf = iofile_re.match(iofile)
                     if zf:
-                        f_summary[zf.group(1)][i] = '+'
+                        f_summary[zf.group(1)][i] = "+"
                         ioserv_filelist.add((zf.group(1), zf.group(2)))
                         ioserv_prefixes.add(zf.group(2))
                     else:
-                        f_summary[iofile][i] = '?'
+                        f_summary[iofile][i] = "?"
             max_names_len = max([len(iofile) for iofile in f_summary.keys()])
-            fmt_names = '{:' + str(max_names_len) + 's}'
-            logger.info('Data location accross the various IOserver directories:\n%s',
-                        '\n'.join([(fmt_names + ' |{:s}|').format(iofile, ''.join(where))
-                                   for iofile, where in sorted(f_summary.items())]))
+            fmt_names = "{:" + str(max_names_len) + "s}"
+            logger.info(
+                "Data location accross the various IOserver directories:\n%s",
+                "\n".join(
+                    [
+                        (fmt_names + " |{:s}|").format(iofile, "".join(where))
+                        for iofile, where in sorted(f_summary.items())
+                    ]
+                ),
+            )
         else:
-            logger.info('No IO directories were found')
+            logger.info("No IO directories were found")
 
-        if 'GRIBPF' in ioserv_prefixes:
+        if "GRIBPF" in ioserv_prefixes:
             # If GRIB are requested, do not bother with old FA PF files
-            ioserv_prefixes.discard('PF')
-            ioserv_filelist = {(f, p) for f, p in ioserv_filelist if p != 'PF'}
+            ioserv_prefixes.discard("PF")
+            ioserv_filelist = {(f, p) for f, p in ioserv_filelist if p != "PF"}
 
         # Touch the output files
         for tgfile, _ in ioserv_filelist:
@@ -336,7 +400,7 @@ class _NWPIoServerMixin:
 
         # Touch the io_poll.todo.PREFIX
         for prefix in ioserv_prefixes:
-            self.system.touch('io_poll.todo.{:s}'.format(prefix))
+            self.system.touch("io_poll.todo.{:s}".format(prefix))
 
 
 class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
@@ -344,7 +408,7 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
 
     _abstract = True
 
-    def __init__(self, * kargs, **kwargs):
+    def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
         self._incore_iotasks = None
         self._effective_incore_iotasks = None
@@ -359,7 +423,7 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
     @incore_iotasks.setter
     def incore_iotasks(self, value):
         """The number of tasks dedicated to the IO server."""
-        if isinstance(value, str) and value.endswith('%'):
+        if isinstance(value, str) and value.endswith("%"):
             value = math.ceil(self.nprocs * float(value[:-1]) / 100)
         self._incore_iotasks = int(value)
         self._effective_incore_iotasks = None
@@ -373,10 +437,12 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
     def incore_iotasks_fixer(self, value):
         """Tweak the number of iotasks in order to respect a given constraints."""
         if not isinstance(value, str):
-            raise ValueError('A string is expected')
-        if value.startswith('nproc_multiple_of_'):
-            self._incore_iotasks_fixer = ('nproc_multiple_of',
-                                          [int(i) for i in value[18:].split(',')])
+            raise ValueError("A string is expected")
+        if value.startswith("nproc_multiple_of_"):
+            self._incore_iotasks_fixer = (
+                "nproc_multiple_of",
+                [int(i) for i in value[18:].split(",")],
+            )
         else:
             raise ValueError('The "{:s}" value is incorrect'.format(value))
 
@@ -391,22 +457,36 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
         if self.incore_iotasks is not None:
             if self._effective_incore_iotasks is None:
                 if self.incore_iotasks_fixer is not None:
-                    if self.incore_iotasks_fixer[0] == 'nproc_multiple_of':
+                    if self.incore_iotasks_fixer[0] == "nproc_multiple_of":
                         # Allow for 5% less, or add some tasks
-                        for candidate in interleave(range(self.incore_iotasks, self.nprocs + 1),
-                                                    range(self.incore_iotasks - 1,
-                                                          int(math.ceil(0.95 * self.incore_iotasks)) - 1,
-                                                          -1)):
-                            if any([(self.nprocs - candidate) % multiple == 0
-                                    for multiple in self.incore_iotasks_fixer[1]]):
+                        for candidate in interleave(
+                            range(self.incore_iotasks, self.nprocs + 1),
+                            range(
+                                self.incore_iotasks - 1,
+                                int(math.ceil(0.95 * self.incore_iotasks)) - 1,
+                                -1,
+                            ),
+                        ):
+                            if any(
+                                [
+                                    (self.nprocs - candidate) % multiple == 0
+                                    for multiple in self.incore_iotasks_fixer[
+                                        1
+                                    ]
+                                ]
+                            ):
                                 self._effective_incore_iotasks = candidate
                                 break
                     else:
-                        raise RuntimeError('Unsupported fixer')
+                        raise RuntimeError("Unsupported fixer")
                     if self._effective_incore_iotasks != self.incore_iotasks:
-                        logger.info('The number of IO tasks was updated form %d to %d ' +
-                                    'because of the "%s" fixer', self.incore_iotasks,
-                                    self._effective_incore_iotasks, self.incore_iotasks_fixer[0])
+                        logger.info(
+                            "The number of IO tasks was updated form %d to %d "
+                            + 'because of the "%s" fixer',
+                            self.incore_iotasks,
+                            self._effective_incore_iotasks,
+                            self.incore_iotasks_fixer[0],
+                        )
                 else:
                     self._effective_incore_iotasks = self.incore_iotasks
             return self._effective_incore_iotasks
@@ -421,17 +501,23 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
     @incore_iodist.setter
     def incore_iodist(self, value):
         """How to distribute IO server tasks within model tasks."""
-        allowed = ('begining', 'end', 'scattered',)
-        if not (isinstance(value, str) and
-                value in allowed):
-            raise ValueError("'{!s}' is not an allowed value ('{:s}')"
-                             .format(value, ', '.join(allowed)))
+        allowed = (
+            "begining",
+            "end",
+            "scattered",
+        )
+        if not (isinstance(value, str) and value in allowed):
+            raise ValueError(
+                "'{!s}' is not an allowed value ('{:s}')".format(
+                    value, ", ".join(allowed)
+                )
+            )
         self._incore_iodist = value
 
     def _set_nam_macro(self, namcontents, namlocal, macro, value):
         """Set a namelist macro and log it!"""
         namcontents.setmacro(macro, value)
-        logger.info('Setup macro %s=%s in %s', macro, str(value), namlocal)
+        logger.info("Setup macro %s=%s in %s", macro, str(value), namlocal)
 
     def setup_namelist_delta(self, namcontents, namlocal):
         """Applying MPI profile on local namelist ``namlocal`` with contents namcontents."""
@@ -445,48 +531,74 @@ class _AbstractMpiNWP(mpitools.MpiBinaryBasic, _NWPIoServerMixin):
         if self.effective_incore_iotasks is not None:
             effective_nprocs -= self.effective_incore_iotasks
         # Set up the effective_nprocs related macros
-        nprocs_macros = ('NPROC', 'NBPROC', 'NTASKS')
+        nprocs_macros = ("NPROC", "NBPROC", "NTASKS")
         if any([n in nam_macros for n in nprocs_macros]):
             for n in nprocs_macros:
                 self._set_nam_macro(namcontents, namlocal, n, effective_nprocs)
             namw = True
-            if any([n in nam_macros for n in ('NCPROC', 'NDPROC')]):
-                self._set_nam_macro(namcontents, namlocal, 'NCPROC',
-                                    int(self.env.VORTEX_NPRGPNS or effective_nprocs))
-                self._set_nam_macro(namcontents, namlocal, 'NDPROC',
-                                    int(self.env.VORTEX_NPRGPEW or 1))
+            if any([n in nam_macros for n in ("NCPROC", "NDPROC")]):
+                self._set_nam_macro(
+                    namcontents,
+                    namlocal,
+                    "NCPROC",
+                    int(self.env.VORTEX_NPRGPNS or effective_nprocs),
+                )
+                self._set_nam_macro(
+                    namcontents,
+                    namlocal,
+                    "NDPROC",
+                    int(self.env.VORTEX_NPRGPEW or 1),
+                )
                 namw = True
-        if 'NAMPAR1' in namcontents:
-            np1 = namcontents['NAMPAR1']
-            for nstr in [x for x in ('NSTRIN', 'NSTROUT') if x in np1]:
-                if isinstance(np1[nstr], (int, float)) and np1[nstr] > effective_nprocs:
-                    logger.info('Setup %s=%s in NAMPAR1 %s', nstr, effective_nprocs, namlocal)
+        if "NAMPAR1" in namcontents:
+            np1 = namcontents["NAMPAR1"]
+            for nstr in [x for x in ("NSTRIN", "NSTROUT") if x in np1]:
+                if (
+                    isinstance(np1[nstr], (int, float))
+                    and np1[nstr] > effective_nprocs
+                ):
+                    logger.info(
+                        "Setup %s=%s in NAMPAR1 %s",
+                        nstr,
+                        effective_nprocs,
+                        namlocal,
+                    )
                     np1[nstr] = effective_nprocs
                     namw = True
         # Deal with partitioning macros
-        namw_p = setup_partitioning_in_namelist(namcontents,
-                                                effective_nprocs,
-                                                self.options.get('openmp', 1),
-                                                namlocal)
+        namw_p = setup_partitioning_in_namelist(
+            namcontents,
+            effective_nprocs,
+            self.options.get("openmp", 1),
+            namlocal,
+        )
         namw = namw or namw_p
         # Incore IO tasks
         if self.effective_incore_iotasks is not None:
             c_iodist = None
             if self.incore_iodist is not None:
-                if self.incore_iodist == 'begining':
+                if self.incore_iodist == "begining":
                     c_iodist = -1
-                elif self.incore_iodist == 'end':
+                elif self.incore_iodist == "end":
                     c_iodist = 0
-                elif self.incore_iodist == 'scattered':
+                elif self.incore_iodist == "scattered":
                     # Ensure that there is at least one task on the first node
-                    c_iodist = min(self.nprocs // self.effective_incore_iotasks,
-                                   self.options.get('nnp', self.nprocs))
+                    c_iodist = min(
+                        self.nprocs // self.effective_incore_iotasks,
+                        self.options.get("nnp", self.nprocs),
+                    )
                 else:
-                    raise RuntimeError("incore_iodist '{!s}' is not supported: check your code"
-                                       .format(self.incore_iodist))
-            namw_io = self._nwp_ioserv_setup_namelist(namcontents, namlocal,
-                                                      self.effective_incore_iotasks,
-                                                      computed_iodist_value=c_iodist)
+                    raise RuntimeError(
+                        "incore_iodist '{!s}' is not supported: check your code".format(
+                            self.incore_iodist
+                        )
+                    )
+            namw_io = self._nwp_ioserv_setup_namelist(
+                namcontents,
+                namlocal,
+                self.effective_incore_iotasks,
+                computed_iodist_value=c_iodist,
+            )
             namw = namw or namw_io
         return namw
 
@@ -501,8 +613,12 @@ class MpiNWP(_AbstractMpiNWP):
     """The kind of binaries used in IFS/Arpege."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(values = ['basicnwp', ]),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "basicnwp",
+                ]
+            ),
         ),
     )
 
@@ -512,8 +628,12 @@ class MpiNWPObsort(_AbstractMpiNWP):
     """The kind of binaries used in IFS/Arpege when the ODB OBSSORT code needs to be run."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(values = ['basicnwpobsort', ]),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "basicnwpobsort",
+                ]
+            ),
         ),
     )
 
@@ -523,8 +643,12 @@ class MpiObsort(mpitools.MpiBinaryBasic):
     """The kind of binaries used when the ODB OBSSORT code needs to be run."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(values = ['basicobsort', ]),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "basicobsort",
+                ]
+            ),
         ),
     )
 
@@ -533,9 +657,15 @@ class MpiNWPIO(mpitools.MpiBinaryIOServer, _NWPIoServerMixin):
     """Standard IFS/Arpege NWP IO server."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(values = ['nwpioserv', ]),
-            iolocation = dict(values = [-1, 0], default = 0, optional = True, type = int),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "nwpioserv",
+                ]
+            ),
+            iolocation=dict(
+                values=[-1, 0], default=0, optional=True, type=int
+            ),
         )
     )
 
@@ -545,7 +675,7 @@ class MpiNWPIO(mpitools.MpiBinaryIOServer, _NWPIoServerMixin):
             namcontents,
             namlocal,
             self.nprocs,
-            computed_iodist_value=(-1 if self.iolocation == 0 else None)
+            computed_iodist_value=(-1 if self.iolocation == 0 else None),
         )
 
     def clean(self, opts=None):

--- a/src/vortex/nwp/algo/odbtools.py
+++ b/src/vortex/nwp/algo/odbtools.py
@@ -32,14 +32,14 @@ logger = loggers.getLogger(__name__)
 
 
 class Raw2OdbExecutionError(ExecutionError):
-
     def __init__(self, odb_database):
         self.odb_database = odb_database
-        super().__init__('Raw2odb execution failed.')
+        super().__init__("Raw2odb execution failed.")
 
     def __str__(self):
-        return ("Error while running bator for ODB database < {:s} >"
-                .format(self.odb_database))
+        return "Error while running bator for ODB database < {:s} >".format(
+            self.odb_database
+        )
 
 
 class Bateur(VortexWorkerBlindRun):
@@ -54,18 +54,18 @@ class Bateur(VortexWorkerBlindRun):
             info="Bateur: launches a single bator execution in a parallel context",
             attr=dict(
                 base=dict(
-                    info        = 'name of the odb database to process',
+                    info="name of the odb database to process",
                 ),
                 workdir=dict(
-                    info        = 'working directory of the run',
+                    info="working directory of the run",
                 ),
-                inputsize = dict(
-                    info        = 'input files total size in bytes',
-                    type        = int,
-                    default     = 0,
-                )
-            )
-        )
+                inputsize=dict(
+                    info="input files total size in bytes",
+                    type=int,
+                    default=0,
+                ),
+            ),
+        ),
     ]
 
     @property
@@ -73,135 +73,168 @@ class Bateur(VortexWorkerBlindRun):
         return self.memory * 1024 * 1024
 
     def vortex_task(self, **kwargs):
-        odb_drv = odb.OdbDriver(self.cycle,
-                                self.system, self.system.env)
-        self.system.cd('wkdir_' + self.base)
+        odb_drv = odb.OdbDriver(self.cycle, self.system, self.system.env)
+        self.system.cd("wkdir_" + self.base)
 
-        dbpath = self.system.path.join(self.workdir, 'ECMA.' + self.base)
+        dbpath = self.system.path.join(self.workdir, "ECMA." + self.base)
         listpath = self.system.path.join(self.workdir, "listing." + self.base)
 
-        odb_drv.fix_db_path('ecma', dbpath)
+        odb_drv.fix_db_path("ecma", dbpath)
 
-        real_time = - time.time()
+        real_time = -time.time()
         start_time = utcnow().isoformat()
         rdict = dict(rc=True)
         try:
             self.local_spawn(listpath)
         except ExecutionError:
-            rdict['rc'] = Raw2OdbExecutionError(self.base)
+            rdict["rc"] = Raw2OdbExecutionError(self.base)
         real_time += time.time()
 
         if self.system.memory_info is not None:
-            realMem = self.system.memory_info.children_maxRSS('B')
-            memRatio = (realMem / float(self.memory_in_bytes)) if self.memory_in_bytes > 0 else None
+            realMem = self.system.memory_info.children_maxRSS("B")
+            memRatio = (
+                (realMem / float(self.memory_in_bytes))
+                if self.memory_in_bytes > 0
+                else None
+            )
         else:
             realMem = None
             memRatio = None
 
-        rdict['synthesis'] = dict(base=self.base,
-                                  inputsize=self.inputsize,
-                                  mem_expected=self.memory_in_bytes,
-                                  mem_real=realMem,
-                                  mem_ratio=memRatio,
-                                  time_expected=self.expected_time,
-                                  time_start=start_time,
-                                  time_real=real_time,
-                                  time_ratio=(real_time / float(self.expected_time)
-                                              if self.expected_time > 0 else None),
-                                  sched_id=self.scheduler_ticket,
-                                  )
+        rdict["synthesis"] = dict(
+            base=self.base,
+            inputsize=self.inputsize,
+            mem_expected=self.memory_in_bytes,
+            mem_real=realMem,
+            mem_ratio=memRatio,
+            time_expected=self.expected_time,
+            time_start=start_time,
+            time_real=real_time,
+            time_ratio=(
+                real_time / float(self.expected_time)
+                if self.expected_time > 0
+                else None
+            ),
+            sched_id=self.scheduler_ticket,
+        )
 
         # Save a copy of io assign map in the new database
         if self.system.path.isdir(dbpath):
-            self.system.cp(self.system.path.join(self.workdir, 'odb_db_template', 'IOASSIGN'),
-                           self.system.path.join(dbpath, 'IOASSIGN'))
+            self.system.cp(
+                self.system.path.join(
+                    self.workdir, "odb_db_template", "IOASSIGN"
+                ),
+                self.system.path.join(dbpath, "IOASSIGN"),
+            )
         else:
-            logger.warning('ODB database not created: ' + self.base)
+            logger.warning("ODB database not created: " + self.base)
 
         return rdict
 
 
-class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
+class Raw2ODBparallel(
+    ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin
+):
     """Convert raw observations files to ODB using taylorism."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['raw2odb', 'bufr2odb', 'obsoul2odb'],
-                remap  = dict(
-                    bufr2odb   = 'raw2odb',
-                    obsoul2odb = 'raw2odb',
-                )
+        attr=dict(
+            kind=dict(
+                values=["raw2odb", "bufr2odb", "obsoul2odb"],
+                remap=dict(
+                    bufr2odb="raw2odb",
+                    obsoul2odb="raw2odb",
+                ),
             ),
-            engine = dict(
-                values = ['blind', 'parallel']  # parallel -> for backward compatibility
+            engine=dict(
+                values=[
+                    "blind",
+                    "parallel",
+                ]  # parallel -> for backward compatibility
             ),
-            ioassign = dict(
-                optional = False,
+            ioassign=dict(
+                optional=False,
             ),
-            lamflag = dict(
-                info     = 'Activate LAMFLAG (i.e work for Limited Area Model)',
-                type     = bool,
-                optional = True,
-                default  = False,
+            lamflag=dict(
+                info="Activate LAMFLAG (i.e work for Limited Area Model)",
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            ontime = dict(
-                info     = "Check observation's resources date vs own data attribute.",
-                type     = bool,
-                optional = True,
-                default  = True,
+            ontime=dict(
+                info="Check observation's resources date vs own data attribute.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            mapall = dict(
-                info     = "All observation files must be accounted for in an obsmap file. ",
-                type     = bool,
-                optional = True,
-                default  = False,
+            mapall=dict(
+                info="All observation files must be accounted for in an obsmap file. ",
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            maponly = dict(
-                info     = ("Work only with observation files listed in the obsmap files. " +
-                            "(if False, obsmap entries may be automatically generated)."),
-                type     = bool,
-                optional = True,
-                default  = False,
+            maponly=dict(
+                info=(
+                    "Work only with observation files listed in the obsmap files. "
+                    + "(if False, obsmap entries may be automatically generated)."
+                ),
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            member = dict(
-                info     = ("The current member's number " +
-                            "(may be omitted in deterministic configurations)."),
-                optional = True,
-                type     = int,
+            member=dict(
+                info=(
+                    "The current member's number "
+                    + "(may be omitted in deterministic configurations)."
+                ),
+                optional=True,
+                type=int,
             ),
-            dataid = dict(
-                info     = ("The ODB databases created by Bator contain an identifier " +
-                            "that is specified as a command-line argument. This " +
-                            "switch tweaks the way the command-line argument is " +
-                            "generated."),
-                values   = ['empty', 'hh'],
-                default  = 'hh',
-                optional = True
+            dataid=dict(
+                info=(
+                    "The ODB databases created by Bator contain an identifier "
+                    + "that is specified as a command-line argument. This "
+                    + "switch tweaks the way the command-line argument is "
+                    + "generated."
+                ),
+                values=["empty", "hh"],
+                default="hh",
+                optional=True,
             ),
-            ntasks = dict(
-                info     = ("The maximum number of allowed concurrent task for "
-                            "parallel execution."),
-                default  = 1,
-                optional = True,
+            ntasks=dict(
+                info=(
+                    "The maximum number of allowed concurrent task for "
+                    "parallel execution."
+                ),
+                default=1,
+                optional=True,
             ),
-            maxmemory = dict(
-                info     = "The maximum amount of usable memory (in GiB)",
-                type     = int,
-                optional = True,
+            maxmemory=dict(
+                info="The maximum amount of usable memory (in GiB)",
+                type=int,
+                optional=True,
             ),
-            parallel_const = dict(
-                info     = ("Constant that are used to predict execution time and " +
-                            "memory consumption for a given ODB database."),
-                type     = footprints.FPDict,
-                optional = True,
-            )
+            parallel_const=dict(
+                info=(
+                    "Constant that are used to predict execution time and "
+                    + "memory consumption for a given ODB database."
+                ),
+                type=footprints.FPDict,
+                optional=True,
+            ),
         )
     )
 
-    _donot_link_roles = ['Observations', 'Obsmap',
-                         'IOPoll', 'LFIScripts', 'LFITOOLS',
-                         'Binary', 'Bator', 'Batodb']
+    _donot_link_roles = [
+        "Observations",
+        "Obsmap",
+        "IOPoll",
+        "LFIScripts",
+        "LFITOOLS",
+        "Binary",
+        "Bator",
+        "Batodb",
+    ]
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
@@ -215,16 +248,25 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         """Return the maximum amount of usable memory (in MiB)."""
         if self._effective_maxmem is None:
             if self.maxmemory:
-                self._effective_maxmem = self.maxmemory * 1024  # maxmemory in GB
+                self._effective_maxmem = (
+                    self.maxmemory * 1024
+                )  # maxmemory in GB
             else:
-                sys_maxmem = self.system.memory_info.system_RAM('MiB')
+                sys_maxmem = self.system.memory_info.system_RAM("MiB")
                 # System memory minus 20% or minus 4GB
-                self._effective_maxmem = max(sys_maxmem * .8, sys_maxmem - 4 * 1024)
+                self._effective_maxmem = max(
+                    sys_maxmem * 0.8, sys_maxmem - 4 * 1024
+                )
         return self._effective_maxmem
 
     def input_obs(self):
         """Find out which are the usable observations."""
-        obsall = [x for x in self.context.sequence.effective_inputs(kind='observations')]
+        obsall = [
+            x
+            for x in self.context.sequence.effective_inputs(
+                kind="observations"
+            )
+        ]
         obsall.sort(key=lambda s: s.rh.resource.part)
 
         # Looking for valid raw observations
@@ -232,24 +274,34 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         obsok = list()
         for secobs in obsall:
             rhobs = secobs.rh
-            if rhobs.resource.nativefmt == 'odb':
-                logger.warning('Observations set [%s] is ODB ready',
-                               rhobs.resource.part)
+            if rhobs.resource.nativefmt == "odb":
+                logger.warning(
+                    "Observations set [%s] is ODB ready", rhobs.resource.part
+                )
                 continue
             if rhobs.container.totalsize < sizemin:
-                logger.warning('Observations set [%s] is far too small: %d',
-                               rhobs.resource.part, rhobs.container.totalsize)
+                logger.warning(
+                    "Observations set [%s] is far too small: %d",
+                    rhobs.resource.part,
+                    rhobs.container.totalsize,
+                )
             else:
-                logger.info('Observations set [%s] has size: %d',
-                            rhobs.resource.part, int(rhobs.container.totalsize))
+                logger.info(
+                    "Observations set [%s] has size: %d",
+                    rhobs.resource.part,
+                    int(rhobs.container.totalsize),
+                )
                 obsok.append(Foo(rh=rhobs, refdata=list(), mapped=False))
 
         # Check the observations dates
         for obs in [obs for obs in obsok if obs.rh.resource.date != self.date]:
-            logger.warning('Observation [%s] %s [time mismatch: %s / %s]',
-                           'discarded' if self.ontime else 'is questionable',
-                           obs.rh.resource.part, obs.rh.resource.date.isoformat(),
-                           self.date.isoformat())
+            logger.warning(
+                "Observation [%s] %s [time mismatch: %s / %s]",
+                "discarded" if self.ontime else "is questionable",
+                obs.rh.resource.part,
+                obs.rh.resource.date.isoformat(),
+                self.date.isoformat(),
+            )
         if self.ontime:
             obsok = [obs for obs in obsok if obs.rh.resource.date == self.date]
 
@@ -258,24 +310,34 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
     def _retrieve_refdatainfo(self, obslist):
         """Look for refdata resources and link their content with the obslist."""
         refmap = dict()
-        refall = list(self.context.sequence.effective_inputs(kind='refdata'))
+        refall = list(self.context.sequence.effective_inputs(kind="refdata"))
         for rdata in refall:
-            logger.info('Inspect refdata ' + rdata.rh.container.localpath())
+            logger.info("Inspect refdata " + rdata.rh.container.localpath())
             self.system.subtitle(rdata.role)
             rdata.rh.container.cat()
             for item in rdata.rh.contents:
-                refmap[(item.fmt.lower(), item.data, item.instr)] = (rdata.rh, item)
+                refmap[(item.fmt.lower(), item.data, item.instr)] = (
+                    rdata.rh,
+                    item,
+                )
 
         # Build actual refdata
         for obs in obslist:
             thispart = obs.rh.resource.part
             thisfmt = obs.rh.container.actualfmt.lower()
-            logger.info(' '.join(('Building information for [', thisfmt, '/', thispart, ']')))
+            logger.info(
+                " ".join(
+                    ("Building information for [", thisfmt, "/", thispart, "]")
+                )
+            )
 
             # Gather equivalent refdata lines
-            if not self.system.path.exists('norefdata.' + thispart) and (
-                    not self.env.VORTEX_OBSDB_NOREF or
-                    not re.search(thispart, self.env.VORTEX_OBSDB_NOREF, re.IGNORECASE)):
+            if not self.system.path.exists("norefdata." + thispart) and (
+                not self.env.VORTEX_OBSDB_NOREF
+                or not re.search(
+                    thispart, self.env.VORTEX_OBSDB_NOREF, re.IGNORECASE
+                )
+            ):
                 for k, v in refmap.items():
                     x_fmt, x_data = k[:2]
                     if x_fmt == thisfmt and x_data == thispart:
@@ -290,18 +352,26 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
             rdata, item = refmap[thiskey]
             thismap.refdata.append(rdata.contents.formatted_data(item))
         else:
-            logger.warning('Creating automatic refdata entry for ' + str(thiskey))
-            item = ObsRefItem(imap.data, imap.fmt, imap.instr, self.date.ymd, self.date.hh)
+            logger.warning(
+                "Creating automatic refdata entry for " + str(thiskey)
+            )
+            item = ObsRefItem(
+                imap.data, imap.fmt, imap.instr, self.date.ymd, self.date.hh
+            )
             if refall:
-                thismap.refdata.append(refall[0].rh.contents.formatted_data(item))
+                thismap.refdata.append(
+                    refall[0].rh.contents.formatted_data(item)
+                )
             else:
-                logger.error('No default for formatting data %s', item)
+                logger.error("No default for formatting data %s", item)
                 thismap.refdata.append(ObsRefContent.formatted_data(item))
 
     @staticmethod
     def _new_obspack_item():
         """Create a now entry in obspack."""
-        return Foo(mapping=list(), standalone=False, refdata=list(), obsfile=dict())
+        return Foo(
+            mapping=list(), standalone=False, refdata=list(), obsfile=dict()
+        )
 
     def prepare(self, rh, opts):
         """Get a look at raw observations input files."""
@@ -310,22 +380,30 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         cycle = rh.resource.cycle
 
         # First create the proper IO assign table for any of the resulting ECMA databases
-        self.odb_create_db('ECMA', 'odb_db_template')
-        self.env.IOASSIGN = sh.path.abspath(sh.path.join('odb_db_template', 'IOASSIGN'))
+        self.odb_create_db("ECMA", "odb_db_template")
+        self.env.IOASSIGN = sh.path.abspath(
+            sh.path.join("odb_db_template", "IOASSIGN")
+        )
 
         # Looking for input observations
         obsok = self.input_obs()
 
         # Building refdata map for direct access to (fmt, data, instr) entries
-        if cycle < 'cy42_op1':
+        if cycle < "cy42_op1":
             # Refdata information is not needed anymore with cy42_op1
             refmap, refall = self._retrieve_refdatainfo(obsok)
 
         # Looking for obs maps
         mapitems = list()
-        for omsec in self.context.sequence.effective_inputs(kind='obsmap'):
-            logger.info(' '.join(('Gathering information from map',
-                                  omsec.rh.container.localpath())))
+        for omsec in self.context.sequence.effective_inputs(kind="obsmap"):
+            logger.info(
+                " ".join(
+                    (
+                        "Gathering information from map",
+                        omsec.rh.container.localpath(),
+                    )
+                )
+            )
             sh.subtitle(omsec.role)
             omsec.rh.container.cat()
             mapitems.extend(omsec.rh.contents)
@@ -333,12 +411,21 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         self.obspack = defaultdict(self._new_obspack_item)  # Reset the obspack
         for imap in mapitems:
             # Match observation files and obsmap entries + Various checks
-            logger.info('Inspect ' + str(imap))
-            candidates = [obs for obs in obsok
-                          if (obs.rh.resource.part == imap.data and
-                              obs.rh.container.actualfmt.lower() == imap.fmt.lower())]
+            logger.info("Inspect " + str(imap))
+            candidates = [
+                obs
+                for obs in obsok
+                if (
+                    obs.rh.resource.part == imap.data
+                    and obs.rh.container.actualfmt.lower() == imap.fmt.lower()
+                )
+            ]
             if not candidates:
-                errmsg = 'No input obsfile could match [data:{:s}/fmt:{:s}]'.format(imap.data, imap.fmt)
+                errmsg = (
+                    "No input obsfile could match [data:{:s}/fmt:{:s}]".format(
+                        imap.data, imap.fmt
+                    )
+                )
                 if self.mapall:
                     raise ValueError(errmsg)
                 else:
@@ -348,38 +435,44 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
             # Build the obspack entry
             thismap = self.obspack[imap.odb]
             thismap.mapping.append(imap)
-            thismap.obsfile[imap.fmt.upper() + '.' + imap.data] = candidates[-1]
+            thismap.obsfile[imap.fmt.upper() + "." + imap.data] = candidates[
+                -1
+            ]
             # Map refdata and obsmap entries
-            if cycle < 'cy42_op1':
+            if cycle < "cy42_op1":
                 # Refdata information is not needed anymore with cy42_op1
                 self._map_refdatainfo(refmap, refall, imap, thismap)
 
         # Deal with observations that are not described in the obsmap
         for notmap in [obs for obs in obsok if not obs.mapped]:
             thispart = notmap.rh.resource.part
-            logger.info('Inspect not mapped obs ' + thispart)
+            logger.info("Inspect not mapped obs " + thispart)
             if thispart not in self.obspack:
                 thisfmt = notmap.rh.container.actualfmt.upper()
-                thismsg = 'standalone obs entry [data:{:s} / fmt:{:s}]'.format(thispart, thisfmt)
+                thismsg = "standalone obs entry [data:{:s} / fmt:{:s}]".format(
+                    thispart, thisfmt
+                )
                 if self.maponly:
-                    logger.warning('Ignore ' + thismsg)
+                    logger.warning("Ignore " + thismsg)
                 else:
-                    logger.warning('Active ' + thismsg)
+                    logger.warning("Active " + thismsg)
                     thismap = self.obspack[thispart]
                     thismap.standalone = thisfmt
-                    thismap.mapping.append(ObsMapItem(thispart, thispart, thisfmt, thispart))
+                    thismap.mapping.append(
+                        ObsMapItem(thispart, thispart, thisfmt, thispart)
+                    )
                     thismap.refdata = notmap.refdata
-                    thismap.obsfile[thisfmt.upper() + '.' + thispart] = notmap
+                    thismap.obsfile[thisfmt.upper() + "." + thispart] = notmap
 
         # Informations about timeslots
         logger.info("The timeslot definition is: %s", str(self.slots))
-        if cycle < 'cy42_op1':
+        if cycle < "cy42_op1":
             # ficdate is not needed anymore with cy42_op1...
-            self.slots.as_file(self.date, 'ficdate')
+            self.slots.as_file(self.date, "ficdate")
         else:
             # From cy42_op1 onward, we only need environment variables
             for var, value in self.slots.as_environment().items():
-                logger.info('Setting env %s = %s', var, str(value))
+                logger.info("Setting env %s = %s", var, str(value))
                 self.env[var] = value
 
         # Let ancestors handling most of the env setting
@@ -388,37 +481,48 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
             BATOR_NBPOOL=self.npool,
             BATODB_NBPOOL=self.npool,
             BATOR_NBSLOT=self.slots.nslot,
-            BATODB_NBSLOT=self.slots.nslot,)
+            BATODB_NBSLOT=self.slots.nslot,
+        )
         self.env.default(
             TIME_INIT_YYYYMMDD=self.date.ymd,
-            TIME_INIT_HHMMSS=self.date.hm + '00',)
+            TIME_INIT_HHMMSS=self.date.hm + "00",
+        )
         if self.lamflag:
-            for lamvar in ('BATOR_LAMFLAG', 'BATODB_LAMFLAG'):
-                logger.info('Setting env %s = %d', lamvar, 1)
+            for lamvar in ("BATOR_LAMFLAG", "BATODB_LAMFLAG"):
+                logger.info("Setting env %s = %d", lamvar, 1)
                 self.env[lamvar] = 1
 
         if self.member is not None:
-            for nam in self.context.sequence.effective_inputs(kind=('namelist', 'namelistfp')):
-                nam.rh.contents.setmacro('MEMBER', self.member)
-                logger.info('Setup macro MEMBER=%s in %s', self.member, nam.rh.container.actualpath())
+            for nam in self.context.sequence.effective_inputs(
+                kind=("namelist", "namelistfp")
+            ):
+                nam.rh.contents.setmacro("MEMBER", self.member)
+                logger.info(
+                    "Setup macro MEMBER=%s in %s",
+                    self.member,
+                    nam.rh.container.actualpath(),
+                )
                 if nam.rh.contents.dumps_needs_update:
                     nam.rh.save()
 
     def spawn_command_options(self):
         """Any data useful to build the command line."""
         opts_dict = super().spawn_command_options()
-        opts_dict['dataid'] = self.dataid
-        opts_dict['date'] = self.date
+        opts_dict["dataid"] = self.dataid
+        opts_dict["date"] = self.date
         return opts_dict
 
     def _default_pre_execute(self, rh, opts):
         """Change default initialisation to use LongerFirstScheduler"""
         # Start the task scheduler
-        self._boss = Boss(verbose=self.verbose,
-                          scheduler=footprints.proxy.scheduler(limit='threads+memory',
-                                                               max_threads=self.ntasks,
-                                                               max_memory=self.effective_maxmem,
-                                                               ))
+        self._boss = Boss(
+            verbose=self.verbose,
+            scheduler=footprints.proxy.scheduler(
+                limit="threads+memory",
+                max_threads=self.ntasks,
+                max_memory=self.effective_maxmem,
+            ),
+        )
         self._boss.make_them_work()
 
     def execute(self, rh, opts):
@@ -430,10 +534,15 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         sh = self.system
         cycle = rh.resource.cycle
 
-        batnam = [x.rh for x in self.context.sequence.effective_inputs(role='NamelistBatodb')]
+        batnam = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role="NamelistBatodb"
+            )
+        ]
         # Give a glance to the actual namelist
         if batnam:
-            sh.subtitle('Namelist Raw2ODB')
+            sh.subtitle("Namelist Raw2ODB")
             batnam[0].container.cat()
 
         self.obsmapout = list()  # Reset the obsmapout
@@ -442,167 +551,277 @@ class Raw2ODBparallel(ParaBlindRun, odb.OdbComponentDecoMixin, drhook.DrHookDeco
         workdir = sh.pwd()
 
         for odbset, thispack in self.obspack.items():
-            odbname = self.virtualdb.upper() + '.' + odbset
-            sh.title('Cocooning ODB set: ' + odbname)
-            with sh.cdcontext('wkdir_' + odbset, create=True):
-
-                for inpt in [s for s in self.context.sequence.inputs() if s.stage == 'get']:
+            odbname = self.virtualdb.upper() + "." + odbset
+            sh.title("Cocooning ODB set: " + odbname)
+            with sh.cdcontext("wkdir_" + odbset, create=True):
+                for inpt in [
+                    s
+                    for s in self.context.sequence.inputs()
+                    if s.stage == "get"
+                ]:
                     if inpt.role not in self._donot_link_roles:
-                        logger.info('creating softlink: %s -> %s', inpt.rh.container.localpath(),
-                                    sh.path.join(workdir, inpt.rh.container.localpath()))
-                        sh.softlink(sh.path.join(workdir, inpt.rh.container.localpath()),
-                                    inpt.rh.container.localpath())
+                        logger.info(
+                            "creating softlink: %s -> %s",
+                            inpt.rh.container.localpath(),
+                            sh.path.join(
+                                workdir, inpt.rh.container.localpath()
+                            ),
+                        )
+                        sh.softlink(
+                            sh.path.join(
+                                workdir, inpt.rh.container.localpath()
+                            ),
+                            inpt.rh.container.localpath(),
+                        )
 
-                if cycle < 'cy42_op1':
+                if cycle < "cy42_op1":
                     # Special stuff for cy < 42
-                    logger.info('creating softlink for ficdate.')
-                    sh.softlink(sh.path.join(workdir, 'ficdate'), 'ficdate')
+                    logger.info("creating softlink for ficdate.")
+                    sh.softlink(sh.path.join(workdir, "ficdate"), "ficdate")
 
                 odb_input_size = 0
                 for obsname, obsinfo in thispack.obsfile.items():
-                    logger.info('creating softlink: %s -> %s', obsname,
-                                sh.path.join(workdir, obsinfo.rh.container.localpath()))
-                    sh.softlink(sh.path.join(workdir, obsinfo.rh.container.localpath()),
-                                obsname)
-                    if thispack.standalone and cycle < 'cy42_op1':
-                        logger.info('creating softlink: %s -> %s', thispack.standalone,
-                                    sh.path.join(workdir, obsinfo.rh.container.localpath()))
-                        sh.softlink(sh.path.join(workdir, obsinfo.rh.container.localpath()),
-                                    thispack.standalone)
+                    logger.info(
+                        "creating softlink: %s -> %s",
+                        obsname,
+                        sh.path.join(
+                            workdir, obsinfo.rh.container.localpath()
+                        ),
+                    )
+                    sh.softlink(
+                        sh.path.join(
+                            workdir, obsinfo.rh.container.localpath()
+                        ),
+                        obsname,
+                    )
+                    if thispack.standalone and cycle < "cy42_op1":
+                        logger.info(
+                            "creating softlink: %s -> %s",
+                            thispack.standalone,
+                            sh.path.join(
+                                workdir, obsinfo.rh.container.localpath()
+                            ),
+                        )
+                        sh.softlink(
+                            sh.path.join(
+                                workdir, obsinfo.rh.container.localpath()
+                            ),
+                            thispack.standalone,
+                        )
 
                     odb_input_size += obsinfo.rh.container.totalsize
 
                 # Fill the actual refdata according to information gathered in prepare stage
-                if cycle < 'cy42_op1':
+                if cycle < "cy42_op1":
                     if thispack.refdata:
-                        with open('refdata', 'w') as fd:
+                        with open("refdata", "w") as fd:
                             for rdentry in thispack.refdata:
                                 fd.write(str(rdentry + "\n"))
-                        sh.subtitle('Local refdata for: {:s}'.format(odbname))
-                        sh.cat('refdata', output=False)
+                        sh.subtitle("Local refdata for: {:s}".format(odbname))
+                        sh.cat("refdata", output=False)
                 # Drive bator with a batormap file (from cy42_op1 onward)
                 else:
-                    with open('batormap', 'w') as fd:
+                    with open("batormap", "w") as fd:
                         for mapentry in sorted(thispack.mapping):
-                            fd.write(str(ObsMapContent.formatted_data(mapentry) + '\n'))
-                    sh.subtitle('Local batormap for: {:s}'.format(odbname))
-                    sh.cat('batormap', output=False)
+                            fd.write(
+                                str(
+                                    ObsMapContent.formatted_data(mapentry)
+                                    + "\n"
+                                )
+                            )
+                    sh.subtitle("Local batormap for: {:s}".format(odbname))
+                    sh.cat("batormap", output=False)
 
                 self.obsmapout.extend(thispack.mapping)
 
                 # Compute the expected memory and time
                 if isinstance(self.parallel_const, dict):
-                    pconst = self.parallel_const.get(odbset,
-                                                     self.parallel_const.get('default', (999999., 1.)))
-                    offsets = self.parallel_const.get('offset', (0., 0.))  # In MiB for the memory
+                    pconst = self.parallel_const.get(
+                        odbset,
+                        self.parallel_const.get("default", (999999.0, 1.0)),
+                    )
+                    offsets = self.parallel_const.get(
+                        "offset", (0.0, 0.0)
+                    )  # In MiB for the memory
                 else:
-                    pconst = (999999., 1.)
-                    offsets = (0., 0.)
+                    pconst = (999999.0, 1.0)
+                    offsets = (0.0, 0.0)
                 bTime = (odb_input_size * pconst[1] / 1048576) + offsets[1]
-                bMemory = odb_input_size * pconst[0] + (offsets[0] * 1024 * 1024)
-                bMemory = bMemory / 1024. / 1024.
+                bMemory = odb_input_size * pconst[0] + (
+                    offsets[0] * 1024 * 1024
+                )
+                bMemory = bMemory / 1024.0 / 1024.0
                 if bMemory > self.effective_maxmem:
-                    logger.info("For %s, the computed memory needs exceed the node limit.", odbset)
-                    logger.info("Memory requirement reseted to %d (originally %d.)",
-                                int(self.effective_maxmem), int(bMemory))
+                    logger.info(
+                        "For %s, the computed memory needs exceed the node limit.",
+                        odbset,
+                    )
+                    logger.info(
+                        "Memory requirement reseted to %d (originally %d.)",
+                        int(self.effective_maxmem),
+                        int(bMemory),
+                    )
                     bMemory = self.effective_maxmem
-                scheduler_instructions['name'].append('ODB_database_{:s}'.format(odbset))
-                scheduler_instructions['base'].append(odbset)
-                scheduler_instructions['memory'].append(bMemory)
-                scheduler_instructions['expected_time'].append(bTime)
-                scheduler_instructions['inputsize'].append(odb_input_size)
+                scheduler_instructions["name"].append(
+                    "ODB_database_{:s}".format(odbset)
+                )
+                scheduler_instructions["base"].append(odbset)
+                scheduler_instructions["memory"].append(bMemory)
+                scheduler_instructions["expected_time"].append(bTime)
+                scheduler_instructions["inputsize"].append(odb_input_size)
 
-        sh.title('Launching Bator using taylorism...')
+        sh.title("Launching Bator using taylorism...")
         self._default_pre_execute(rh, opts)
         common_i = self._default_common_instructions(rh, opts)
         # Update the common instructions
-        common_i.update(dict(workdir=workdir, cycle=cycle, ))
+        common_i.update(
+            dict(
+                workdir=workdir,
+                cycle=cycle,
+            )
+        )
 
         self._add_instructions(common_i, scheduler_instructions)
 
         post_opts = copy.copy(opts)
-        post_opts['synthesis'] = self.para_synthesis
+        post_opts["synthesis"] = self.para_synthesis
         self._default_post_execute(rh, post_opts)
 
     def _default_rc_action(self, rh, opts, report, rc):
         super()._default_rc_action(rh, opts, report, rc)
-        my_report = report['report'].get('synthesis', None)
+        my_report = report["report"].get("synthesis", None)
         if my_report:
-            opts['synthesis'][my_report.pop('base')] = my_report
+            opts["synthesis"][my_report.pop("base")] = my_report
 
     def postfix(self, rh, opts):
         """Post conversion cleaning."""
         sh = self.system
 
         # Remove empty ECMA databases from the output obsmap
-        self.obsmapout = [x for x in self.obsmapout
-                          if (sh.path.isdir('ECMA.' + x.odb) and
-                              sh.path.isdir('ECMA.' + x.odb + '/1'))]
+        self.obsmapout = [
+            x
+            for x in self.obsmapout
+            if (
+                sh.path.isdir("ECMA." + x.odb)
+                and sh.path.isdir("ECMA." + x.odb + "/1")
+            )
+        ]
 
         # At least one non-empty database is needed...
-        self.algoassert(self.obsmapout, "At least one non-empty ODB database is expected")
+        self.algoassert(
+            self.obsmapout, "At least one non-empty ODB database is expected"
+        )
 
         # Generate the output bator_map
-        with open('batodb_map.out', 'w') as fd:
+        with open("batodb_map.out", "w") as fd:
             for x in sorted(self.obsmapout):
-                fd.write(str(ObsMapContent.formatted_data(x) + '\n'))
+                fd.write(str(ObsMapContent.formatted_data(x) + "\n"))
 
         # Generate a global refdata (if cycle allows it and if possible)
-        if rh.resource.cycle < 'cy42_op1':
-            rdrh_dict = {y.rh.resource.part: y.rh
-                         for y in self.context.sequence.effective_inputs(kind='refdata')
-                         if y.rh.resource.part != 'all'}
-            with open('refdata_global', 'w') as rdg:
+        if rh.resource.cycle < "cy42_op1":
+            rdrh_dict = {
+                y.rh.resource.part: y.rh
+                for y in self.context.sequence.effective_inputs(kind="refdata")
+                if y.rh.resource.part != "all"
+            }
+            with open("refdata_global", "w") as rdg:
                 for x in sorted(self.obsmapout):
-                    if (x.data in rdrh_dict and
-                            sh.path.getsize(rdrh_dict[x.data].container.localpath()) > 0):
-                        with open(rdrh_dict[x.data].container.localpath()) as rdl:
+                    if (
+                        x.data in rdrh_dict
+                        and sh.path.getsize(
+                            rdrh_dict[x.data].container.localpath()
+                        )
+                        > 0
+                    ):
+                        with open(
+                            rdrh_dict[x.data].container.localpath()
+                        ) as rdl:
                             rdg.write(rdl.readline())
-                    elif (sh.path.exists('refdata.' + x.data) and
-                          sh.path.getsize('refdata.' + x.data) > 0):
-                        with open('refdata.' + x.data) as rdl:
+                    elif (
+                        sh.path.exists("refdata." + x.data)
+                        and sh.path.getsize("refdata." + x.data) > 0
+                    ):
+                        with open("refdata." + x.data) as rdl:
                             rdg.write(rdl.readline())
                     else:
-                        logger.info("Unable to create a global refdata entry for data=" + x.data)
+                        logger.info(
+                            "Unable to create a global refdata entry for data="
+                            + x.data
+                        )
 
-        sh.json_dump(self.para_synthesis, 'parallel_exec_synthesis.json')
+        sh.json_dump(self.para_synthesis, "parallel_exec_synthesis.json")
 
         # Print the parallel execution summary
-        sh.subtitle('Here is the parallel execution synthesis: memory aspects')
-        header = 'Database  InputSize(MiB) PredMem(GiB) RealMem(GiB) Real/Pred Ratio'
-        rfmt = '{:8s} {:>15.0f} {:>12.1f} {:>12.1f} {:>15.2f}'
+        sh.subtitle("Here is the parallel execution synthesis: memory aspects")
+        header = "Database  InputSize(MiB) PredMem(GiB) RealMem(GiB) Real/Pred Ratio"
+        rfmt = "{:8s} {:>15.0f} {:>12.1f} {:>12.1f} {:>15.2f}"
         print(header)
         for row in sorted(self.para_synthesis.keys()):
             srep = self.para_synthesis[row]
-            print(rfmt.format(row,
-                              convert_bytes_in_unit(srep['inputsize'], 'MiB'),
-                              convert_bytes_in_unit(srep['mem_expected'], 'GiB'),
-                              (99.99 if srep['mem_real'] is None else
-                               convert_bytes_in_unit(srep['mem_real'], 'GiB')),
-                              (99.99 if srep['mem_ratio'] is None else
-                               srep['mem_ratio'])))
+            print(
+                rfmt.format(
+                    row,
+                    convert_bytes_in_unit(srep["inputsize"], "MiB"),
+                    convert_bytes_in_unit(srep["mem_expected"], "GiB"),
+                    (
+                        99.99
+                        if srep["mem_real"] is None
+                        else convert_bytes_in_unit(srep["mem_real"], "GiB")
+                    ),
+                    (
+                        99.99
+                        if srep["mem_ratio"] is None
+                        else srep["mem_ratio"]
+                    ),
+                )
+            )
 
-        sh.subtitle('Here is the parallel execution synthesis: elapsed time aspects')
-        header = 'Database  InputSize(MiB) PredTime(s) RealTime(s) Real/Pred Ratio'
-        rfmt = '{:8s} {:>15.0f} {:>11.1f} {:>11.1f} {:>15.2f}'
+        sh.subtitle(
+            "Here is the parallel execution synthesis: elapsed time aspects"
+        )
+        header = (
+            "Database  InputSize(MiB) PredTime(s) RealTime(s) Real/Pred Ratio"
+        )
+        rfmt = "{:8s} {:>15.0f} {:>11.1f} {:>11.1f} {:>15.2f}"
         print(header)
         for row in sorted(self.para_synthesis.keys()):
             srep = self.para_synthesis[row]
-            print(rfmt.format(row,
-                              convert_bytes_in_unit(srep['inputsize'], 'MiB'),
-                              srep['time_expected'], srep['time_real'],
-                              (99.99 if srep['time_ratio'] is None else srep['time_ratio'])))
+            print(
+                rfmt.format(
+                    row,
+                    convert_bytes_in_unit(srep["inputsize"], "MiB"),
+                    srep["time_expected"],
+                    srep["time_real"],
+                    (
+                        99.99
+                        if srep["time_ratio"] is None
+                        else srep["time_ratio"]
+                    ),
+                )
+            )
 
-        sh.subtitle('Here is the parallel execution synthesis: timeline')
-        header = 'Database                           StartTime(UTC) PredMem(GiB) RealTime(s) ExecSlot'
-        rfmt = '{:8s} {:>40s} {:>11.1f} {:>12.1f} {:>8s}'
+        sh.subtitle("Here is the parallel execution synthesis: timeline")
+        header = "Database                           StartTime(UTC) PredMem(GiB) RealTime(s) ExecSlot"
+        rfmt = "{:8s} {:>40s} {:>11.1f} {:>12.1f} {:>8s}"
         print(header)
-        for (row, srep) in sorted(self.para_synthesis.items(), key=lambda x: x[1]['time_start']):
-            print(rfmt.format(row, srep['time_start'],
-                              convert_bytes_in_unit(srep['mem_expected'], 'GiB'),
-                              srep['time_real'], str(srep['sched_id'])))
+        for row, srep in sorted(
+            self.para_synthesis.items(), key=lambda x: x[1]["time_start"]
+        ):
+            print(
+                rfmt.format(
+                    row,
+                    srep["time_start"],
+                    convert_bytes_in_unit(srep["mem_expected"], "GiB"),
+                    srep["time_real"],
+                    str(srep["sched_id"]),
+                )
+            )
 
-        print('\nThe memory limit was set to: {:.1f} GiB'.format(self.effective_maxmem / 1024.))
+        print(
+            "\nThe memory limit was set to: {:.1f} GiB".format(
+                self.effective_maxmem / 1024.0
+            )
+        )
 
         super().postfix(rh, opts)
 
@@ -611,22 +830,22 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
     """TODO the father of this component is very much welcome."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['average'],
+        attr=dict(
+            kind=dict(
+                values=["average"],
             ),
-            binarysingle = dict(
-                default = 'basicobsort',
+            binarysingle=dict(
+                default="basicobsort",
             ),
-            ioassign = dict(),
-            outdb = dict(
-                optional = True,
-                default  = 'ccma',
-                value    = ['ecma', 'ccma'],
+            ioassign=dict(),
+            outdb=dict(
+                optional=True,
+                default="ccma",
+                value=["ecma", "ccma"],
             ),
-            maskname = dict(
-                optional = True,
-                default  = 'mask4x4.txt',
+            maskname=dict(
+                optional=True,
+                default="mask4x4.txt",
             ),
         )
     )
@@ -637,10 +856,14 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         sh = self.system
 
         # Looking for input observations
-        obsall = [x for x in self.lookupodb() if x.rh.resource.layout.lower() == 'ecma']
+        obsall = [
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.layout.lower() == "ecma"
+        ]
         # One database at a time
         if len(obsall) != 1:
-            raise ValueError('One and only one ECMA input should be here')
+            raise ValueError("One and only one ECMA input should be here")
         self.bingo = ecma = obsall[0]
 
         # First create a fake CCMA
@@ -654,10 +877,10 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
         self.odb.ioassign_gather(ecma_path, ccma_path)
 
-        ecma_pool = sh.path.join(ecma_path, '1')
+        ecma_pool = sh.path.join(ecma_path, "1")
         if not sh.path.isdir(ecma_pool):
-            logger.error('The input ECMA base is empty')
-            self.abort('No ECMA input')
+            logger.error("The input ECMA base is empty")
+            self.abort("No ECMA input")
             return
 
         self.odb.create_poolmask(self.layout_new, ccma_path)
@@ -688,15 +911,18 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
         sh = self.system
 
-        mask = [x.rh for x in self.context.sequence.effective_inputs(kind='atmsmask')]
+        mask = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(kind="atmsmask")
+        ]
         if not mask:
-            raise ValueError('Could not find any MASK input')
+            raise ValueError("Could not find any MASK input")
 
         # Have a look to mask file
         if mask[0].container.localpath() != self.maskname:
             sh.softlink(mask[0].container.localpath(), self.maskname)
 
-        sh.subtitle('Mask')
+        sh.subtitle("Mask")
         mask[0].container.cat()
 
         # Standard execution
@@ -707,13 +933,19 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         sh = self.system
 
         with sh.cdcontext(self.layout_new):
-            for ccma in sh.glob('{:s}.*'.format(self.layout_new)):
-                slurp = sh.cat(ccma, outsplit=False).replace(self.layout_new, self.layout_in)
-                with open(ccma.replace(self.layout_new, self.layout_in), 'w') as fd:
+            for ccma in sh.glob("{:s}.*".format(self.layout_new)):
+                slurp = sh.cat(ccma, outsplit=False).replace(
+                    self.layout_new, self.layout_in
+                )
+                with open(
+                    ccma.replace(self.layout_new, self.layout_in), "w"
+                ) as fd:
                     fd.write(str(slurp))
                 sh.rm(ccma)
 
-        sh.mv(self.layout_new, self.layout_in + '.' + self.bingo.rh.resource.part)
+        sh.mv(
+            self.layout_new, self.layout_in + "." + self.bingo.rh.resource.part
+        )
 
         super().postfix(rh, opts)
 
@@ -722,30 +954,36 @@ class OdbCompress(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
     """Take a screening ODB ECMA database and create the compressed CCMA database."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['odbcompress'],
+        attr=dict(
+            kind=dict(
+                values=["odbcompress"],
             ),
-            ioassign = dict(),
+            ioassign=dict(),
         )
     )
 
     def prepare(self, rh, opts):
         """Find any ODB candidate in input files and fox ODB env accordingly."""
 
-        obsall = [x for x in self.lookupodb() if x.rh.resource.layout.lower() == 'ecma']
+        obsall = [
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.layout.lower() == "ecma"
+        ]
         if len(obsall) > 1:
-            obsvirtual = [o for o in obsall if o.rh.resource.part == 'virtual']
+            obsvirtual = [o for o in obsall if o.rh.resource.part == "virtual"]
             if len(obsvirtual) != 1:
-                raise ValueError('One and only one virtual database must be provided')
+                raise ValueError(
+                    "One and only one virtual database must be provided"
+                )
             ecma = obsvirtual[0]
         elif len(obsall) == 1:
             ecma = obsall[0]
         else:
-            raise ValueError('No ECMA database provided')
+            raise ValueError("No ECMA database provided")
 
         # First create a fake CCMA
-        self.layout_new = 'ccma'
+        self.layout_new = "ccma"
         ccma_path = self.odb_create_db(self.layout_new)
         self.odb.fix_db_path(self.layout_new, ccma_path)
 
@@ -757,7 +995,7 @@ class OdbCompress(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
         self.odb.create_poolmask(self.layout_new, ccma_path)
 
-        self.odb_rw_or_overwrite_method(* obsall)
+        self.odb_rw_or_overwrite_method(*obsall)
 
         # Let ancesters handling most of the env setting
         super().prepare(rh, opts)
@@ -777,14 +1015,14 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
     """Report some information from post-minim CCMA to post-screening ECMA base."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['matchup'],
+        attr=dict(
+            kind=dict(
+                values=["matchup"],
             ),
-            fcmalayout = dict(
-                optional = True,
-                value    = ['ecma', 'ccma', 'CCMA', 'ECMA'],
-                remap    = dict(CCMA ='ccma', ECMA = 'ecma'),
+            fcmalayout=dict(
+                optional=True,
+                value=["ecma", "ccma", "CCMA", "ECMA"],
+                remap=dict(CCMA="ccma", ECMA="ecma"),
             ),
         )
     )
@@ -796,31 +1034,40 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
         # Looking for input observations
         obsscr_virtual = [
-            x for x in self.lookupodb()
-            if x.rh.resource.stage.startswith('screen') and x.rh.resource.part == 'virtual'
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.stage.startswith("screen")
+            and x.rh.resource.part == "virtual"
         ]
         obsscr_parts = [
-            x for x in self.lookupodb()
-            if x.rh.resource.stage.startswith('screen') and x.rh.resource.part != 'virtual'
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.stage.startswith("screen")
+            and x.rh.resource.part != "virtual"
         ]
         obscompressed = [
-            x for x in self.lookupodb()
-            if x.rh.resource.stage.startswith('min') or x.rh.resource.stage.startswith('traj')
+            x
+            for x in self.lookupodb()
+            if x.rh.resource.stage.startswith("min")
+            or x.rh.resource.stage.startswith("traj")
         ]
 
         # One database at a time
         if not obsscr_virtual:
-            raise ValueError('Could not find any ODB screening input')
+            raise ValueError("Could not find any ODB screening input")
         if not obscompressed:
-            raise ValueError('Could not find any ODB minim input')
+            raise ValueError("Could not find any ODB minim input")
 
         # Set actual layout and path
         ecma = obsscr_virtual.pop(0)
         ccma = obscompressed.pop(0)
         self.layout_screening = ecma.rh.resource.layout
         self.layout_compressed = ccma.rh.resource.layout
-        self.layout_fcma = (self.layout_compressed if self.fcmalayout is None
-                            else self.fcmalayout)
+        self.layout_fcma = (
+            self.layout_compressed
+            if self.fcmalayout is None
+            else self.fcmalayout
+        )
         ecma_path = sh.path.abspath(ecma.rh.container.localpath())
         ccma_path = sh.path.abspath(ccma.rh.container.localpath())
 
@@ -829,14 +1076,17 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         self.odb.ioassign_gather(ccma_path, ecma_path)
 
         # Ok, but why ???
-        sh.cp(sh.path.join(ecma_path, 'ECMA.dd'), sh.path.join(ccma_path, 'ECMA.dd'))
+        sh.cp(
+            sh.path.join(ecma_path, "ECMA.dd"),
+            sh.path.join(ccma_path, "ECMA.dd"),
+        )
 
         # Let ancesters handling most of the env setting
         super().prepare(rh, opts)
 
         # Fix the input database intent
         self.odb_rw_or_overwrite_method(ecma)
-        self.odb_rw_or_overwrite_method(* obsscr_parts)
+        self.odb_rw_or_overwrite_method(*obsscr_parts)
 
     def spawn_command_options(self):
         """Prepare command line options to binary."""
@@ -850,45 +1100,45 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         )
 
 
-class OdbReshuffle(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
+class OdbReshuffle(
+    Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin
+):
     """Take a bunch of ECMA databases and create new ones with an updated number of pools."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['reshuffle'],
+        attr=dict(
+            kind=dict(
+                values=["reshuffle"],
             ),
         )
     )
 
-    _OUT_DIRECTORY = 'reshuffled'
-    _BARE_OUT_LAYOUT = 'ccma'
+    _OUT_DIRECTORY = "reshuffled"
+    _BARE_OUT_LAYOUT = "ccma"
 
     def prepare(self, rh, opts):
         """Find ODB candidates in input files."""
 
         # Looking for input observations
         obs_in_virtual = [
-            x for x in self.lookupodb()
-            if x.rh.resource.part == 'virtual'
+            x for x in self.lookupodb() if x.rh.resource.part == "virtual"
         ]
         if obs_in_virtual:
-            raise ValueError('Do not input a Virtual database')
+            raise ValueError("Do not input a Virtual database")
         self.obs_in_parts = [
-            x for x in self.lookupodb()
-            if x.rh.resource.part != 'virtual'
+            x for x in self.lookupodb() if x.rh.resource.part != "virtual"
         ]
 
         # Find the input layout
         in_layout = {x.rh.resource.layout for x in self.obs_in_parts}
         if len(in_layout) != 1:
-            raise ValueError('Incoherent layout in input databases or no input databases')
+            raise ValueError(
+                "Incoherent layout in input databases or no input databases"
+            )
         self.layout_in = in_layout.pop()
 
         # Some extra settings
-        self.env.update(
-            TO_ODB_FULL=1
-        )
+        self.env.update(TO_ODB_FULL=1)
 
         # prepare the ouputs' directory
         self.system.mkdir(self._OUT_DIRECTORY)
@@ -899,12 +1149,17 @@ class OdbReshuffle(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         """Loop on available databases."""
         sh = self.system
         for a_db in self.obs_in_parts:
-            sh.subtitle('Dealing with {:s}'.format(a_db.rh.container.localpath()))
+            sh.subtitle(
+                "Dealing with {:s}".format(a_db.rh.container.localpath())
+            )
 
             ecma_path = sh.path.abspath(a_db.rh.container.localpath())
-            ccma_path = sh.path.abspath(sh.path.join(self._OUT_DIRECTORY,
-                                                     '.'.join([self.layout_in.upper(),
-                                                               a_db.rh.resource.part])))
+            ccma_path = sh.path.abspath(
+                sh.path.join(
+                    self._OUT_DIRECTORY,
+                    ".".join([self.layout_in.upper(), a_db.rh.resource.part]),
+                )
+            )
             self.odb_create_db(self._BARE_OUT_LAYOUT, dbpath=ccma_path)
             self.odb.fix_db_path(self.layout_in, ecma_path)
             self.odb.fix_db_path(self._BARE_OUT_LAYOUT, ccma_path)
@@ -917,15 +1172,20 @@ class OdbReshuffle(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
             super().execute(rh, opts)
 
             # CCMA -> ECMA
-            self.odb.change_layout(self._BARE_OUT_LAYOUT, self.layout_in, ccma_path)
+            self.odb.change_layout(
+                self._BARE_OUT_LAYOUT, self.layout_in, ccma_path
+            )
 
     def postfix(self, rh, opts):
         """Create a virtual database for output data."""
-        self.system.subtitle('Creating the virtual database')
-        virtual_db = self.odb_merge_if_needed(self.obs_in_parts,
-                                              subdir=self._OUT_DIRECTORY)
-        logger.info('The output virtual DB was created: %s',
-                    self.system.path.join(self._OUT_DIRECTORY, virtual_db))
+        self.system.subtitle("Creating the virtual database")
+        virtual_db = self.odb_merge_if_needed(
+            self.obs_in_parts, subdir=self._OUT_DIRECTORY
+        )
+        logger.info(
+            "The output virtual DB was created: %s",
+            self.system.path.join(self._OUT_DIRECTORY, virtual_db),
+        )
 
     def spawn_command_options(self):
         """Prepare command line options to binary."""
@@ -936,14 +1196,16 @@ class OdbReshuffle(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         )
 
 
-class FlagsCompute(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
+class FlagsCompute(
+    Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin
+):
     """Compute observations flags."""
 
     _footprint = dict(
-        info = 'Computation of observations flags.',
-        attr = dict(
-            kind = dict(
-                values = ['flagscomp'],
+        info="Computation of observations flags.",
+        attr=dict(
+            kind=dict(
+                values=["flagscomp"],
             ),
         ),
     )
@@ -952,23 +1214,25 @@ class FlagsCompute(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         """Spawn the binary for each of the input databases."""
         # Look for the input databases
         input_databases = self.context.sequence.effective_inputs(
-            role='ECMA',
-            kind='observations',
+            role="ECMA",
+            kind="observations",
         )
         # Check that there is at least one database
         if len(input_databases) < 1:
-            raise AttributeError('No database in input. Stop.')
+            raise AttributeError("No database in input. Stop.")
 
         for input_database in input_databases:
             ecma = input_database.rh
             ecma_filename = ecma.container.filename
             # Environment variable to set DB path
             self.odb.fix_db_path(ecma.resource.layout, ecma.container.abspath)
-            self.env.setvar('ODB_ECMA', ecma_filename)
-            logger.info('Variable %s set to %s.', 'ODB_ECMA', ecma_filename)
+            self.env.setvar("ODB_ECMA", ecma_filename)
+            logger.info("Variable %s set to %s.", "ODB_ECMA", ecma_filename)
             # Path to the IOASSIGN file
-            self.env.IOASSIGN = self.system.path.join(ecma.container.abspath, 'IOASSIGN')
+            self.env.IOASSIGN = self.system.path.join(
+                ecma.container.abspath, "IOASSIGN"
+            )
             # Let ancesters handling most of the env setting
             super().execute(rh, opts)
             # Rename the output file according to the name of the part of the observations treated
-            self.system.mv('BDM_CQ', '_'.join(['BDM_CQ', ecma.resource.part]))
+            self.system.mv("BDM_CQ", "_".join(["BDM_CQ", ecma.resource.part]))

--- a/src/vortex/nwp/algo/oopsroot.py
+++ b/src/vortex/nwp/algo/oopsroot.py
@@ -11,7 +11,11 @@ from bronx.fancies.dump import lightdump, fulldump
 from bronx.stdtypes.date import Date, Time, Period
 from bronx.compat.functools import cached_property
 
-from vortex.algo.components import AlgoComponentError, AlgoComponentDecoMixin, Parallel
+from vortex.algo.components import (
+    AlgoComponentError,
+    AlgoComponentDecoMixin,
+    Parallel,
+)
 from vortex.algo.components import algo_component_deco_mixin_autodoc
 from vortex.data import geometries
 from vortex.tools import grib
@@ -25,7 +29,7 @@ __all__ = []
 logger = footprints.loggers.getLogger(__name__)
 
 
-OOPSMemberInfos = namedtuple('OOPSMemberInfos', ('member', 'date'))
+OOPSMemberInfos = namedtuple("OOPSMemberInfos", ("member", "date"))
 
 
 class EnsSizeAlgoComponentError(AlgoComponentError):
@@ -35,11 +39,17 @@ class EnsSizeAlgoComponentError(AlgoComponentError):
         self.nominal_ens_size = nominal_ens_size
         self.actual_ens_size = actual_ens_size
         self.min_ens_size = min_ens_size
-        super().__init__('{:d} found ({:d} required)'.format(actual_ens_size, min_ens_size))
+        super().__init__(
+            "{:d} found ({:d} required)".format(actual_ens_size, min_ens_size)
+        )
 
     def __reduce__(self):
         red = list(super().__reduce__())
-        red[1] = (self.nominal_ens_size, self.actual_ens_size, self.min_ens_size)
+        red[1] = (
+            self.nominal_ens_size,
+            self.actual_ens_size,
+            self.min_ens_size,
+        )
         return tuple(red)
 
 
@@ -47,17 +57,17 @@ class EnsSizeAlgoComponentError(AlgoComponentError):
 class OOPSMemberDecoMixin(AlgoComponentDecoMixin):
     """Add a member footprints' attribute and use it in the configuration files."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = (algo_member, )
+    _MIXIN_EXTRA_FOOTPRINTS = (algo_member,)
 
     def _algo_member_deco_setup(self, rh, opts):  # @UnusedVariable
         """Update the configuration files."""
         if self.member is not None:
-            self._generic_config_subs['member'] = self.member
+            self._generic_config_subs["member"] = self.member
             for namrh in self.updatable_namelists:
-                namrh.contents.setmacro('MEMBER', self.member)
-                namrh.contents.setmacro('PERTURB', self.member)
+                namrh.contents.setmacro("MEMBER", self.member)
+                namrh.contents.setmacro("PERTURB", self.member)
 
-    _MIXIN_PREPARE_HOOKS = (_algo_member_deco_setup, )
+    _MIXIN_PREPARE_HOOKS = (_algo_member_deco_setup,)
 
 
 @algo_component_deco_mixin_autodoc
@@ -73,42 +83,49 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
     :note: Effective terms are considered (i.e term - (current_date - resource_date))
     """
 
-    _membersdetect_roles = tuple(p + r
-                                 for p in ('', 'Ensemble')
-                                 for r in ('ModelState',
-                                           'Guess',
-                                           'InitialCondition',
-                                           'Background',
-                                           'SurfaceModelState',
-                                           'SurfaceGuess',
-                                           'SurfaceInitialCondition',
-                                           'SurfaceBackground',)
-                                 )
-
-    _MIXIN_EXTRA_FOOTPRINTS = (footprints.Footprint(
-        info="Abstract mbdetect footprint",
-        attr=dict(
-            ens_minsize=dict(
-                info="For a multi-member algocomponent, the minimum of the ensemble.",
-                optional=True,
-                type=int
-            ),
-            ens_failure_conf_objects=dict(
-                info="For a multi-member algocomponent, alternative config file when the ensemble is too small.",
-                optional=True,
-            ),
-            strict_mbdetect=dict(
-                info="Performs a strict members/terms detection",
-                type=bool,
-                optional=True,
-                default=True,
-                doc_zorder=-60,
-            )
+    _membersdetect_roles = tuple(
+        p + r
+        for p in ("", "Ensemble")
+        for r in (
+            "ModelState",
+            "Guess",
+            "InitialCondition",
+            "Background",
+            "SurfaceModelState",
+            "SurfaceGuess",
+            "SurfaceInitialCondition",
+            "SurfaceBackground",
         )
-    ),)
+    )
+
+    _MIXIN_EXTRA_FOOTPRINTS = (
+        footprints.Footprint(
+            info="Abstract mbdetect footprint",
+            attr=dict(
+                ens_minsize=dict(
+                    info="For a multi-member algocomponent, the minimum of the ensemble.",
+                    optional=True,
+                    type=int,
+                ),
+                ens_failure_conf_objects=dict(
+                    info="For a multi-member algocomponent, alternative config file when the ensemble is too small.",
+                    optional=True,
+                ),
+                strict_mbdetect=dict(
+                    info="Performs a strict members/terms detection",
+                    type=bool,
+                    optional=True,
+                    default=True,
+                    doc_zorder=-60,
+                ),
+            ),
+        ),
+    )
 
     @staticmethod
-    def _stateless_members_detect(smap, basedate, section_check_cb, ensminsize=None, utest=False):
+    def _stateless_members_detect(
+        smap, basedate, section_check_cb, ensminsize=None, utest=False
+    ):
         """
         This method does not really need to be static but this way it allows for
         unit-testing (see ``tests.tests_algo.test_oopspara.py``).
@@ -124,15 +141,22 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
         for arole, srole in smap.items():
             # Gather data
             for s in srole:
-                minfo = OOPSMemberInfos(getattr(s.rh.provider, 'member', None),
-                                        getattr(s.rh.resource, 'date', None))
-                allmembers[arole][minfo][getattr(s.rh.resource, 'term', None)].add(s)
+                minfo = OOPSMemberInfos(
+                    getattr(s.rh.provider, "member", None),
+                    getattr(s.rh.resource, "date", None),
+                )
+                allmembers[arole][minfo][
+                    getattr(s.rh.resource, "term", None)
+                ].add(s)
             # Sanity checks and filtering
             role_members_info = set(allmembers[arole].keys())
             if None in {a_member.member for a_member in role_members_info}:
                 # Ignore sections when some sections have no members defined
                 if len(role_members_info) > 1:
-                    logger.warning('Role: %s. Only some sections have a member number.', arole)
+                    logger.warning(
+                        "Role: %s. Only some sections have a member number.",
+                        arole,
+                    )
                 role_members_info = set()
             if len(role_members_info) > 1:
                 if not members:
@@ -140,7 +164,9 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
                 else:
                     # Consistency check on members numbering
                     if members != role_members_info:
-                        raise AlgoComponentError('Inconsistent members numbering')
+                        raise AlgoComponentError(
+                            "Inconsistent members numbering"
+                        )
             else:
                 # If there is only one member, ignore it: it's not really an ensemble!
                 del allmembers[arole]
@@ -155,14 +181,19 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
             # Be verbose...
             if lagged:
                 for a_date, a_mset in members_by_date.items():
-                    logger.info('Members detected from date=%s: %s',
-                                a_date, ','.join(sorted(str(m) for m in a_mset)))
+                    logger.info(
+                        "Members detected from date=%s: %s",
+                        a_date,
+                        ",".join(sorted(str(m) for m in a_mset)),
+                    )
             else:
-                logger.info('Members detected: %s',
-                            ','.join(sorted(str(m[0]) for m in members)))
-            logger.info('Total number of detected members: %d', len(members))
+                logger.info(
+                    "Members detected: %s",
+                    ",".join(sorted(str(m[0]) for m in members)),
+                )
+            logger.info("Total number of detected members: %d", len(members))
             r_members = sorted(allmembers.keys())
-            logger.info('Members roles: %s', ','.join(r_members))
+            logger.info("Members roles: %s", ",".join(r_members))
 
         # Look for effective terms
         alleffterms = dict()
@@ -171,24 +202,30 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
             for minfo, mterms in srole.items():
                 effterms = set()
                 for term in mterms.keys():
-                    effterms.add(term - (basedate - minfo.date)
-                                 if term is not None and minfo.date is not None
-                                 else None)
+                    effterms.add(
+                        term - (basedate - minfo.date)
+                        if term is not None and minfo.date is not None
+                        else None
+                    )
                 # Intra-role consistency
                 if first_effterms is None:
                     first_effterms = effterms
                 else:
                     # Consistency check on members numbering
                     if effterms != first_effterms:
-                        raise AlgoComponentError('Inconsistent effective terms between members sets (role={:s})'
-                                                 .format(arole))
+                        raise AlgoComponentError(
+                            "Inconsistent effective terms between members sets (role={:s})".format(
+                                arole
+                            )
+                        )
             # If there are more than one term, consider it
             if len(first_effterms) > 1:
                 # Check that there is no None in the way
                 if None in first_effterms:
                     raise AlgoComponentError(
-                        'For a given role, all of the resources or none of then should have a term (role={:s})'
-                        .format(arole)
+                        "For a given role, all of the resources or none of then should have a term (role={:s})".format(
+                            arole
+                        )
                     )
             # Remove Nones
             first_effterms = {e for e in first_effterms if e is not None}
@@ -200,19 +237,34 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
         l_effterms = []
         if alleffterms:
             # Hard check only when multiple effetive terms are found
-            multieffterms = {r: ets for r, ets in alleffterms.items() if len(ets) > 1}
+            multieffterms = {
+                r: ets for r, ets in alleffterms.items() if len(ets) > 1
+            }
             if multieffterms:
-                if sum(1 for _ in itertools.groupby(multieffterms.values())) > 1:
-                    raise AlgoComponentError('Inconsistent effective terms between relevant roles')
+                if (
+                    sum(1 for _ in itertools.groupby(multieffterms.values()))
+                    > 1
+                ):
+                    raise AlgoComponentError(
+                        "Inconsistent effective terms between relevant roles"
+                    )
                 r_effterms = sorted(multieffterms.keys())
                 _, l_effterms = multieffterms.popitem()
             else:
-                if sum(1 for _ in itertools.groupby(alleffterms.values())) == 1:
+                if (
+                    sum(1 for _ in itertools.groupby(alleffterms.values()))
+                    == 1
+                ):
                     r_effterms = sorted(alleffterms.keys())
                     _, l_effterms = alleffterms.popitem()
             l_effterms = sorted(l_effterms)
-            logger.info('Effective terms detected: %s', ','.join([str(t) for t in effterms]))
-            logger.info('Terms roles: %s', ','.join(sorted(alleffterms.keys())))
+            logger.info(
+                "Effective terms detected: %s",
+                ",".join([str(t) for t in effterms]),
+            )
+            logger.info(
+                "Terms roles: %s", ",".join(sorted(alleffterms.keys()))
+            )
 
         # Theoretical ensemble size
         nominal_ens_size = len(members)
@@ -222,55 +274,87 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
                 # Look for missing resources in the various relevant roles
                 broken = list()
                 for arole in allmembers.keys():
-                    broken.extend([(s, arole)
-                                   for t, slist in allmembers[arole][mb].items()
-                                   for s in slist
-                                   if not section_check_cb(s)])
+                    broken.extend(
+                        [
+                            (s, arole)
+                            for t, slist in allmembers[arole][mb].items()
+                            for s in slist
+                            if not section_check_cb(s)
+                        ]
+                    )
                 for s, arole in broken:
                     if not utest:
-                        logger.warning('Missing items: %s (role: %s).',
-                                       s.rh.container.localpath(), arole)
+                        logger.warning(
+                            "Missing items: %s (role: %s).",
+                            s.rh.container.localpath(),
+                            arole,
+                        )
                 if broken:
-                    logger.warning('Throwing away member: %s', mb)
+                    logger.warning("Throwing away member: %s", mb)
                 else:
                     eff_members.add(mb)
             # Sanity checks depending on ensminsize
             if ensminsize is None and len(eff_members) != nominal_ens_size:
-                raise EnsSizeAlgoComponentError(nominal_ens_size, len(eff_members), nominal_ens_size)
+                raise EnsSizeAlgoComponentError(
+                    nominal_ens_size, len(eff_members), nominal_ens_size
+                )
             elif ensminsize is not None and len(eff_members) < ensminsize:
-                raise EnsSizeAlgoComponentError(nominal_ens_size, len(eff_members), ensminsize)
+                raise EnsSizeAlgoComponentError(
+                    nominal_ens_size, len(eff_members), ensminsize
+                )
 
             members = eff_members
 
         l_members = [m.member for m in sorted(members)]
         l_members_d = [m.date for m in sorted(members)]
-        l_members_o = [None if m.date is None else (basedate - m.date)
-                       for m in sorted(members)]
+        l_members_o = [
+            None if m.date is None else (basedate - m.date)
+            for m in sorted(members)
+        ]
 
-        return (l_members, l_members_d, l_members_o, l_effterms,
-                lagged, nominal_ens_size, r_members, r_effterms)
+        return (
+            l_members,
+            l_members_d,
+            l_members_o,
+            l_effterms,
+            lagged,
+            nominal_ens_size,
+            r_members,
+            r_effterms,
+        )
 
     def members_detect(self):
         """Detect the members/terms list and update the substitution dictionary."""
-        sectionsmap = {r: self.context.sequence.filtered_inputs(role=r, no_alternates=True)
-                       for r in self._membersdetect_roles}
+        sectionsmap = {
+            r: self.context.sequence.filtered_inputs(
+                role=r, no_alternates=True
+            )
+            for r in self._membersdetect_roles
+        }
         try:
-            (self._ens_members_num,
-             self._ens_members_date,
-             self._ens_members_offset,
-             self._ens_effterms,
-             self._ens_is_lagged,
-             self._ens_nominal_size,
-             _, _) = self._stateless_members_detect(sectionsmap,
-                                                    self.date,
-                                                    self.context.sequence.is_somehow_viable,
-                                                    self.ens_minsize)
+            (
+                self._ens_members_num,
+                self._ens_members_date,
+                self._ens_members_offset,
+                self._ens_effterms,
+                self._ens_is_lagged,
+                self._ens_nominal_size,
+                _,
+                _,
+            ) = self._stateless_members_detect(
+                sectionsmap,
+                self.date,
+                self.context.sequence.is_somehow_viable,
+                self.ens_minsize,
+            )
         except EnsSizeAlgoComponentError as e:
             if self.strict_mbdetect and self.ens_failure_conf_objects is None:
                 raise
             else:
                 logger.warning("Members detection failed: %s", str(e))
-                logger.info("'strict_mbdetect' is False... going on with empty lists.")
+                logger.info(
+                    "'strict_mbdetect' is False... going on with empty lists."
+                )
                 self._ens_members_num = []
                 self._ens_members_date = []
                 self._ens_members_offset = []
@@ -281,12 +365,17 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
                     # Find the new configuration object
                     main_conf = None
                     for sconf, ssub in self._individual_config_subs.items():
-                        if getattr(sconf.rh.resource, 'objects', '') == self.ens_failure_conf_objects:
+                        if (
+                            getattr(sconf.rh.resource, "objects", "")
+                            == self.ens_failure_conf_objects
+                        ):
                             main_conf = sconf
                             main_conf_sub = ssub
                             break
                     if main_conf is None:
-                        raise AlgoComponentError('Alternative configuration file was not found')
+                        raise AlgoComponentError(
+                            "Alternative configuration file was not found"
+                        )
                     # Update the config ordered dictionary
                     del self._individual_config_subs[main_conf]
                     new_individual_config_subs = OrderedDict()
@@ -294,31 +383,40 @@ class OOPSMembersTermsDetectDecoMixin(AlgoComponentDecoMixin):
                     for sconf, ssub in self._individual_config_subs.items():
                         new_individual_config_subs[sconf] = ssub
                     self._individual_config_subs = new_individual_config_subs
-                    logger.info("Using an alternative configuration file (objects=%s, role=%s)",
-                                self.ens_failure_conf_objects, main_conf.role)
+                    logger.info(
+                        "Using an alternative configuration file (objects=%s, role=%s)",
+                        self.ens_failure_conf_objects,
+                        main_conf.role,
+                    )
 
-        self._generic_config_subs['ens_members_num'] = self._ens_members_num
-        self._generic_config_subs['ens_members_date'] = self._ens_members_date
-        self._generic_config_subs['ens_members_offset'] = self._ens_members_offset
-        self._generic_config_subs['ens_is_lagged'] = self._ens_is_lagged
+        self._generic_config_subs["ens_members_num"] = self._ens_members_num
+        self._generic_config_subs["ens_members_date"] = self._ens_members_date
+        self._generic_config_subs["ens_members_offset"] = (
+            self._ens_members_offset
+        )
+        self._generic_config_subs["ens_is_lagged"] = self._ens_is_lagged
         # Legacy:
-        self._generic_config_subs['members'] = self._ens_members_num
+        self._generic_config_subs["members"] = self._ens_members_num
         # Namelist stuff
         for namrh in self.updatable_namelists:
-            namrh.contents.setmacro('ENS_MEMBERS', len(self._ens_members_num))
+            namrh.contents.setmacro("ENS_MEMBERS", len(self._ens_members_num))
             if self._ens_members_num:
-                namrh.contents.setmacro('ENS_AUTO_NSTRIN', len(self._ens_members_num))
+                namrh.contents.setmacro(
+                    "ENS_AUTO_NSTRIN", len(self._ens_members_num)
+                )
             else:
-                namrh.contents.setmacro('ENS_AUTO_NSTRIN', self._ens_nominal_size)
-        self._generic_config_subs['ens_effterms'] = self._ens_effterms
+                namrh.contents.setmacro(
+                    "ENS_AUTO_NSTRIN", self._ens_nominal_size
+                )
+        self._generic_config_subs["ens_effterms"] = self._ens_effterms
         # Legacy:
-        self._generic_config_subs['effterms'] = self._ens_effterms
+        self._generic_config_subs["effterms"] = self._ens_effterms
 
     def _membersd_setup(self, rh, opts):  # @UnusedVariable
         """Set up the members/terms detection."""
         self.members_detect()
 
-    _MIXIN_PREPARE_HOOKS = (_membersd_setup, )
+    _MIXIN_PREPARE_HOOKS = (_membersd_setup,)
 
 
 @algo_component_deco_mixin_autodoc
@@ -331,137 +429,171 @@ class OOPSMembersTermsDecoMixin(AlgoComponentDecoMixin):
     the configuration file substitutions dictionary ``_generic_config_subs``.
     """
 
-    _MIXIN_EXTRA_FOOTPRINTS = (oops_members_terms_lists, )
+    _MIXIN_EXTRA_FOOTPRINTS = (oops_members_terms_lists,)
 
     def _membersterms_deco_setup(self, rh, opts):  # @UnusedVariable
         """Setup the configuration file."""
-        actualmembers = [m if isinstance(m, int) else int(m)
-                         for m in self.members]
-        actualterms = [t if isinstance(t, Time) else Time(t)
-                       for t in self.terms]
-        self._generic_config_subs['members'] = actualmembers
-        self._generic_config_subs['effterms'] = actualterms
+        actualmembers = [
+            m if isinstance(m, int) else int(m) for m in self.members
+        ]
+        actualterms = [
+            t if isinstance(t, Time) else Time(t) for t in self.terms
+        ]
+        self._generic_config_subs["members"] = actualmembers
+        self._generic_config_subs["effterms"] = actualterms
 
-    _MIXIN_PREPARE_HOOKS = (_membersterms_deco_setup, )
+    _MIXIN_PREPARE_HOOKS = (_membersterms_deco_setup,)
 
 
 @algo_component_deco_mixin_autodoc
 class OOPSTimestepDecoMixin(AlgoComponentDecoMixin):
     """Add a timsestep attribute and handle substitutions."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = (footprints.Footprint(
-        info="Abstract timestep footprint",
-        attr=dict(
-            timestep=dict(
-                info="A possible model timestep (in seconds).",
-                optional=True,
-                type=float
+    _MIXIN_EXTRA_FOOTPRINTS = (
+        footprints.Footprint(
+            info="Abstract timestep footprint",
+            attr=dict(
+                timestep=dict(
+                    info="A possible model timestep (in seconds).",
+                    optional=True,
+                    type=float,
+                ),
             ),
         ),
-    ),)
+    )
 
     def _timestep_deco_setup(self, rh, opts):  # @UnusedVariable
         """Set up the timestep in config and namelists."""
         if self.timestep is not None:
-            self._generic_config_subs['timestep'] = Period(seconds=self.timestep)
+            self._generic_config_subs["timestep"] = Period(
+                seconds=self.timestep
+            )
             logger.info("Set macro TIMESTEP=%f in namelists.", self.timestep)
             for namrh in self.updatable_namelists:
-                namrh.contents.setmacro('TIMESTEP', self.timestep)
+                namrh.contents.setmacro("TIMESTEP", self.timestep)
 
-    _MIXIN_PREPARE_HOOKS = (_timestep_deco_setup, )
+    _MIXIN_PREPARE_HOOKS = (_timestep_deco_setup,)
 
 
 @algo_component_deco_mixin_autodoc
 class OOPSIncrementalDecoMixin(AlgoComponentDecoMixin):
     """Add incremental attributes and handle substitutions."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = (footprints.Footprint(
-        info="Abstract incremental_* footprint",
-        attr=dict(
-            incremental_tsteps=dict(
-                info="Timestep for each of the outer loop iteration (in seconds).",
-                optional=True,
-                type=footprints.FPList,
-                default=footprints.FPList(),
-            ),
-            incremental_niters=dict(
-                info="Inner loop size for each of the outer loop iteration.",
-                optional=True,
-                type=footprints.FPList,
-                default=footprints.FPList(),
-            ),
-            incremental_geos=dict(
-                info="Geometry for each of the outer loop iteration.",
-                optional=True,
-                type=footprints.FPList,
-                default=footprints.FPList(),
+    _MIXIN_EXTRA_FOOTPRINTS = (
+        footprints.Footprint(
+            info="Abstract incremental_* footprint",
+            attr=dict(
+                incremental_tsteps=dict(
+                    info="Timestep for each of the outer loop iteration (in seconds).",
+                    optional=True,
+                    type=footprints.FPList,
+                    default=footprints.FPList(),
+                ),
+                incremental_niters=dict(
+                    info="Inner loop size for each of the outer loop iteration.",
+                    optional=True,
+                    type=footprints.FPList,
+                    default=footprints.FPList(),
+                ),
+                incremental_geos=dict(
+                    info="Geometry for each of the outer loop iteration.",
+                    optional=True,
+                    type=footprints.FPList,
+                    default=footprints.FPList(),
+                ),
             ),
         ),
-    ),)
+    )
 
     def _incremental_deco_setup(self, rh, opts):  # @UnusedVariable
         """Set up the incremental DA settings in config and namelists."""
         if self.incremental_tsteps or self.incremental_niters:
-            sizes = {len(t) for t in [self.incremental_tsteps,
-                                      self.incremental_niters,
-                                      self.incremental_geos] if t}
+            sizes = {
+                len(t)
+                for t in [
+                    self.incremental_tsteps,
+                    self.incremental_niters,
+                    self.incremental_geos,
+                ]
+                if t
+            }
             if len(sizes) != 1:
-                raise ValueError('Inconsistent sizes between incr_tsteps and incr_niters')
+                raise ValueError(
+                    "Inconsistent sizes between incr_tsteps and incr_niters"
+                )
             actual_tsteps = [float(t) for t in (self.incremental_tsteps or ())]
             actual_tsteps_p = [Period(seconds=t) for t in actual_tsteps]
             actual_niters = [int(t) for t in (self.incremental_niters or ())]
-            actual_geos = [g if isinstance(g, geometries.Geometry) else geometries.get(tag=g)
-                           for g in (self.incremental_geos or ())]
+            actual_geos = [
+                g
+                if isinstance(g, geometries.Geometry)
+                else geometries.get(tag=g)
+                for g in (self.incremental_geos or ())
+            ]
             if actual_tsteps:
-                self._generic_config_subs['incremental_tsteps'] = actual_tsteps_p
+                self._generic_config_subs["incremental_tsteps"] = (
+                    actual_tsteps_p
+                )
                 for upd_i, tstep in enumerate(actual_tsteps, start=1):
-                    logger.info("Set macro UPD%d_TIMESTEP=%f macro in namelists.",
-                                upd_i, tstep)
+                    logger.info(
+                        "Set macro UPD%d_TIMESTEP=%f macro in namelists.",
+                        upd_i,
+                        tstep,
+                    )
                     for namrh in self.updatable_namelists:
-                        namrh.contents.setmacro('UPD{:d}_TIMESTEP'.format(upd_i), tstep)
+                        namrh.contents.setmacro(
+                            "UPD{:d}_TIMESTEP".format(upd_i), tstep
+                        )
             if actual_niters:
-                self._generic_config_subs['incremental_niters'] = actual_niters
+                self._generic_config_subs["incremental_niters"] = actual_niters
                 for upd_i, niter in enumerate(actual_niters, start=1):
-                    logger.info("Set macro UPD%d_NITER=%d macro in namelists.",
-                                upd_i, niter)
+                    logger.info(
+                        "Set macro UPD%d_NITER=%d macro in namelists.",
+                        upd_i,
+                        niter,
+                    )
                     for namrh in self.updatable_namelists:
-                        namrh.contents.setmacro('UPD{:d}_NITER'.format(upd_i), niter)
+                        namrh.contents.setmacro(
+                            "UPD{:d}_NITER".format(upd_i), niter
+                        )
             if actual_geos:
-                self._generic_config_subs['incremental_geos'] = actual_geos
+                self._generic_config_subs["incremental_geos"] = actual_geos
 
     _MIXIN_PREPARE_HOOKS = (_incremental_deco_setup,)
 
 
-class OOPSParallel(Parallel,
-                   drhook.DrHookDecoMixin,
-                   grib.EcGribDecoMixin,
-                   satrad.SatRadDecoMixin):
+class OOPSParallel(
+    Parallel,
+    drhook.DrHookDecoMixin,
+    grib.EcGribDecoMixin,
+    satrad.SatRadDecoMixin,
+):
     """Abstract AlgoComponent for any OOPS run."""
 
     _abstract = True
     _footprint = dict(
-        info = "Any OOPS Run (abstract).",
-        attr = dict(
-            kind = dict(
-                values          = ['oorun'],
+        info="Any OOPS Run (abstract).",
+        attr=dict(
+            kind=dict(
+                values=["oorun"],
             ),
-            date = dict(
-                info            = 'The current run date.',
-                access          = 'rwx',
-                type            = Date,
-                doc_zorder      = -50,
+            date=dict(
+                info="The current run date.",
+                access="rwx",
+                type=Date,
+                doc_zorder=-50,
             ),
-            config_subs = dict(
-                info            = "Substitutions to be performed in the config file (before run)",
-                optional        = True,
-                type            = footprints.FPDict,
-                default         = footprints.FPDict(),
-                doc_zorder      = -60,
+            config_subs=dict(
+                info="Substitutions to be performed in the config file (before run)",
+                optional=True,
+                type=footprints.FPDict,
+                default=footprints.FPDict(),
+                doc_zorder=-60,
             ),
             binarysingle=dict(
-                default         = 'basicnwp',
+                default="basicnwp",
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -480,11 +612,11 @@ class OOPSParallel(Parallel,
     def valid_executable(self, rh):
         """Be sure that the specified executable has a cycle attribute."""
         valid = super().valid_executable(rh)
-        if hasattr(rh.resource, 'cycle'):
+        if hasattr(rh.resource, "cycle"):
             self._oops_cycle = rh.resource.cycle
             return valid
         else:
-            logger.error('The binary < %s > has no cycle attribute', repr(rh))
+            logger.error("The binary < %s > has no cycle attribute", repr(rh))
             return False
 
     def prepare(self, rh, opts):
@@ -508,24 +640,31 @@ class OOPSParallel(Parallel,
         """Prepare options for the binary's command line."""
         mconfig = list(self._individual_config_subs.keys())[0]
         configfile = mconfig.rh.container.localpath()
-        options = {'configfile': configfile}
+        options = {"configfile": configfile}
         return options
 
     @cached_property
     def updatable_namelists(self):
-        return [s.rh for s in self.context.sequence.effective_inputs(role='Namelist')]
+        return [
+            s.rh
+            for s in self.context.sequence.effective_inputs(role="Namelist")
+        ]
 
     def set_config_rendering(self):
         """
         Look into effective inputs for configuration files and register them for
         a later rendering using bronx' templating system.
         """
-        mconfig = self.context.sequence.effective_inputs(role='MainConfig')
-        gconfig = self.context.sequence.effective_inputs(role='Config')
+        mconfig = self.context.sequence.effective_inputs(role="MainConfig")
+        gconfig = self.context.sequence.effective_inputs(role="Config")
         if len(mconfig) > 1:
-            raise AlgoComponentError("Only one Main Config section may be provided.")
+            raise AlgoComponentError(
+                "Only one Main Config section may be provided."
+            )
         if len(mconfig) == 0 and len(gconfig) != 1:
-            raise AlgoComponentError("Please provide a Main Config section or a unique Config section.")
+            raise AlgoComponentError(
+                "Please provide a Main Config section or a unique Config section."
+            )
         if len(mconfig) == 1:
             gconfig.insert(0, mconfig[0])
         self._individual_config_subs = {sconf: dict() for sconf in gconfig}
@@ -534,40 +673,53 @@ class OOPSParallel(Parallel,
         """Render registered configuration files using the bronx' templating system."""
         l_first = True
         for sconf, sdict in self._individual_config_subs.items():
-            self.system.subtitle('Configuration file rendering for: {:s}'
-                                 .format(sconf.rh.container.localpath()))
+            self.system.subtitle(
+                "Configuration file rendering for: {:s}".format(
+                    sconf.rh.container.localpath()
+                )
+            )
             l_subs = dict(now=self.date, date=self.date)
             l_subs.update(self._generic_config_subs)
             l_subs.update(sdict)
             l_subs.update(self.config_subs)
             if l_subs != self._last_l_subs.get(sconf, dict()):
-                if not hasattr(sconf.rh.contents, 'bronx_tpl_render'):
-                    logger.error('The < %s > content object has no "bronx_tpl_render" method. Skipping it.',
-                                 repr(sconf.rh.contents))
+                if not hasattr(sconf.rh.contents, "bronx_tpl_render"):
+                    logger.error(
+                        'The < %s > content object has no "bronx_tpl_render" method. Skipping it.',
+                        repr(sconf.rh.contents),
+                    )
                     continue
                 try:
-                    sconf.rh.contents.bronx_tpl_render(** l_subs)
+                    sconf.rh.contents.bronx_tpl_render(**l_subs)
                 except Exception:
-                    logger.error('The config file rendering failed. The substitution dict was: \n%s',
-                                 lightdump(l_subs))
+                    logger.error(
+                        "The config file rendering failed. The substitution dict was: \n%s",
+                        lightdump(l_subs),
+                    )
                     raise
                 self._last_l_subs[sconf] = l_subs
                 if l_first:
                     print(fulldump(sconf.rh.contents.data))
                 sconf.rh.save()
             else:
-                logger.info("It's not necessary to update the file (no changes).")
+                logger.info(
+                    "It's not necessary to update the file (no changes)."
+                )
             l_first = False
 
     def do_namelist_rendering(self):
-        todo = [r for r in self.updatable_namelists if r.contents.dumps_needs_update]
-        self.system.subtitle('Updating namelists')
+        todo = [
+            r
+            for r in self.updatable_namelists
+            if r.contents.dumps_needs_update
+        ]
+        self.system.subtitle("Updating namelists")
         if todo:
             for namrh in todo:
-                logger.info('Rewriting %s.', namrh.container.localpath())
+                logger.info("Rewriting %s.", namrh.container.localpath())
                 namrh.save()
         else:
-            logger.info('None of the namelists need to be rewritten.')
+            logger.info("None of the namelists need to be rewritten.")
 
     def boost_defaults(self):
         """Set defaults for BOOST environment variables.
@@ -576,14 +728,14 @@ class OOPSParallel(Parallel,
         depends on the code's cycle number.
         """
         defaults = {
-            IfsCycle('cy1'): {
-                'BOOST_TEST_CATCH_SYSTEM_ERRORS': 'no',
-                'BOOST_TEST_DETECT_FP_EXCEPTIONS': 'no',
-                'BOOST_TEST_LOG_FORMAT': 'XML',
-                'BOOST_TEST_LOG_LEVEL': 'message',
-                'BOOST_TEST_OUTPUT_FORMAT': 'XML',
-                'BOOST_TEST_REPORT_FORMAT': 'XML',
-                'BOOST_TEST_RESULT_CODE': 'yes'
+            IfsCycle("cy1"): {
+                "BOOST_TEST_CATCH_SYSTEM_ERRORS": "no",
+                "BOOST_TEST_DETECT_FP_EXCEPTIONS": "no",
+                "BOOST_TEST_LOG_FORMAT": "XML",
+                "BOOST_TEST_LOG_LEVEL": "message",
+                "BOOST_TEST_OUTPUT_FORMAT": "XML",
+                "BOOST_TEST_REPORT_FORMAT": "XML",
+                "BOOST_TEST_RESULT_CODE": "yes",
             }
         }
         cydefaults = None
@@ -591,9 +743,11 @@ class OOPSParallel(Parallel,
             if k < self.oops_cycle:
                 cydefaults = defdict
                 break
-        self.algoassert(cydefaults is not None,
-                        'BOOST defaults not found for cycle: {!s}'.format(self.oops_cycle))
-        logger.info('Setting up BOOST defaults:%s', lightdump(cydefaults))
+        self.algoassert(
+            cydefaults is not None,
+            "BOOST defaults not found for cycle: {!s}".format(self.oops_cycle),
+        )
+        logger.info("Setting up BOOST defaults:%s", lightdump(cydefaults))
         self.env.default(**cydefaults)
 
     def eckit_defaults(self):
@@ -603,10 +757,12 @@ class OOPSParallel(Parallel,
         depends on the code's cycle number.
         """
         defaults = {
-            IfsCycle('cy1'): {
-                'ECKIT_MPI_INIT_THREAD': ('MPI_THREAD_MULTIPLE'
-                                          if int(self.env.get('OMP_NUM_THREADS', '1')) > 1
-                                          else 'MPI_THREAD_SINGLE'),
+            IfsCycle("cy1"): {
+                "ECKIT_MPI_INIT_THREAD": (
+                    "MPI_THREAD_MULTIPLE"
+                    if int(self.env.get("OMP_NUM_THREADS", "1")) > 1
+                    else "MPI_THREAD_SINGLE"
+                ),
             }
         }
         cydefaults = None
@@ -614,9 +770,11 @@ class OOPSParallel(Parallel,
             if k < self.oops_cycle:
                 cydefaults = defdict
                 break
-        self.algoassert(cydefaults is not None,
-                        'eckit defaults not found for cycle: {!s}'.format(self.oops_cycle))
-        logger.info('Setting up eckit defaults:%s', lightdump(cydefaults))
+        self.algoassert(
+            cydefaults is not None,
+            "eckit defaults not found for cycle: {!s}".format(self.oops_cycle),
+        )
+        logger.info("Setting up eckit defaults:%s", lightdump(cydefaults))
         self.env.default(**cydefaults)
 
 
@@ -625,15 +783,15 @@ class OOPSODB(OOPSParallel, odb.OdbComponentDecoMixin):
 
     _abstract = True
     _footprint = dict(
-        info = "OOPS ObsOperator Test run.",
-        attr = dict(
-            kind = dict(
-                values      = ['oorunodb'],
+        info="OOPS ObsOperator Test run.",
+        attr=dict(
+            kind=dict(
+                values=["oorunodb"],
             ),
-            binarysingle = dict(
-                default     = 'basicnwpobsort',
+            binarysingle=dict(
+                default="basicnwpobsort",
             ),
-        )
+        ),
     )
 
     #: If ``True``, an empty CCMA database will be created before the run and
@@ -648,18 +806,24 @@ class OOPSODB(OOPSParallel, odb.OdbComponentDecoMixin):
 
         # Looking for input observations
         allodb = self.lookupodb()
-        allcma = [x for x in allodb if x.rh.resource.layout.lower() == self.virtualdb]
-        if self.virtualdb.lower() == 'ccma':
-            self.algoassert(len(allcma) == 1, 'A unique CCMA database is to be provided.')
-            self.algoassert(not self._OOPSODB_CCMA_DIRECT,
-                            '_OOPSODB_CCMA_DIRECT needs to be False if virtualdb=ccma.')
+        allcma = [
+            x for x in allodb if x.rh.resource.layout.lower() == self.virtualdb
+        ]
+        if self.virtualdb.lower() == "ccma":
+            self.algoassert(
+                len(allcma) == 1, "A unique CCMA database is to be provided."
+            )
+            self.algoassert(
+                not self._OOPSODB_CCMA_DIRECT,
+                "_OOPSODB_CCMA_DIRECT needs to be False if virtualdb=ccma.",
+            )
             cma = allcma[0]
             cma_path = sh.path.abspath(cma.rh.container.localpath())
         else:
             cma_path = self.odb_merge_if_needed(allcma)
             if self._OOPSODB_CCMA_DIRECT:
-                ccma_path = self.odb_create_db(layout='CCMA')
-                self.odb.fix_db_path('CCMA', ccma_path)
+                ccma_path = self.odb_create_db(layout="CCMA")
+                self.odb.fix_db_path("CCMA", ccma_path)
 
         # Set ODB environment
         self.odb.fix_db_path(self.virtualdb, cma_path)
@@ -669,51 +833,61 @@ class OOPSODB(OOPSParallel, odb.OdbComponentDecoMixin):
         else:
             self.odb.ioassign_gather(cma_path)
 
-        if self.virtualdb.lower() != 'ccma':
+        if self.virtualdb.lower() != "ccma":
             self.odb.create_poolmask(self.virtualdb, cma_path)
-            self.odb.shuffle_setup(self.slots,
-                                   mergedirect=True,
-                                   ccmadirect=self._OOPSODB_CCMA_DIRECT)
+            self.odb.shuffle_setup(
+                self.slots,
+                mergedirect=True,
+                ccmadirect=self._OOPSODB_CCMA_DIRECT,
+            )
 
         # Fix the input databases intent
-        self.odb_rw_or_overwrite_method(* allcma)
+        self.odb_rw_or_overwrite_method(*allcma)
 
         # Look for extras ODB raw
         self.odb_handle_raw_dbs()
 
         # Allow assimilation window / timeslots configuration
-        self._generic_config_subs['window_length'] = self.slots.window
-        self._generic_config_subs['window_lmargin'] = Period(- self.slots.start)
-        self._generic_config_subs['window_rmargin'] = self.slots.window + self.slots.start
-        self._generic_config_subs['timeslot_length'] = self.slots.chunk
-        self._generic_config_subs['timeslot_centered'] = self.slots.center
-        self._generic_config_subs['timeslot_centers'] = self.slots.as_centers_fromstart()
+        self._generic_config_subs["window_length"] = self.slots.window
+        self._generic_config_subs["window_lmargin"] = Period(-self.slots.start)
+        self._generic_config_subs["window_rmargin"] = (
+            self.slots.window + self.slots.start
+        )
+        self._generic_config_subs["timeslot_length"] = self.slots.chunk
+        self._generic_config_subs["timeslot_centered"] = self.slots.center
+        self._generic_config_subs["timeslot_centers"] = (
+            self.slots.as_centers_fromstart()
+        )
 
 
-class OOPSAnalysis(OOPSODB,
-                   OOPSTimestepDecoMixin,
-                   OOPSIncrementalDecoMixin,
-                   OOPSMemberDecoMixin,
-                   OOPSMembersTermsDetectDecoMixin):
+class OOPSAnalysis(
+    OOPSODB,
+    OOPSTimestepDecoMixin,
+    OOPSIncrementalDecoMixin,
+    OOPSMemberDecoMixin,
+    OOPSMembersTermsDetectDecoMixin,
+):
     """Any kind of OOPS analysis (screening/thining step excluded)."""
 
     _footprint = dict(
-        info = "OOPS minimisation.",
-        attr = dict(
-            kind = dict(
-                values   = ['ooanalysis', 'oominim'],
-                remap    = dict(autoremap='first'),
+        info="OOPS minimisation.",
+        attr=dict(
+            kind=dict(
+                values=["ooanalysis", "oominim"],
+                remap=dict(autoremap="first"),
             ),
-            virtualdb = dict(
-                default  = 'ccma',
+            virtualdb=dict(
+                default="ccma",
             ),
             withscreening=dict(
-                values   = [False, ],
-                type     = bool,
-                optional = True,
-                default  = False,
+                values=[
+                    False,
+                ],
+                type=bool,
+                optional=True,
+                default=False,
             ),
-        )
+        ),
     )
 
 
@@ -723,13 +897,15 @@ class OOPSAnalysisWithScreening(OOPSAnalysis):
     _OOPSODB_CCMA_DIRECT = True
 
     _footprint = dict(
-        attr = dict(
-            virtualdb = dict(
-                default  = 'ecma',
+        attr=dict(
+            virtualdb=dict(
+                default="ecma",
             ),
-            withscreening = dict(
-                values   = [True, ],
-                optional = False,
+            withscreening=dict(
+                values=[
+                    True,
+                ],
+                optional=False,
             ),
         )
     )

--- a/src/vortex/nwp/algo/oopstests.py
+++ b/src/vortex/nwp/algo/oopstests.py
@@ -6,9 +6,17 @@ import json
 
 import footprints
 
-from vortex.algo.components import AlgoComponentDecoMixin, algo_component_deco_mixin_autodoc
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    algo_component_deco_mixin_autodoc,
+)
 from ..syntax.stdattrs import oops_test_type, oops_expected_target
-from .oopsroot import OOPSParallel, OOPSODB, OOPSMembersTermsDecoMixin, OOPSMembersTermsDetectDecoMixin
+from .oopsroot import (
+    OOPSParallel,
+    OOPSODB,
+    OOPSMembersTermsDecoMixin,
+    OOPSMembersTermsDetectDecoMixin,
+)
 
 #: No automatic export
 __all__ = []
@@ -25,14 +33,14 @@ class _OOPSTestDecoMixin(AlgoComponentDecoMixin):
     the dictionary that is used to build the binary' command line.
     """
 
-    _MIXIN_EXTRA_FOOTPRINTS = (oops_test_type, )
+    _MIXIN_EXTRA_FOOTPRINTS = (oops_test_type,)
 
     def _ooptest_cli_opts_extend(self, prev):
         """Prepare options for the resource's command line."""
-        prev['test_type'] = self.test_type
+        prev["test_type"] = self.test_type
         return prev
 
-    _MIXIN_CLI_OPTS_EXTEND = (_ooptest_cli_opts_extend, )
+    _MIXIN_CLI_OPTS_EXTEND = (_ooptest_cli_opts_extend,)
 
 
 @algo_component_deco_mixin_autodoc
@@ -61,11 +69,13 @@ class _OOPSTestExpTargetDecoMixin(AlgoComponentDecoMixin):
         # if attribute 'expected_target' is attribute and given to the algo, use it
         target = self._set_expected_target_from_attribute()
         # else, go find Reference summary in effective inputs
-        if target is not None and target.get('from') == 'reference_summary':
+        if target is not None and target.get("from") == "reference_summary":
             target = self._set_expected_target_from_reference_summary()
         # Else, default to be sure to pass any in-binary-test
         if target is None:
-            target = self._set_expected_target_default()  # CLEANME: to be removed after CY47 ?
+            target = (
+                self._set_expected_target_default()
+            )  # CLEANME: to be removed after CY47 ?
         # Then in the end, export variable
         target = json.dumps(target)
         logger.info("Expected Target for Test: " + target)
@@ -73,88 +83,112 @@ class _OOPSTestExpTargetDecoMixin(AlgoComponentDecoMixin):
 
     def _set_expected_target_from_attribute(self):
         """Read target in Algo attribute."""
-        if hasattr(self, 'expected_target'):
+        if hasattr(self, "expected_target"):
             if self.expected_target is not None:
                 target = self.expected_target
-                logger.info('Set EXPECTED_RESULT from Attribute')
+                logger.info("Set EXPECTED_RESULT from Attribute")
                 return target
 
     def _set_expected_target_from_reference_summary(self):
         """Read target in ReferenceSummary effective input"""
         target = None
-        ref_summary = [s for s in self.context.sequence.effective_inputs(role=('Reference',))
-                       if s.rh.resource.kind == 'taskinfo']
+        ref_summary = [
+            s
+            for s in self.context.sequence.effective_inputs(
+                role=("Reference",)
+            )
+            if s.rh.resource.kind == "taskinfo"
+        ]
         if len(ref_summary) > 0:
             ref_summary = ref_summary[0].rh.contents.data
-            target = ref_summary.get('oops:' + self.test_type,
-                                     {}).get('as EXPECTED_RESULT', None)
+            target = ref_summary.get("oops:" + self.test_type, {}).get(
+                "as EXPECTED_RESULT", None
+            )
         if target is not None:
-            logger.info('Set EXPECTED_RESULT from Reference summary')
+            logger.info("Set EXPECTED_RESULT from Reference summary")
         return target
 
-    def _set_expected_target_default(self):  # CLEANME: to be removed after CY47 ?
+    def _set_expected_target_default(
+        self,
+    ):  # CLEANME: to be removed after CY47 ?
         """Set default, for binary not to crash before CY47."""
-        target = {'significant_digits': '-9',
-                  'expected_Jo': '9999',
-                  'expected_variances': '9999',
-                  'expected_diff': '9999'}
-        logger.info('Set default EXPECTED_RESULT')
+        target = {
+            "significant_digits": "-9",
+            "expected_Jo": "9999",
+            "expected_variances": "9999",
+            "expected_diff": "9999",
+        }
+        logger.info("Set default EXPECTED_RESULT")
         return target
 
     def _ooptest_exptarget_prepare_hook(self, rh, opts):
         """Call set_expected_target juste after prepare."""
         self.set_expected_target()
 
-    _MIXIN_PREPARE_HOOKS = (_ooptest_exptarget_prepare_hook, )
+    _MIXIN_PREPARE_HOOKS = (_ooptest_exptarget_prepare_hook,)
 
 
-class OOPSTest(OOPSParallel, _OOPSTestDecoMixin, _OOPSTestExpTargetDecoMixin,
-               OOPSMembersTermsDetectDecoMixin):
+class OOPSTest(
+    OOPSParallel,
+    _OOPSTestDecoMixin,
+    _OOPSTestExpTargetDecoMixin,
+    OOPSMembersTermsDetectDecoMixin,
+):
     """OOPS Tests without ODB."""
 
     _footprint = dict(
-        info = "OOPS Test run.",
-        attr = dict(
-            kind = dict(
-                values = ['ootest'],
+        info="OOPS Test run.",
+        attr=dict(
+            kind=dict(
+                values=["ootest"],
             ),
-            test_type = dict(
-                outcast = ['ensemble/build', ]
+            test_type=dict(
+                outcast=[
+                    "ensemble/build",
+                ]
             ),
-        )
+        ),
     )
 
 
-class OOPSTestEnsBuild(OOPSParallel, _OOPSTestDecoMixin, OOPSMembersTermsDecoMixin):
+class OOPSTestEnsBuild(
+    OOPSParallel, _OOPSTestDecoMixin, OOPSMembersTermsDecoMixin
+):
     """OOPS Tests without ODB: ensemble/build specific case"""
 
     _footprint = dict(
-        info = "OOPS Test run.",
-        attr = dict(
-            kind = dict(
-                values = ['ootest'],
+        info="OOPS Test run.",
+        attr=dict(
+            kind=dict(
+                values=["ootest"],
             ),
-            test_type = dict(
-                values = ['ensemble/build', ]
+            test_type=dict(
+                values=[
+                    "ensemble/build",
+                ]
             ),
-        )
+        ),
     )
 
 
-class OOPSObsOpTest(OOPSODB, _OOPSTestDecoMixin, _OOPSTestExpTargetDecoMixin,
-                    OOPSMembersTermsDetectDecoMixin):
+class OOPSObsOpTest(
+    OOPSODB,
+    _OOPSTestDecoMixin,
+    _OOPSTestExpTargetDecoMixin,
+    OOPSMembersTermsDetectDecoMixin,
+):
     """OOPS Obs Operators Tests."""
 
     _footprint = dict(
-        info = "OOPS Obs Operators Tests.",
-        attr = dict(
-            kind = dict(
-                values = ['ootestobs'],
+        info="OOPS Obs Operators Tests.",
+        attr=dict(
+            kind=dict(
+                values=["ootestobs"],
             ),
-            virtualdb = dict(
-                default  = 'ccma',
+            virtualdb=dict(
+                default="ccma",
             ),
-        )
+        ),
     )
 
 
@@ -162,15 +196,15 @@ class OOPSecma2ccma(OOPSODB, _OOPSTestDecoMixin):
     """OOPS Test ECMA 2 CCMA completer."""
 
     _footprint = dict(
-        info = "OOPS ECMA 2 CCMA completer.",
-        attr = dict(
-            kind = dict(
-                values = ['ootest2ccma'],
+        info="OOPS ECMA 2 CCMA completer.",
+        attr=dict(
+            kind=dict(
+                values=["ootest2ccma"],
             ),
-            virtualdb = dict(
-                values = ['ecma'],
+            virtualdb=dict(
+                values=["ecma"],
             ),
-        )
+        ),
     )
 
     def postfix(self, rh, opts):
@@ -182,5 +216,5 @@ class OOPSecma2ccma(OOPSODB, _OOPSTestDecoMixin):
         """Make the appropriate renaming of files in ECMA to CCMA."""
         for e in self.lookupodb():
             edir = e.rh.container.localpath()
-            self.odb.change_layout('ECMA', 'CCMA', edir)
-            self.system.mv(edir, edir.replace('ECMA', 'CCMA'))
+            self.odb.change_layout("ECMA", "CCMA", edir)
+            self.system.mv(edir, edir.replace("ECMA", "CCMA"))

--- a/src/vortex/nwp/algo/request.py
+++ b/src/vortex/nwp/algo/request.py
@@ -8,11 +8,20 @@ from bronx.fancies import loggers
 from bronx.stdtypes.date import Time
 import footprints
 
-from vortex.algo.components import AlgoComponent, AlgoComponentDecoMixin, Expresso, BlindRun
+from vortex.algo.components import (
+    AlgoComponent,
+    AlgoComponentDecoMixin,
+    Expresso,
+    BlindRun,
+)
 from vortex.algo.components import algo_component_deco_mixin_autodoc
 from vortex.syntax.stdattrs import a_date
 from vortex.tools.systems import ExecutionError
-from ..tools.bdap import BDAPrequest_actual_command, BDAPGetError, BDAPRequestConfigurationError
+from ..tools.bdap import (
+    BDAPrequest_actual_command,
+    BDAPGetError,
+    BDAPRequestConfigurationError,
+)
 from ..tools.bdmp import BDMPrequest_actual_command, BDMPGetError
 from ..tools.bdcp import BDCPrequest_actual_command, BDCPGetError
 from ..tools.bdm import BDMGetError, BDMRequestConfigurationError, BDMError
@@ -29,27 +38,27 @@ class GetBDAPResource(AlgoComponent):
     """Algo component to get BDAP resources considering a BDAP query file."""
 
     _footprint = dict(
-        info = 'Algo component to get BDAP files.',
-        attr = dict(
-            kind = dict(
-                values = ['get_bdap'],
+        info="Algo component to get BDAP files.",
+        attr=dict(
+            kind=dict(
+                values=["get_bdap"],
             ),
-            date = a_date,
-            target_bdap = dict(
-                default = 'OPER',
-                optional = True,
-                values = ['OPER', 'INTE'],
+            date=a_date,
+            target_bdap=dict(
+                default="OPER",
+                optional=True,
+                values=["OPER", "INTE"],
             ),
-            terms = dict(
-                info = "A forecast term or a list of terms (rangex will be used to expand the string)",
-                alias = ('term', )
+            terms=dict(
+                info="A forecast term or a list of terms (rangex will be used to expand the string)",
+                alias=("term",),
             ),
-            command = dict(
-                default = 'dap3',
-                optional =True,
-                values = ['dap3', 'dap3_dev'],
+            command=dict(
+                default="dap3",
+                optional=True,
+                values=["dap3", "dap3_dev"],
             ),
-        )
+        ),
     )
 
     def execute_single(self, rh, opts):
@@ -60,40 +69,54 @@ class GetBDAPResource(AlgoComponent):
         """
 
         # Determine the target BDAP
-        int_bdap = self.target_bdap == 'INTE'
+        int_bdap = self.target_bdap == "INTE"
 
         # Look for the input queries
         input_queries = self.context.sequence.effective_inputs(
-            role='Query',
-            kind='bdap_query',
+            role="Query",
+            kind="bdap_query",
         )
 
         rc_all = True
 
         for input_query in input_queries:
             for term in [Time(t) for t in footprints.util.rangex(self.terms)]:
-
                 # Launch each input queries in a dedicated file
                 # (to check that the files do not overwrite each other)
                 query_file = input_query.rh.container.abspath
-                local_directory = '_'.join([query_file, self.date.ymdhms, term.fmtraw])
+                local_directory = "_".join(
+                    [query_file, self.date.ymdhms, term.fmtraw]
+                )
 
                 with self.system.cdcontext(local_directory, create=True):
                     # Determine the command to be launched
-                    actual_command = BDAPrequest_actual_command(command=self.command,
-                                                                date=self.date,
-                                                                term=term,
-                                                                query=query_file,
-                                                                int_extraenv=int_bdap)
-                    logger.info(' '.join(['BDAP extract command:', actual_command]))
-                    logger.info('The %s directive file contains:', query_file)
+                    actual_command = BDAPrequest_actual_command(
+                        command=self.command,
+                        date=self.date,
+                        term=term,
+                        query=query_file,
+                        int_extraenv=int_bdap,
+                    )
+                    logger.info(
+                        " ".join(["BDAP extract command:", actual_command])
+                    )
+                    logger.info("The %s directive file contains:", query_file)
                     self.system.cat(query_file, output=False)
                     # Launch the BDAP request
-                    rc = self.system.spawn([actual_command, ], shell=True, output=False, fatal=False)
+                    rc = self.system.spawn(
+                        [
+                            actual_command,
+                        ],
+                        shell=True,
+                        output=False,
+                        fatal=False,
+                    )
 
                 if not rc:
-                    logger.exception('Problem during the BDAP request of %s.', query_file)
-                    if self.system.path.isfile('DIAG_BDAP'):
+                    logger.exception(
+                        "Problem during the BDAP request of %s.", query_file
+                    )
+                    if self.system.path.isfile("DIAG_BDAP"):
                         raise BDAPRequestConfigurationError
                     else:
                         raise BDAPGetError
@@ -101,7 +124,7 @@ class GetBDAPResource(AlgoComponent):
                 rc_all = rc_all and rc
 
         if not rc_all:
-            logger.exception('Problem during the BDAP request.')
+            logger.exception("Problem during the BDAP request.")
 
         return rc_all
 
@@ -110,22 +133,22 @@ class GetBDMPResource(AlgoComponent):
     """Algo component to get BDMP resources considering a BDMP query file."""
 
     _footprint = dict(
-        info = 'Algo component to get BDMP files.',
-        attr = dict(
-            kind = dict(
-                values = ['get_bdmp'],
+        info="Algo component to get BDMP files.",
+        attr=dict(
+            kind=dict(
+                values=["get_bdmp"],
             ),
-            target_bdmp = dict(
-                default = 'OPER',
-                optional = True,
-                values = ['OPER', 'INTE', 'ARCH'],
+            target_bdmp=dict(
+                default="OPER",
+                optional=True,
+                values=["OPER", "INTE", "ARCH"],
             ),
-            command = dict(
-                default = 'bdmp_lecture',
-                optional =True,
-                values = ['bdmp_lecture', 'bdmp_lecture_pg', 'bdmp_lecture_ora'],
+            command=dict(
+                default="bdmp_lecture",
+                optional=True,
+                values=["bdmp_lecture", "bdmp_lecture_pg", "bdmp_lecture_ora"],
             ),
-        )
+        ),
     )
 
     def execute_single(self, rh, opts):
@@ -137,40 +160,50 @@ class GetBDMPResource(AlgoComponent):
 
         # Look for the input queries
         input_queries = self.context.sequence.effective_inputs(
-            role='Query',
-            kind='bdmp_query',
+            role="Query",
+            kind="bdmp_query",
         )
 
         rc_all = True
 
         for input_query in input_queries:
-
             # Get information on the query file
             query_file = input_query.rh.container.abspath
-            logger.info('The %s directive file contains:', query_file)
+            logger.info("The %s directive file contains:", query_file)
             self.system.cat(query_file, output=False)
 
             # Construct the name of the temporary directory
-            local_directory = '_'.join([query_file, 'extract'])
+            local_directory = "_".join([query_file, "extract"])
 
             # Determine the command to be launched
-            actual_command = BDMPrequest_actual_command(command=self.command,
-                                                        query=query_file,
-                                                        target_bdmp=self.target_bdmp)
-            logger.info(' '.join(['BDMP extract command:', actual_command]))
+            actual_command = BDMPrequest_actual_command(
+                command=self.command,
+                query=query_file,
+                target_bdmp=self.target_bdmp,
+            )
+            logger.info(" ".join(["BDMP extract command:", actual_command]))
 
             # Launch the BDMP request
             with self.system.cdcontext(local_directory, create=True):
-                rc = self.system.spawn([actual_command, ], shell=True, output=False, fatal=False)
+                rc = self.system.spawn(
+                    [
+                        actual_command,
+                    ],
+                    shell=True,
+                    output=False,
+                    fatal=False,
+                )
 
             if not rc:
-                logger.exception('Problem during the BDMP request of %s.', query_file)
+                logger.exception(
+                    "Problem during the BDMP request of %s.", query_file
+                )
                 raise BDMPGetError
 
             rc_all = rc_all and rc
 
         if not rc_all:
-            logger.exception('Problem during the BDMP request.')
+            logger.exception("Problem during the BDMP request.")
 
         return rc_all
 
@@ -179,22 +212,22 @@ class GetBDCPResource(AlgoComponent):
     """Algo component to get BDCP resources considering a BDCP query file."""
 
     _footprint = dict(
-        info = 'Algo component to get BDCP files.',
-        attr = dict(
-            kind = dict(
-                values = ['get_bdcp'],
+        info="Algo component to get BDCP files.",
+        attr=dict(
+            kind=dict(
+                values=["get_bdcp"],
             ),
-            target_bdcp = dict(
-                default = 'OPER',
-                optional = True,
-                values = ['OPER'],
+            target_bdcp=dict(
+                default="OPER",
+                optional=True,
+                values=["OPER"],
             ),
-            command = dict(
-                default = 'extraction_directives',
-                optional =True,
-                values = ['extraction_directives'],
+            command=dict(
+                default="extraction_directives",
+                optional=True,
+                values=["extraction_directives"],
             ),
-        )
+        ),
     )
 
     def execute_single(self, rh, opts):
@@ -206,45 +239,55 @@ class GetBDCPResource(AlgoComponent):
 
         # Look for the input queries
         input_queries = self.context.sequence.effective_inputs(
-            role='Query',
-            kind='bdcp_query',
+            role="Query",
+            kind="bdcp_query",
         )
 
         rc_all = True
 
         for input_query in input_queries:
-
             # Get information on the query file
             query_file = input_query.rh.container.abspath
-            logger.info('The %s directive file contains:', query_file)
+            logger.info("The %s directive file contains:", query_file)
             self.system.cat(query_file, output=False)
 
             # Construct the name of the output and log files
-            local_directory = '_'.join([query_file, 'extract'])
-            output_file = 'extract.out'
-            output_log = 'extract.out.diag'
+            local_directory = "_".join([query_file, "extract"])
+            output_file = "extract.out"
+            output_log = "extract.out.diag"
 
             # Determine the command to be launched
-            actual_command = BDCPrequest_actual_command(command=self.command,
-                                                        query_file=query_file,
-                                                        output_file=output_file)
-            logger.info(' '.join(['BDMP extract command:', actual_command]))
+            actual_command = BDCPrequest_actual_command(
+                command=self.command,
+                query_file=query_file,
+                output_file=output_file,
+            )
+            logger.info(" ".join(["BDMP extract command:", actual_command]))
 
             # Launch the BDCP request
             with self.system.cdcontext(local_directory, create=True):
-                rc = self.system.spawn([actual_command, ], shell=True, output=False, fatal=False)
+                rc = self.system.spawn(
+                    [
+                        actual_command,
+                    ],
+                    shell=True,
+                    output=False,
+                    fatal=False,
+                )
                 # Cat the log file
-                logger.info('Content of the log file:')
+                logger.info("Content of the log file:")
                 self.system.cat(output_log, output=False)
 
             if not rc:
-                logger.exception('Problem during the BDCP request of %s.', query_file)
+                logger.exception(
+                    "Problem during the BDCP request of %s.", query_file
+                )
                 raise BDCPGetError
 
             rc_all = rc_all and rc
 
         if not rc_all:
-            logger.exception('Problem during the BDCP request.')
+            logger.exception("Problem during the BDCP request.")
 
         return rc_all
 
@@ -253,47 +296,51 @@ class GetBDCPResource(AlgoComponent):
 class _GetBDMDecoMixin(AlgoComponentDecoMixin):
     """Class variables and methods usefull for BDM extractions."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = [footprints.Footprint(
-        attr=dict(
-            date=a_date,
-            pwd_file=dict(
-                default='/usr/local/sopra/neons_pwd',
-                values=['/usr/local/sopra/neons_pwd'],
-                optional=True,
-            ),
-            fatal=dict(
-                type=bool,
-                default=False,
-                values=[True, False],
-                optional=True,
-            ),
-            defaut_queryname=dict(
-                default='vortexdefault_query_name',
-                doc_visibility=footprints.doc.visibility.GURU,
-                optional=True,
+    _MIXIN_EXTRA_FOOTPRINTS = [
+        footprints.Footprint(
+            attr=dict(
+                date=a_date,
+                pwd_file=dict(
+                    default="/usr/local/sopra/neons_pwd",
+                    values=["/usr/local/sopra/neons_pwd"],
+                    optional=True,
+                ),
+                fatal=dict(
+                    type=bool,
+                    default=False,
+                    values=[True, False],
+                    optional=True,
+                ),
+                defaut_queryname=dict(
+                    default="vortexdefault_query_name",
+                    doc_visibility=footprints.doc.visibility.GURU,
+                    optional=True,
+                ),
             )
         )
-    )]
+    ]
 
     def _verbose_env_export(self, varname, value):
         self.env.setvar(varname, value)
-        logger.info('Setting environment variable %s = %s', varname, str(value))
+        logger.info(
+            "Setting environment variable %s = %s", varname, str(value)
+        )
 
     def _prepare_commons(self, rh, opts):
         """
         Prepare the launch of the script
         """
         # Some exports to be done
-        self._verbose_env_export('PWD_FILE', self.pwd_file)
-        self._verbose_env_export('DMT_DATE_PIVOT', self.date.ymdhms)
+        self._verbose_env_export("PWD_FILE", self.pwd_file)
+        self._verbose_env_export("DMT_DATE_PIVOT", self.date.ymdhms)
 
-    _MIXIN_PREPARE_HOOKS = (_prepare_commons, )
+    _MIXIN_PREPARE_HOOKS = (_prepare_commons,)
 
     def _spawn_command_options_extend(self, prev):
-        prev['query'] = self.defaut_queryname
+        prev["query"] = self.defaut_queryname
         return prev
 
-    _MIXIN_CLI_OPTS_EXTEND = (_spawn_command_options_extend, )
+    _MIXIN_CLI_OPTS_EXTEND = (_spawn_command_options_extend,)
 
     def _execute_commons(self, rh, opts):
         """Launch the BDM request(s).
@@ -317,25 +364,34 @@ class _GetBDMDecoMixin(AlgoComponentDecoMixin):
             # (to check that the files do not overwrite one another)
             with self.system.cdcontext(loc_dir, create=True):
                 # Make the links needed
-                self.system.symlink(query_abspath,
-                                    self.defaut_queryname)
+                self.system.symlink(query_abspath, self.defaut_queryname)
                 # Cat the query content
-                logger.info('The %s directive file contains:', query_filename)
+                logger.info("The %s directive file contains:", query_filename)
                 self.system.cat(self.defaut_queryname, output=False)
                 # Launch the BDM request and catch
                 try:
-                    super(self.mixin_execute_companion(), self).execute(rh, opts)
+                    super(self.mixin_execute_companion(), self).execute(
+                        rh, opts
+                    )
                 except ExecutionError:
                     rc_all = False
-                    logger.error('Problem during the BDM request of %s.', query_filename)
+                    logger.error(
+                        "Problem during the BDM request of %s.", query_filename
+                    )
                     if self.fatal:
-                        raise BDMGetError('Problem during the BDM request of {}.'.format(query_filename))
+                        raise BDMGetError(
+                            "Problem during the BDM request of {}.".format(
+                                query_filename
+                            )
+                        )
                 # Delete the links
                 self.system.rm(self.defaut_queryname)
                 self.system.dir(output=False, fatal=False)
 
         if not rc_all:
-            logger.error('At least one of the BDM request failed. Please check the logs above.')
+            logger.error(
+                "At least one of the BDM request failed. Please check the logs above."
+            )
 
     _MIXIN_EXECUTE_OVERWRITE = _execute_commons
 
@@ -345,15 +401,17 @@ class _GetBDMDecoMixin(AlgoComponentDecoMixin):
         # BATORMAP concatenation
         # Determine the name of the batormap produced by the execution in the different directories
         input_queries = self._get_input_queries()
-        local_dir = [self._local_directory(input_query.rh.container.filename)
-                     for input_query in input_queries]
+        local_dir = [
+            self._local_directory(input_query.rh.container.filename)
+            for input_query in input_queries
+        ]
         temp_files = []
         for directory in local_dir:
-            glob_files = self.system.glob('/'.join([directory, '*batormap*']))
+            glob_files = self.system.glob("/".join([directory, "*batormap*"]))
             for element in glob_files:
                 temp_files.append(element)
         # Initialize the resulting batormap file
-        obsmap_filename = '_'.join(['OBSMAP', self.date.ymdhms])
+        obsmap_filename = "_".join(["OBSMAP", self.date.ymdhms])
         content = []
         # Check if a batormap is already present in the directory (from previous extract)
         if self.system.path.isfile(obsmap_filename):
@@ -370,70 +428,74 @@ class _GetBDMDecoMixin(AlgoComponentDecoMixin):
         out_container = footprints.proxy.container(local=obsmap_filename)
         out_content.rewrite(out_container)
         out_container.close()
-        logger.info('Content of the global batormap:')
+        logger.info("Content of the global batormap:")
         self.system.cat(out_container.filename, output=False)
 
         # Listing concatenation
         # Initialize the resulting file
-        listing_filename = 'OULOUTPUT'
+        listing_filename = "OULOUTPUT"
         # Determine the name of the listing files produced by the execution
         listing_files = []
         for directory in local_dir:
-            glob_files = self.system.glob('/'.join([directory, listing_filename]))
+            glob_files = self.system.glob(
+                "/".join([directory, listing_filename])
+            )
             for element in glob_files:
                 listing_files.append(element)
         # Check if a listing is already present and has to be merged with the other
         if self.system.path.isfile(listing_filename):
-            temp_listing = '.'.join([listing_filename, 'tmp'])
+            temp_listing = ".".join([listing_filename, "tmp"])
             self.system.mv(listing_filename, temp_listing)
             listing_files.append(temp_listing)
         # Concatenate the listings
         self.system.cat(*listing_files, output=listing_filename)
 
-    _MIXIN_POSTFIX_HOOKS = (_postfix_commons, )
+    _MIXIN_POSTFIX_HOOKS = (_postfix_commons,)
 
 
 class GetBDMBufr(Expresso, _GetBDMDecoMixin):
     """Algo component to get BDM resources considering a BDM query file."""
 
     _footprint = dict(
-        info = 'Algo component to get BDM BUFR.',
-        attr = dict(
-            kind = dict(
-                values = ['get_bdm_bufr'],
+        info="Algo component to get BDM BUFR.",
+        attr=dict(
+            kind=dict(
+                values=["get_bdm_bufr"],
             ),
-            db_file_bdm = dict(
-                default = '/usr/local/sopra/neons_db_bdm',
-                values = ['/usr/local/sopra/neons_db_bdm',
-                          '/usr/local/sopra/neons_db_bdm.archi',
-                          '/usr/local/sopra/neons_db_bdm.intgr'],
-                optional = True,
+            db_file_bdm=dict(
+                default="/usr/local/sopra/neons_db_bdm",
+                values=[
+                    "/usr/local/sopra/neons_db_bdm",
+                    "/usr/local/sopra/neons_db_bdm.archi",
+                    "/usr/local/sopra/neons_db_bdm.intgr",
+                ],
+                optional=True,
             ),
-            extra_env_opt = dict(
-                values = ['RECHERCHE', 'OPERATIONNEL', 'OPER'],
-                default = 'OPER',
-                optional = True,
+            extra_env_opt=dict(
+                values=["RECHERCHE", "OPERATIONNEL", "OPER"],
+                default="OPER",
+                optional=True,
             ),
-            shlib_path = dict(
-                default = '/usr/local/lib',
-                optional = True,
+            shlib_path=dict(
+                default="/usr/local/lib",
+                optional=True,
             ),
-            interpreter = dict(
-                default = 'awk',
-                values = ['awk'],
-                optional = True,
+            interpreter=dict(
+                default="awk",
+                values=["awk"],
+                optional=True,
             ),
-        )
+        ),
     )
 
     def _local_directory(self, query_filename):
-        return '_'.join(['BUFR', query_filename, self.date.ymdhms])
+        return "_".join(["BUFR", query_filename, self.date.ymdhms])
 
     def _get_input_queries(self):
         """Returns the list of queries to process."""
         return self.context.sequence.effective_inputs(
-            role='Query',
-            kind='bdm_query',
+            role="Query",
+            kind="bdm_query",
         )
 
     def prepare(self, rh, opts):
@@ -444,45 +506,51 @@ class GetBDMBufr(Expresso, _GetBDMDecoMixin):
         super().prepare(rh, opts)
 
         # Some exports to be done
-        self._verbose_env_export('EXTR_ENV', self.extra_env_opt)
-        self._verbose_env_export('DB_FILE_BDM', self.db_file_bdm)
-        self._verbose_env_export('SHLIB_PATH', ':'.join(['$SHLIB_PATH', self.shlib_path]))
+        self._verbose_env_export("EXTR_ENV", self.extra_env_opt)
+        self._verbose_env_export("DB_FILE_BDM", self.db_file_bdm)
+        self._verbose_env_export(
+            "SHLIB_PATH", ":".join(["$SHLIB_PATH", self.shlib_path])
+        )
 
         # Check if query files are present
         input_queries = self._get_input_queries()
         if len(input_queries) < 1:
-            logger.exception('No query file found for the BDM extraction. Stop.')
-            raise BDMRequestConfigurationError('No query file found for the BDM extraction')
+            logger.exception(
+                "No query file found for the BDM extraction. Stop."
+            )
+            raise BDMRequestConfigurationError(
+                "No query file found for the BDM extraction"
+            )
 
 
 class GetBDMOulan(BlindRun, _GetBDMDecoMixin):
     """Algo component to get BDM files using Oulan."""
 
     _footprint = dict(
-        info = "Algo component to get BDM files using Oulan.",
-        attr = dict(
-            kind = dict(
-                values = ['get_bdm_oulan'],
+        info="Algo component to get BDM files using Oulan.",
+        attr=dict(
+            kind=dict(
+                values=["get_bdm_oulan"],
             ),
-            db_file = dict(
-                default = '/usr/local/sopra/neons_db',
-                values = ['/usr/local/sopra/neons_db'],
-                optional = True,
+            db_file=dict(
+                default="/usr/local/sopra/neons_db",
+                values=["/usr/local/sopra/neons_db"],
+                optional=True,
             ),
-            defaut_queryname = dict(
-                default = 'NAMELIST',
+            defaut_queryname=dict(
+                default="NAMELIST",
             ),
-        )
+        ),
     )
 
     def _local_directory(self, query_filename):
-        return '_'.join(['Oulan', query_filename, self.date.ymdhms])
+        return "_".join(["Oulan", query_filename, self.date.ymdhms])
 
     def _get_input_queries(self):
         """Returns the list of namelists to process."""
         return self.context.sequence.effective_inputs(
-            role='NamelistOulan',
-            kind='namutil',
+            role="NamelistOulan",
+            kind="namutil",
         )
 
     def prepare(self, rh, opts):
@@ -491,40 +559,36 @@ class GetBDMOulan(BlindRun, _GetBDMDecoMixin):
         super().prepare(rh, opts)
 
         # Export additional variables
-        self._verbose_env_export('DB_FILE', self.db_file)
+        self._verbose_env_export("DB_FILE", self.db_file)
 
         # Check if namelists are present
         input_namelists = self._get_input_queries()
         if len(input_namelists) < 1:
-            logger.error('No Oulan namelist found. Stop.')
-            raise BDMError('No Oulan namelist found.')
+            logger.error("No Oulan namelist found. Stop.")
+            raise BDMError("No Oulan namelist found.")
 
 
 class GetMarsResource(AlgoComponent):
     """AlgoComponent to get Mars resources using a Mars query file"""
 
     _footprint = dict(
-        info = 'AlgoComponent to get a Mars resource',
-        attr = dict(
-            kind = dict(
-                values = ['get_mars', ]
+        info="AlgoComponent to get a Mars resource",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "get_mars",
+                ]
             ),
-            date = a_date,
-            substitutions = dict(
-                info = "A dictionary of values to be substituted",
-                type = footprints.stdtypes.FPDict,
-                default = footprints.stdtypes.FPDict(),
-                optional = True
+            date=a_date,
+            substitutions=dict(
+                info="A dictionary of values to be substituted",
+                type=footprints.stdtypes.FPDict,
+                default=footprints.stdtypes.FPDict(),
+                optional=True,
             ),
-            command = dict(
-                optional = True
-            ),
-            fatal = dict(
-                type = bool,
-                default = True,
-                optional = True
-            )
-        )
+            command=dict(optional=True),
+            fatal=dict(type=bool, default=True, optional=True),
+        ),
     )
 
     def execute(self, rh, opts):
@@ -535,17 +599,21 @@ class GetMarsResource(AlgoComponent):
         """
         # Look for input queries
         input_queries = self.context.sequence.effective_inputs(
-            role='Query',
-            kind='mars_query',
+            role="Query",
+            kind="mars_query",
         )
         if len(input_queries) < 1:
-            logger.exception('No query file found for the Mars extraction. Stop.')
-            raise MarsGetError('No query file found for the Mars extraction')
+            logger.exception(
+                "No query file found for the Mars extraction. Stop."
+            )
+            raise MarsGetError("No query file found for the Mars extraction")
 
         rc_all = True
 
         # Find the command to be launched
-        actual_command = findMarsExtractCommand(sh=self.system, command=self.command)
+        actual_command = findMarsExtractCommand(
+            sh=self.system, command=self.command
+        )
 
         # Prepare the substitutions' dictionnary
         dictkeyvalue = copy.deepcopy(self.substitutions)
@@ -563,17 +631,30 @@ class GetMarsResource(AlgoComponent):
             # Launch each input queries in a dedicated file
             # (to check that the files do not overwrite each other)
             query_file_path = input_query.rh.container.abspath
-            local_directory = '_'.join([query_file_path, self.date.ymdhms])
-            logger.info("Here is the content of the query file %s (after substitution):", query_file_path)
+            local_directory = "_".join([query_file_path, self.date.ymdhms])
+            logger.info(
+                "Here is the content of the query file %s (after substitution):",
+                query_file_path,
+            )
             self.system.cat(query_file_path, output=False)
             with self.system.cdcontext(local_directory, create=True):
                 # Launch the command
-                rc = callMarsExtract(sh=self.system, query_file=query_file_path, fatal=self.fatal,
-                                     command=actual_command)
+                rc = callMarsExtract(
+                    sh=self.system,
+                    query_file=query_file_path,
+                    fatal=self.fatal,
+                    command=actual_command,
+                )
                 if not rc:
                     if self.fatal:
-                        logger.error("Problem during the Mars request of %s", query_file_path)
+                        logger.error(
+                            "Problem during the Mars request of %s",
+                            query_file_path,
+                        )
                         raise MarsGetError
                     else:
-                        logger.warning("Problem during the Mars request of %s", query_file_path)
+                        logger.warning(
+                            "Problem during the Mars request of %s",
+                            query_file_path,
+                        )
                 rc_all = rc_all and rc

--- a/src/vortex/nwp/algo/stdpost.py
+++ b/src/vortex/nwp/algo/stdpost.py
@@ -13,12 +13,32 @@ from footprints.stdtypes import FPTuple
 import footprints
 from taylorism import Boss
 
-from vortex.layout.monitor import BasicInputMonitor, AutoMetaGang, MetaGang, EntrySt, GangSt
-from vortex.algo.components import AlgoComponentDecoMixin, AlgoComponentError, algo_component_deco_mixin_autodoc
-from vortex.algo.components import TaylorRun, BlindRun, ParaBlindRun, Parallel, Expresso
+from vortex.layout.monitor import (
+    BasicInputMonitor,
+    AutoMetaGang,
+    MetaGang,
+    EntrySt,
+    GangSt,
+)
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    AlgoComponentError,
+    algo_component_deco_mixin_autodoc,
+)
+from vortex.algo.components import (
+    TaylorRun,
+    BlindRun,
+    ParaBlindRun,
+    Parallel,
+    Expresso,
+)
 from vortex.syntax.stdattrs import DelayedEnvValue, FmtInt
 from vortex.tools.grib import EcGribDecoMixin
-from vortex.tools.parallelism import TaylorVortexWorker, VortexWorkerBlindRun, ParallelResultParser
+from vortex.tools.parallelism import (
+    TaylorVortexWorker,
+    VortexWorkerBlindRun,
+    ParallelResultParser,
+)
 from vortex.tools.systems import ExecutionError
 
 from ..tools.grib import GRIBFilter
@@ -37,66 +57,57 @@ class _FA2GribWorker(VortexWorkerBlindRun):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['fa2grib']
-            ),
+        attr=dict(
+            kind=dict(values=["fa2grib"]),
             # Progrid parameters
-            fortnam = dict(),
-            fortinput = dict(),
-            compact = dict(),
-            timeshift = dict(
-                type = int
-            ),
-            timeunit = dict(
-                type = int
-            ),
-            numod = dict(
-                type = int
-            ),
-            sciz = dict(
-                type = int
-            ),
-            scizoffset = dict(
-                type = int,
-                optional = True
-            ),
+            fortnam=dict(),
+            fortinput=dict(),
+            compact=dict(),
+            timeshift=dict(type=int),
+            timeunit=dict(type=int),
+            numod=dict(type=int),
+            sciz=dict(type=int),
+            scizoffset=dict(type=int, optional=True),
             # Input/Output data
-            file_in = dict(),
-            file_out = dict(),
-            member = dict(
-                type = FmtInt,
-                optional = True,
-            )
+            file_in=dict(),
+            file_out=dict(),
+            member=dict(
+                type=FmtInt,
+                optional=True,
+            ),
         )
     )
 
     def vortex_task(self, **kwargs):
-
         logger.info("Starting the Fa2Grib processing for tag=%s", self.name)
 
-        thisoutput = 'GRIDOUTPUT'
+        thisoutput = "GRIDOUTPUT"
         rdict = dict(rc=True)
 
         # First, check that the hooks were applied
-        for thisinput in [x for x in self.context.sequence.inputs()
-                          if x.rh.container.localpath() == self.file_in]:
+        for thisinput in [
+            x
+            for x in self.context.sequence.inputs()
+            if x.rh.container.localpath() == self.file_in
+        ]:
             if thisinput.rh.delayhooks:
                 thisinput.rh.apply_get_hooks()
 
         # Jump into a working directory
         cwd = self.system.pwd()
-        tmpwd = self.system.path.join(cwd, self.file_out + '.process.d')
+        tmpwd = self.system.path.join(cwd, self.file_out + ".process.d")
         self.system.mkdir(tmpwd)
         self.system.cd(tmpwd)
 
         # Build the local namelist block
-        nb = NamelistBlock(name='NAML')
+        nb = NamelistBlock(name="NAML")
         nb.NBDOM = 1
         nb.CHOPER = self.compact
         nb.INUMOD = self.numod
         if self.scizoffset is not None:
-            nb.ISCIZ = self.scizoffset + (self.member if self.member is not None else 0)
+            nb.ISCIZ = self.scizoffset + (
+                self.member if self.member is not None else 0
+            )
         else:
             if self.sciz:
                 nb.ISCIZ = self.sciz
@@ -104,28 +115,31 @@ class _FA2GribWorker(VortexWorkerBlindRun):
             nb.IHCTPI = self.timeshift
         if self.timeunit:
             nb.ITUNIT = self.timeunit
-        nb['CLFSORT(1)'] = thisoutput
-        nb['CDNOMF(1)'] = self.fortinput
-        with open(self.fortnam, 'w') as namfd:
+        nb["CLFSORT(1)"] = thisoutput
+        nb["CDNOMF(1)"] = self.fortinput
+        with open(self.fortnam, "w") as namfd:
             namfd.write(nb.dumps())
 
         # Finally set the actual init file
-        self.system.softlink(self.system.path.join(cwd, self.file_in),
-                             self.fortinput)
+        self.system.softlink(
+            self.system.path.join(cwd, self.file_in), self.fortinput
+        )
 
         # Standard execution
         list_name = self.system.path.join(cwd, self.file_out + ".listing")
         try:
             self.local_spawn(list_name)
         except ExecutionError as e:
-            rdict['rc'] = e
+            rdict["rc"] = e
 
         # Freeze the current output
         if self.system.path.exists(thisoutput):
-            self.system.move(thisoutput, self.system.path.join(cwd, self.file_out))
+            self.system.move(
+                thisoutput, self.system.path.join(cwd, self.file_out)
+            )
         else:
-            logger.warning('Missing some grib output: %s', self.file_out)
-            rdict['rc'] = False
+            logger.warning("Missing some grib output: %s", self.file_out)
+            rdict["rc"] = False
 
         # Final cleaning
         self.system.cd(cwd)
@@ -133,8 +147,12 @@ class _FA2GribWorker(VortexWorkerBlindRun):
 
         if self.system.path.exists(self.file_out):
             # Deal with promised resources
-            expected = [x for x in self.context.sequence.outputs()
-                        if x.rh.provider.expected and x.rh.container.localpath() == self.file_out]
+            expected = [
+                x
+                for x in self.context.sequence.outputs()
+                if x.rh.provider.expected
+                and x.rh.container.localpath() == self.file_out
+            ]
             for thispromise in expected:
                 thispromise.put(incache=True)
 
@@ -150,35 +168,32 @@ class _GribFilterWorker(TaylorVortexWorker):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['gribfilter']
-            ),
+        attr=dict(
+            kind=dict(values=["gribfilter"]),
             # Filter settings
-            filters = dict(
-                type = FPTuple,
+            filters=dict(
+                type=FPTuple,
             ),
-            concatenate = dict(
-                type = bool,
+            concatenate=dict(
+                type=bool,
             ),
             # Put files if they are expected
-            put_promises = dict(
-                type = bool,
-                optional = True,
-                default = True,
+            put_promises=dict(
+                type=bool,
+                optional=True,
+                default=True,
             ),
             # Input/Output data
-            file_in = dict(),
-            file_outfmt = dict(),
-            file_outintent = dict(
-                optional = True,
-                default = 'in',
+            file_in=dict(),
+            file_outfmt=dict(),
+            file_outintent=dict(
+                optional=True,
+                default="in",
             ),
         )
     )
 
     def vortex_task(self, **kwargs):
-
         logger.info("Starting the GribFiltering for tag=%s", self.file_in)
 
         rdict = dict(rc=True)
@@ -186,7 +201,7 @@ class _GribFilterWorker(TaylorVortexWorker):
         # Create the filtering object and add filters
         gfilter = GRIBFilter(concatenate=self.concatenate)
         if self.filters:
-            gfilter.add_filters(* list(self.filters))
+            gfilter.add_filters(*list(self.filters))
 
         # Process the input file
         newfiles = gfilter(self.file_in, self.file_outfmt, self.file_outintent)
@@ -194,24 +209,37 @@ class _GribFilterWorker(TaylorVortexWorker):
         if newfiles:
             if self.put_promises:
                 # Deal with promised resources
-                allpromises = [x for x in self.context.sequence.outputs()
-                               if x.rh.provider.expected]
+                allpromises = [
+                    x
+                    for x in self.context.sequence.outputs()
+                    if x.rh.provider.expected
+                ]
                 for newfile in newfiles:
-                    expected = [x for x in allpromises
-                                if x.rh.container.localpath() == newfile]
+                    expected = [
+                        x
+                        for x in allpromises
+                        if x.rh.container.localpath() == newfile
+                    ]
                     for thispromise in expected:
                         thispromise.put(incache=True)
         else:
-            logger.warning('No file has been generated.')
-            rdict['rc'] = False
+            logger.warning("No file has been generated.")
+            rdict["rc"] = False
 
         logger.info("GribFiltering is done for tag=%s", self.name)
 
         return rdict
 
 
-def parallel_grib_filter(context, inputs, outputs, intents=(),
-                         cat=False, filters=FPTuple(), nthreads=8):
+def parallel_grib_filter(
+    context,
+    inputs,
+    outputs,
+    intents=(),
+    cat=False,
+    filters=FPTuple(),
+    nthreads=8,
+):
     """A simple method that calls the GRIBFilter class in parallel.
 
     :param vortex.layout.contexts.Context context: the current context
@@ -223,26 +251,58 @@ def parallel_grib_filter(context, inputs, outputs, intents=(),
     :param int nthreads: the maximum number of tasks used concurently (8 by default)
     """
     if not cat and len(filters) == 0:
-        raise AlgoComponentError("cat must be true or filters must be provided")
+        raise AlgoComponentError(
+            "cat must be true or filters must be provided"
+        )
     if len(inputs) != len(outputs):
-        raise AlgoComponentError("inputs and outputs must have the same length")
+        raise AlgoComponentError(
+            "inputs and outputs must have the same length"
+        )
     if len(intents) != len(outputs):
-        intents = FPTuple(['in', ] * len(outputs))
-    boss = Boss(scheduler=footprints.proxy.scheduler(limit='threads', max_threads=nthreads))
-    common_i = dict(kind='gribfilter', filters=filters, concatenate=cat, put_promises=False)
+        intents = FPTuple(
+            [
+                "in",
+            ]
+            * len(outputs)
+        )
+    boss = Boss(
+        scheduler=footprints.proxy.scheduler(
+            limit="threads", max_threads=nthreads
+        )
+    )
+    common_i = dict(
+        kind="gribfilter", filters=filters, concatenate=cat, put_promises=False
+    )
     for ifile, ofile, intent in zip(inputs, outputs, intents):
-        logger.info("%s -> %s (intent: %s) added to the GRIBfilter task's list",
-                    ifile, ofile, intent)
-        boss.set_instructions(common_i, dict(name=[ifile, ],
-                                             file_in=[ifile, ],
-                                             file_outfmt=[ofile, ],
-                                             file_outintent=[intent, ]))
+        logger.info(
+            "%s -> %s (intent: %s) added to the GRIBfilter task's list",
+            ifile,
+            ofile,
+            intent,
+        )
+        boss.set_instructions(
+            common_i,
+            dict(
+                name=[
+                    ifile,
+                ],
+                file_in=[
+                    ifile,
+                ],
+                file_outfmt=[
+                    ofile,
+                ],
+                file_outintent=[
+                    intent,
+                ],
+            ),
+        )
     boss.make_them_work()
     boss.wait_till_finished()
     logger.info("All files are processed.")
     report = boss.get_report()
     prp = ParallelResultParser(context)
-    for r in report['workers_report']:
+    for r in report["workers_report"]:
         if isinstance(prp(r), Exception):
             raise AlgoComponentError("An error occurred in GRIBfilter.")
 
@@ -251,60 +311,60 @@ class Fa2Grib(ParaBlindRun):
     """Standard FA conversion, e.g. with PROGRID as a binary resource."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['fa2grib'],
+        attr=dict(
+            kind=dict(
+                values=["fa2grib"],
             ),
-            timeout = dict(
-                type = int,
-                optional = True,
-                default = 300,
+            timeout=dict(
+                type=int,
+                optional=True,
+                default=300,
             ),
-            refreshtime = dict(
-                type = int,
-                optional = True,
-                default = 20,
+            refreshtime=dict(
+                type=int,
+                optional=True,
+                default=20,
             ),
-            fatal = dict(
-                type = bool,
-                optional = True,
-                default = True,
+            fatal=dict(
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            fortnam = dict(
-                optional = True,
-                default  = 'fort.4',
+            fortnam=dict(
+                optional=True,
+                default="fort.4",
             ),
-            fortinput = dict(
-                optional = True,
-                default  = 'fort.11',
+            fortinput=dict(
+                optional=True,
+                default="fort.11",
             ),
-            compact = dict(
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_COMPACT', 'L'),
+            compact=dict(
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_COMPACT", "L"),
             ),
-            timeshift = dict(
-                type     = int,
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_SHIFT', 0),
+            timeshift=dict(
+                type=int,
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_SHIFT", 0),
             ),
-            timeunit = dict(
-                type     = int,
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_TUNIT', 1),
+            timeunit=dict(
+                type=int,
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_TUNIT", 1),
             ),
-            numod = dict(
-                type     = int,
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_NUMOD', 221),
+            numod=dict(
+                type=int,
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_NUMOD", 221),
             ),
-            sciz = dict(
-                type     = int,
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_SCIZ', 0),
+            sciz=dict(
+                type=int,
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_SCIZ", 0),
             ),
-            scizoffset = dict(
-                type     = int,
-                optional = True,
+            scizoffset=dict(
+                type=int,
+                optional=True,
             ),
         )
     )
@@ -314,7 +374,9 @@ class Fa2Grib(ParaBlindRun):
         super().prepare(rh, opts)
         self.system.remove(self.fortinput)
         self.env.DR_HOOK_NOT_MPI = 1
-        self.system.subtitle('{:s} : directory listing (pre-run)'.format(self.realkind))
+        self.system.subtitle(
+            "{:s} : directory listing (pre-run)".format(self.realkind)
+        )
         self.system.dir(output=False, fatal=False)
 
     def execute(self, rh, opts):
@@ -324,34 +386,64 @@ class Fa2Grib(ParaBlindRun):
 
         common_i = self._default_common_instructions(rh, opts)
         # Update the common instructions
-        common_i.update(dict(fortnam=self.fortnam, fortinput=self.fortinput,
-                             compact=self.compact, numod=self.numod,
-                             sciz=self.sciz, scizoffset=self.scizoffset,
-                             timeshift=self.timeshift, timeunit=self.timeunit))
+        common_i.update(
+            dict(
+                fortnam=self.fortnam,
+                fortinput=self.fortinput,
+                compact=self.compact,
+                numod=self.numod,
+                sciz=self.sciz,
+                scizoffset=self.scizoffset,
+                timeshift=self.timeshift,
+                timeunit=self.timeunit,
+            )
+        )
         tmout = False
 
         # Monitor for the input files
-        bm = BasicInputMonitor(self.context, caching_freq=self.refreshtime,
-                               role='Gridpoint', kind='gridpoint')
+        bm = BasicInputMonitor(
+            self.context,
+            caching_freq=self.refreshtime,
+            role="Gridpoint",
+            kind="gridpoint",
+        )
         with bm:
             while not bm.all_done or len(bm.available) > 0:
-
                 while bm.available:
                     s = bm.pop_available().section
                     file_in = s.rh.container.localpath()
                     # Find the name of the output file
                     if s.rh.provider.member is not None:
-                        file_out = 'GRIB{:s}_{!s}+{:s}'.format(s.rh.resource.geometry.area,
-                                                               s.rh.provider.member,
-                                                               s.rh.resource.term.fmthm)
+                        file_out = "GRIB{:s}_{!s}+{:s}".format(
+                            s.rh.resource.geometry.area,
+                            s.rh.provider.member,
+                            s.rh.resource.term.fmthm,
+                        )
                     else:
-                        file_out = 'GRIB{:s}+{:s}'.format(s.rh.resource.geometry.area,
-                                                          s.rh.resource.term.fmthm)
-                    logger.info("Adding input file %s to the job list", file_in)
-                    self._add_instructions(common_i,
-                                           dict(name=[file_in, ],
-                                                file_in=[file_in, ], file_out=[file_out, ],
-                                                member=[s.rh.provider.member, ]))
+                        file_out = "GRIB{:s}+{:s}".format(
+                            s.rh.resource.geometry.area,
+                            s.rh.resource.term.fmthm,
+                        )
+                    logger.info(
+                        "Adding input file %s to the job list", file_in
+                    )
+                    self._add_instructions(
+                        common_i,
+                        dict(
+                            name=[
+                                file_in,
+                            ],
+                            file_in=[
+                                file_in,
+                            ],
+                            file_out=[
+                                file_out,
+                            ],
+                            member=[
+                                s.rh.provider.member,
+                            ],
+                        ),
+                    )
 
                 if not (bm.all_done or len(bm.available) > 0):
                     # Timeout ?
@@ -364,42 +456,47 @@ class Fa2Grib(ParaBlindRun):
 
         self._default_post_execute(rh, opts)
 
-        for failed_file in [e.section.rh.container.localpath() for e in bm.failed.values()]:
-            logger.error("We were unable to fetch the following file: %s", failed_file)
+        for failed_file in [
+            e.section.rh.container.localpath() for e in bm.failed.values()
+        ]:
+            logger.error(
+                "We were unable to fetch the following file: %s", failed_file
+            )
             if self.fatal:
-                self.delayed_exception_add(IOError("Unable to fetch {:s}".format(failed_file)),
-                                           traceback=False)
+                self.delayed_exception_add(
+                    IOError("Unable to fetch {:s}".format(failed_file)),
+                    traceback=False,
+                )
 
         if tmout:
             raise OSError("The waiting loop timed out")
 
 
 class StandaloneGRIBFilter(TaylorRun):
-
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['gribfilter'],
+        attr=dict(
+            kind=dict(
+                values=["gribfilter"],
             ),
-            timeout = dict(
-                type = int,
-                optional = True,
-                default = 300,
+            timeout=dict(
+                type=int,
+                optional=True,
+                default=300,
             ),
-            refreshtime = dict(
-                type = int,
-                optional = True,
-                default = 20,
+            refreshtime=dict(
+                type=int,
+                optional=True,
+                default=20,
             ),
-            concatenate = dict(
-                type = bool,
-                default = False,
-                optional = True,
+            concatenate=dict(
+                type=bool,
+                default=False,
+                optional=True,
             ),
-            fatal = dict(
-                type = bool,
-                optional = True,
-                default = True,
+            fatal=dict(
+                type=bool,
+                optional=True,
+                default=True,
             ),
         )
     )
@@ -407,40 +504,63 @@ class StandaloneGRIBFilter(TaylorRun):
     def prepare(self, rh, opts):
         """Set some variables according to target definition."""
         super().prepare(rh, opts)
-        self.system.subtitle('{:s} : directory listing (pre-run)'.format(self.realkind))
+        self.system.subtitle(
+            "{:s} : directory listing (pre-run)".format(self.realkind)
+        )
         self.system.dir(output=False, fatal=False)
 
     def execute(self, rh, opts):
-
         # We re-serialise data because footprints don't like dictionaries
-        filters = [json.dumps(x.rh.contents.data)
-                   for x in self.context.sequence.effective_inputs(role='GRIBFilteringRequest',
-                                                                   kind='filtering_request')]
+        filters = [
+            json.dumps(x.rh.contents.data)
+            for x in self.context.sequence.effective_inputs(
+                role="GRIBFilteringRequest", kind="filtering_request"
+            )
+        ]
         filters = FPTuple(filters)
 
         self._default_pre_execute(rh, opts)
 
         common_i = self._default_common_instructions(rh, opts)
         # Update the common instructions
-        common_i.update(dict(concatenate=self.concatenate,
-                             filters=filters))
+        common_i.update(dict(concatenate=self.concatenate, filters=filters))
         tmout = False
 
         # Monitor for the input files
-        bm = BasicInputMonitor(self.context, caching_freq=self.refreshtime,
-                               role='Gridpoint', kind='gridpoint')
+        bm = BasicInputMonitor(
+            self.context,
+            caching_freq=self.refreshtime,
+            role="Gridpoint",
+            kind="gridpoint",
+        )
         with bm:
             while not bm.all_done or len(bm.available) > 0:
-
                 while bm.available:
                     s = bm.pop_available().section
                     file_in = s.rh.container.localpath()
-                    file_outfmt = re.sub(r'^(.*?)((:?\.[^.]*)?)$', r'\1_{filtername:s}\2', file_in)
+                    file_outfmt = re.sub(
+                        r"^(.*?)((:?\.[^.]*)?)$",
+                        r"\1_{filtername:s}\2",
+                        file_in,
+                    )
 
-                    logger.info("Adding input file %s to the job list", file_in)
-                    self._add_instructions(common_i,
-                                           dict(name=[file_in, ],
-                                                file_in=[file_in, ], file_outfmt=[file_outfmt, ]))
+                    logger.info(
+                        "Adding input file %s to the job list", file_in
+                    )
+                    self._add_instructions(
+                        common_i,
+                        dict(
+                            name=[
+                                file_in,
+                            ],
+                            file_in=[
+                                file_in,
+                            ],
+                            file_outfmt=[
+                                file_outfmt,
+                            ],
+                        ),
+                    )
 
                 if not (bm.all_done or len(bm.available) > 0):
                     # Timeout ?
@@ -453,11 +573,17 @@ class StandaloneGRIBFilter(TaylorRun):
 
         self._default_post_execute(rh, opts)
 
-        for failed_file in [e.section.rh.container.localpath() for e in bm.failed.values()]:
-            logger.error("We were unable to fetch the following file: %s", failed_file)
+        for failed_file in [
+            e.section.rh.container.localpath() for e in bm.failed.values()
+        ]:
+            logger.error(
+                "We were unable to fetch the following file: %s", failed_file
+            )
             if self.fatal:
-                self.delayed_exception_add(IOError("Unable to fetch {:s}".format(failed_file)),
-                                           traceback=False)
+                self.delayed_exception_add(
+                    IOError("Unable to fetch {:s}".format(failed_file)),
+                    traceback=False,
+                )
 
         if tmout:
             raise OSError("The waiting loop timed out")
@@ -467,24 +593,24 @@ class AddField(BlindRun):
     """Miscellaneous manipulation on input FA resources."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['addcst', 'addconst', 'addfield'],
-                remap = dict(
-                    addconst = 'addcst',
+        attr=dict(
+            kind=dict(
+                values=["addcst", "addconst", "addfield"],
+                remap=dict(
+                    addconst="addcst",
                 ),
             ),
-            fortnam = dict(
-                optional = True,
-                default = 'fort.4',
+            fortnam=dict(
+                optional=True,
+                default="fort.4",
             ),
-            fortinput = dict(
-                optional = True,
-                default = 'fort.11',
+            fortinput=dict(
+                optional=True,
+                default="fort.11",
             ),
-            fortoutput = dict(
-                optional = True,
-                default = 'fort.12',
+            fortoutput=dict(
+                optional=True,
+                default="fort.12",
             ),
         )
     )
@@ -499,21 +625,32 @@ class AddField(BlindRun):
         """Loop on the various initial conditions provided."""
 
         # Is there any namelist provided ?
-        namrh = [x.rh for x in self.context.sequence.effective_inputs(role=('Namelist'),
-                                                                      kind='namelist')]
+        namrh = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role=("Namelist"), kind="namelist"
+            )
+        ]
         if namrh:
             self.system.softlink(namrh[0].container.localpath(), self.fortnam)
         else:
-            logger.warning('Do not find any namelist for %s', self.kind)
+            logger.warning("Do not find any namelist for %s", self.kind)
 
         # Look for some sources files
-        srcrh = [x.rh for x in self.context.sequence.effective_inputs(role=('Gridpoint', 'Sources'),
-                                                                      kind='gridpoint')]
+        srcrh = [
+            x.rh
+            for x in self.context.sequence.effective_inputs(
+                role=("Gridpoint", "Sources"), kind="gridpoint"
+            )
+        ]
         srcrh.sort(key=lambda rh: rh.resource.term)
 
         for r in srcrh:
-            self.system.title('Loop on domain {:s} and term {:s}'.format(r.resource.geometry.area,
-                                                                         r.resource.term.fmthm))
+            self.system.title(
+                "Loop on domain {:s} and term {:s}".format(
+                    r.resource.geometry.area, r.resource.term.fmthm
+                )
+            )
 
             # Some cleaning
             self.system.remove(self.fortinput)
@@ -524,11 +661,11 @@ class AddField(BlindRun):
             self.system.cp(r.container.localpath(), self.fortoutput)
 
             # Standard execution
-            opts['loop'] = r.resource.term
+            opts["loop"] = r.resource.term
             super().execute(rh, opts)
 
             # Some cleaning
-            self.system.rmall('DAPDIR', self.fortinput, self.fortoutput)
+            self.system.rmall("DAPDIR", self.fortinput, self.fortoutput)
 
     def postfix(self, rh, opts):
         """Post add cleaning."""
@@ -538,14 +675,18 @@ class AddField(BlindRun):
 
 class DegradedDiagPEError(AlgoComponentError):
     """Exception raised when some of the members are missing in the calculations."""
+
     def __init__(self, ginfo, missings):
         super().__init__()
         self._ginfo = ginfo
         self._missings = missings
 
     def __str__(self):
-        outstr = "Missing input data for geometry={0.area:s}, term={1!s}:\n".format(self._ginfo['geometry'],
-                                                                                    self._ginfo['term'])
+        outstr = (
+            "Missing input data for geometry={0.area:s}, term={1!s}:\n".format(
+                self._ginfo["geometry"], self._ginfo["term"]
+            )
+        )
         for k, missing in self._missings.items():
             for member in missing:
                 outstr += "{:s}: member #{!s}\n".format(k, member)
@@ -554,80 +695,97 @@ class DegradedDiagPEError(AlgoComponentError):
 
 class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
     """Execution of diagnostics on grib input (ensemble forecasts specific)."""
+
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['diagpe'],
+        attr=dict(
+            kind=dict(
+                values=["diagpe"],
             ),
-            method = dict(
-                info   = 'The method used to compute the diagnosis',
-                values = ['neighbour'],
+            method=dict(
+                info="The method used to compute the diagnosis",
+                values=["neighbour"],
             ),
-            numod = dict(
-                type     = int,
-                info     = 'The GRIB model number',
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_NUMOD', 118),
+            numod=dict(
+                type=int,
+                info="The GRIB model number",
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_NUMOD", 118),
             ),
-            timeout = dict(
-                type     = int,
-                optional = True,
-                default  = 900,
+            timeout=dict(
+                type=int,
+                optional=True,
+                default=900,
             ),
-            refreshtime = dict(
-                type     = int,
-                optional = True,
-                default  = 20,
+            refreshtime=dict(
+                type=int,
+                optional=True,
+                default=20,
             ),
-            missinglimit = dict(
-                type     = int,
-                optional = True,
-                default  = 0,
+            missinglimit=dict(
+                type=int,
+                optional=True,
+                default=0,
             ),
-            waitlimit = dict(
-                type     = int,
-                optional = True,
-                default  = 900,
+            waitlimit=dict(
+                type=int,
+                optional=True,
+                default=900,
             ),
-            fatal = dict(
-                type     = bool,
-                optional = True,
-                default  = True,
+            fatal=dict(
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            gribfilter_tasks = dict(
-                type     = int,
-                optional = True,
-                default  = 8,
+            gribfilter_tasks=dict(
+                type=int,
+                optional=True,
+                default=8,
             ),
         ),
     )
 
-    _method2output_map = dict(neighbour='GRIB_PE_VOISIN')
+    _method2output_map = dict(neighbour="GRIB_PE_VOISIN")
 
     def spawn_hook(self):
         """Usually a good habit to dump the fort.4 namelist."""
         super().spawn_hook()
-        if self.system.path.exists('fort.4'):
-            self.system.subtitle('{:s} : dump namelist <fort.4>'.format(self.realkind))
-            self.system.cat('fort.4', output=False)
+        if self.system.path.exists("fort.4"):
+            self.system.subtitle(
+                "{:s} : dump namelist <fort.4>".format(self.realkind)
+            )
+            self.system.cat("fort.4", output=False)
 
-    def _actual_execute(self, gmembers, ifilters, filters, basedate, finalterm, rh, opts, gang):
+    def _actual_execute(
+        self, gmembers, ifilters, filters, basedate, finalterm, rh, opts, gang
+    ):
+        mygeometry = gang.info["geometry"]
+        myterm = gang.info["term"]
 
-        mygeometry = gang.info['geometry']
-        myterm = gang.info['term']
-
-        self.system.title('Start processing for geometry={:s}, term={!s}.'.
-                          format(mygeometry.area, myterm))
+        self.system.title(
+            "Start processing for geometry={:s}, term={!s}.".format(
+                mygeometry.area, myterm
+            )
+        )
 
         # Find out what is the common set of members
-        members = set(gmembers)  # gmembers is mutable: we need a copy of it (hence the explicit set())
+        members = set(
+            gmembers
+        )  # gmembers is mutable: we need a copy of it (hence the explicit set())
         missing_members = dict()
         for subgang in gang.memberslist:
-            smembers = {s.section.rh.provider.member for s in subgang.memberslist
-                        if s.state == EntrySt.available}
-            ufomembers = {s.section.rh.provider.member for s in subgang.memberslist
-                          if s.state == EntrySt.ufo}
-            missing_members[subgang.nickname] = gmembers - smembers - ufomembers
+            smembers = {
+                s.section.rh.provider.member
+                for s in subgang.memberslist
+                if s.state == EntrySt.available
+            }
+            ufomembers = {
+                s.section.rh.provider.member
+                for s in subgang.memberslist
+                if s.state == EntrySt.ufo
+            }
+            missing_members[subgang.nickname] = (
+                gmembers - smembers - ufomembers
+            )
             members &= smembers
         # Record an error
         if members != gmembers:
@@ -636,7 +794,9 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
             if self.fatal:
                 self.delayed_exception_add(newexc, traceback=False)
             else:
-                logger.info("Fatal is false consequently no exception is recorded. It would look like this:")
+                logger.info(
+                    "Fatal is false consequently no exception is recorded. It would look like this:"
+                )
                 print(newexc)
         members = sorted(members)
 
@@ -647,68 +807,113 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
         # If needed, concatenate or filter the "superset" files
         supersets = list()
         for subgang in gang.memberslist:
-            supersets.extend([(s.section.rh.container.localpath(),
-                               re.sub(r'^[a-zA-Z]+_(.*)$', r'\1', s.section.rh.container.localpath()))
-                              for s in subgang.memberslist
-                              if s.section.role == 'GridpointSuperset'])
-        supersets_todo = [(s, t) for s, t in supersets
-                          if not self.system.path.exists(t)]
+            supersets.extend(
+                [
+                    (
+                        s.section.rh.container.localpath(),
+                        re.sub(
+                            r"^[a-zA-Z]+_(.*)$",
+                            r"\1",
+                            s.section.rh.container.localpath(),
+                        ),
+                    )
+                    for s in subgang.memberslist
+                    if s.section.role == "GridpointSuperset"
+                ]
+            )
+        supersets_todo = [
+            (s, t) for s, t in supersets if not self.system.path.exists(t)
+        ]
         if supersets_todo:
             if len(ifilters):
-                parallel_grib_filter(self.context,
-                                     [s for s, t in supersets_todo],
-                                     [t for s, t in supersets_todo],
-                                     filters=ifilters, nthreads=self.gribfilter_tasks)
+                parallel_grib_filter(
+                    self.context,
+                    [s for s, t in supersets_todo],
+                    [t for s, t in supersets_todo],
+                    filters=ifilters,
+                    nthreads=self.gribfilter_tasks,
+                )
             else:
-                parallel_grib_filter(self.context,
-                                     [s for s, t in supersets_todo],
-                                     [t for s, t in supersets_todo],
-                                     cat=True, nthreads=self.gribfilter_tasks)
+                parallel_grib_filter(
+                    self.context,
+                    [s for s, t in supersets_todo],
+                    [t for s, t in supersets_todo],
+                    cat=True,
+                    nthreads=self.gribfilter_tasks,
+                )
 
         # Tweak the namelist
-        namsec = self.setlink(initrole='Namelist', initkind='namelist', initname='fort.4')
-        for nam in [x.rh for x in namsec if 'NAM_PARAM' in x.rh.contents]:
-            logger.info("Substitute the date (%s) to AAAAMMJJHH namelist entry", basedate.ymdh)
-            nam.contents['NAM_PARAM']['AAAAMMJJHH'] = basedate.ymdh
-            logger.info("Substitute the number of members (%d) to NBRUN namelist entry", len(members))
-            nam.contents['NAM_PARAM']['NBRUN'] = len(members)
-            logger.info("Substitute the the number of terms to NECH(0) namelist entry")
-            nam.contents['NAM_PARAM']['NECH(0)'] = 1
-            logger.info("Substitute the ressource term to NECH(1) namelist entry")
+        namsec = self.setlink(
+            initrole="Namelist", initkind="namelist", initname="fort.4"
+        )
+        for nam in [x.rh for x in namsec if "NAM_PARAM" in x.rh.contents]:
+            logger.info(
+                "Substitute the date (%s) to AAAAMMJJHH namelist entry",
+                basedate.ymdh,
+            )
+            nam.contents["NAM_PARAM"]["AAAAMMJJHH"] = basedate.ymdh
+            logger.info(
+                "Substitute the number of members (%d) to NBRUN namelist entry",
+                len(members),
+            )
+            nam.contents["NAM_PARAM"]["NBRUN"] = len(members)
+            logger.info(
+                "Substitute the the number of terms to NECH(0) namelist entry"
+            )
+            nam.contents["NAM_PARAM"]["NECH(0)"] = 1
+            logger.info(
+                "Substitute the ressource term to NECH(1) namelist entry"
+            )
             # NB: term should be expressed in minutes
-            nam.contents['NAM_PARAM']['NECH(1)'] = int(myterm)
-            nam.contents['NAM_PARAM']['ECHFINALE'] = finalterm.hour
+            nam.contents["NAM_PARAM"]["NECH(1)"] = int(myterm)
+            nam.contents["NAM_PARAM"]["ECHFINALE"] = finalterm.hour
             # Now, update the model number for the GRIB files
-            logger.info("Substitute the model number (%d) to namelist entry", self.numod)
-            nam.contents['NAM_PARAM']['NMODELE'] = self.numod
+            logger.info(
+                "Substitute the model number (%d) to namelist entry",
+                self.numod,
+            )
+            nam.contents["NAM_PARAM"]["NMODELE"] = self.numod
             # Add the NAM_PARAMPE block
-            if 'NAM_NMEMBRES' in nam.contents:
+            if "NAM_NMEMBRES" in nam.contents:
                 # Cleaning is needed...
-                del nam.contents['NAM_NMEMBRES']
-            newblock = nam.contents.newblock('NAM_NMEMBRES')
+                del nam.contents["NAM_NMEMBRES"]
+            newblock = nam.contents.newblock("NAM_NMEMBRES")
             for i, member in enumerate(members):
-                newblock['NMEMBRES({:d})'.format(i + 1)] = int(member)
+                newblock["NMEMBRES({:d})".format(i + 1)] = int(member)
             # We are done with the namelist
             nam.save()
 
         # Standard execution
-        opts['loop'] = myterm
+        opts["loop"] = myterm
         super().execute(rh, opts)
 
-        actualname = r'{:s}_{:s}\+{:s}'.format(self._method2output_map[self.method],
-                                               mygeometry.area, myterm.fmthm)
+        actualname = r"{:s}_{:s}\+{:s}".format(
+            self._method2output_map[self.method], mygeometry.area, myterm.fmthm
+        )
         # Find out the output file and filter it
         filtered_out = list()
         if len(filters):
-            for candidate in [f for f in self.system.glob(self._method2output_map[self.method] + '*')
-                              if re.match(actualname, f)]:
+            for candidate in [
+                f
+                for f in self.system.glob(
+                    self._method2output_map[self.method] + "*"
+                )
+                if re.match(actualname, f)
+            ]:
                 logger.info("Starting GRIB filtering on %s.", candidate)
-                filtered_out.extend(filters(candidate, candidate + '_{filtername:s}'))
+                filtered_out.extend(
+                    filters(candidate, candidate + "_{filtername:s}")
+                )
 
         # The diagnostic output may be promised
-        expected = [x for x in self.promises
-                    if (re.match(actualname, x.rh.container.localpath()) or
-                        x.rh.container.localpath() in filtered_out)]
+        expected = [
+            x
+            for x in self.promises
+            if (
+                re.match(actualname, x.rh.container.localpath())
+                or x.rh.container.localpath() in filtered_out
+            )
+        ]
         for thispromise in expected:
             thispromise.put(incache=True)
 
@@ -718,20 +923,30 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
         # Intialise a GRIBFilter for output files (at least try to)
         gfilter = GRIBFilter(concatenate=False)
         # We re-serialise data because footprints don't like dictionaries
-        ofilters = [x.rh.contents.data
-                    for x in self.context.sequence.effective_inputs(role='GRIBFilteringRequest',
-                                                                    kind='filtering_request')]
+        ofilters = [
+            x.rh.contents.data
+            for x in self.context.sequence.effective_inputs(
+                role="GRIBFilteringRequest", kind="filtering_request"
+            )
+        ]
         gfilter.add_filters(ofilters)
 
         # Do we need to filter input files ?
         # We re-serialise data because footprints don't like dictionaries
-        ifilters = [json.dumps(x.rh.contents.data)
-                    for x in self.context.sequence.effective_inputs(role='GRIBInputFilteringRequest')]
+        ifilters = [
+            json.dumps(x.rh.contents.data)
+            for x in self.context.sequence.effective_inputs(
+                role="GRIBInputFilteringRequest"
+            )
+        ]
 
         # Monitor for the input files
-        bm = BasicInputMonitor(self.context, caching_freq=self.refreshtime,
-                               role=(re.compile(r'^Gridpoint'), 'Sources'),
-                               kind='gridpoint')
+        bm = BasicInputMonitor(
+            self.context,
+            caching_freq=self.refreshtime,
+            role=(re.compile(r"^Gridpoint"), "Sources"),
+            kind="gridpoint",
+        )
         # Check that the date is consistent among inputs
         basedates = set()
         members = set()
@@ -739,19 +954,29 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
             basedates.add(rhI.resource.date)
             members.add(rhI.provider.member)
         if len(basedates) > 1:
-            raise AlgoComponentError('The date must be consistent among the input resources')
+            raise AlgoComponentError(
+                "The date must be consistent among the input resources"
+            )
         basedate = basedates.pop()
         # Setup BasicGangs
         basicmeta = AutoMetaGang()
-        basicmeta.autofill(bm, ('term', 'safeblock', 'geometry'),
-                           allowmissing=self.missinglimit, waitlimit=self.waitlimit)
+        basicmeta.autofill(
+            bm,
+            ("term", "safeblock", "geometry"),
+            allowmissing=self.missinglimit,
+            waitlimit=self.waitlimit,
+        )
         # Find out what are the terms, domains and blocks
         geometries = set()
         terms = collections.defaultdict(set)
         blocks = collections.defaultdict(set)
         reverse = dict()
         for m in basicmeta.memberslist:
-            (geo, term, block) = (m.info['geometry'], m.info['term'], m.info['safeblock'])
+            (geo, term, block) = (
+                m.info["geometry"],
+                m.info["term"],
+                m.info["safeblock"],
+            )
             geometries.add(geo)
             terms[geo].add(term)
             blocks[geo].add(block)
@@ -766,20 +991,25 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
             for i_term, term in enumerate(terms[geometry]):
                 elementary_meta = MetaGang()
                 elementary_meta.info = dict(geometry=geometry, term=term)
-                cterms = [terms[geometry][i] for i in range(i_term,
-                                                            min(i_term + 2, nterms))]
+                cterms = [
+                    terms[geometry][i]
+                    for i in range(i_term, min(i_term + 2, nterms))
+                ]
                 for inside_term in cterms:
                     for inside_block in blocks[geometry]:
                         try:
-                            elementary_meta.add_member(reverse[(geometry, inside_term, inside_block)])
+                            elementary_meta.add_member(
+                                reverse[(geometry, inside_term, inside_block)]
+                            )
                         except KeyError:
-                            raise KeyError("Something is wrong in the inputs: check again !")
+                            raise KeyError(
+                                "Something is wrong in the inputs: check again !"
+                            )
                 complexmeta.add_member(elementary_meta)
                 complexgangs[geometry].append(elementary_meta)
 
         # Now, starts monitoring everything
         with bm:
-
             current_gang = dict()
             for geometry in geometries:
                 try:
@@ -788,23 +1018,40 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
                     current_gang[geometry] = None
 
             while any([g is not None for g in current_gang.values()]):
-
-                for geometry, a_gang in [(g, current_gang[g]) for g in geometries
-                                         if (current_gang[g] is not None and
-                                             current_gang[g].state is not GangSt.ufo)]:
-
-                    self._actual_execute(members, ifilters, gfilter, basedate,
-                                         terms[geometry][-1], rh, opts, a_gang)
+                for geometry, a_gang in [
+                    (g, current_gang[g])
+                    for g in geometries
+                    if (
+                        current_gang[g] is not None
+                        and current_gang[g].state is not GangSt.ufo
+                    )
+                ]:
+                    self._actual_execute(
+                        members,
+                        ifilters,
+                        gfilter,
+                        basedate,
+                        terms[geometry][-1],
+                        rh,
+                        opts,
+                        a_gang,
+                    )
 
                     # Next one
                     try:
-                        current_gang[geometry] = complexgangs[geometry].popleft()
+                        current_gang[geometry] = complexgangs[
+                            geometry
+                        ].popleft()
                     except IndexError:
                         current_gang[geometry] = None
 
-                if not (bm.all_done or any(gang is not None and
-                                           gang.state is not GangSt.ufo
-                                           for gang in current_gang.values())):
+                if not (
+                    bm.all_done
+                    or any(
+                        gang is not None and gang.state is not GangSt.ufo
+                        for gang in current_gang.values()
+                    )
+                ):
                     # Timeout ?
                     bm.is_timedout(self.timeout, IOError)
                     # Wait a little bit :-)
@@ -816,40 +1063,41 @@ class DiagPE(BlindRun, DrHookDecoMixin, EcGribDecoMixin):
 class _DiagPIDecoMixin(AlgoComponentDecoMixin):
     """Class variables and methods usefull for DiagPI."""
 
-    _MIXIN_EXTRA_FOOTPRINTS = [footprints.Footprint(
-        attr=dict(
-            kind=dict(
-                values=['diagpi', 'diaglabo'],
+    _MIXIN_EXTRA_FOOTPRINTS = [
+        footprints.Footprint(
+            attr=dict(
+                kind=dict(
+                    values=["diagpi", "diaglabo"],
+                ),
+                numod=dict(
+                    info="The GRIB model number",
+                    type=int,
+                    optional=True,
+                    default=DelayedEnvValue("VORTEX_GRIB_NUMOD", 62),
+                ),
+                gribcat=dict(type=bool, optional=True, default=False),
+                gribfilter_tasks=dict(
+                    type=int,
+                    optional=True,
+                    default=8,
+                ),
             ),
-            numod=dict(
-                info='The GRIB model number',
-                type=int,
-                optional=True,
-                default=DelayedEnvValue('VORTEX_GRIB_NUMOD', 62),
-            ),
-            gribcat=dict(
-                type=bool,
-                optional=True,
-                default=False
-            ),
-            gribfilter_tasks=dict(
-                type=int,
-                optional=True,
-                default=8,
-            ),
-        ),
-    )]
+        )
+    ]
 
     def _prepare_pihook(self, rh, opts):
         """Set some variables according to target definition."""
 
         # Check for input files to concatenate
         if self.gribcat:
-            srcsec = self.context.sequence.effective_inputs(role=('Gridpoint', 'Sources',
-                                                                  'Preview', 'Previous'),
-                                                            kind='gridpoint')
+            srcsec = self.context.sequence.effective_inputs(
+                role=("Gridpoint", "Sources", "Preview", "Previous"),
+                kind="gridpoint",
+            )
             cat_list_in = [sec for sec in srcsec if not sec.rh.is_expected()]
-            outsec = self.context.sequence.effective_inputs(role='GridpointOutputPrepare')
+            outsec = self.context.sequence.effective_inputs(
+                role="GridpointOutputPrepare"
+            )
             cat_list_out = [sec for sec in outsec if not sec.rh.is_expected()]
             self._automatic_cat(cat_list_in, cat_list_out)
 
@@ -863,13 +1111,15 @@ class _DiagPIDecoMixin(AlgoComponentDecoMixin):
 
     def _spawn_pihook(self):
         """Usually a good habit to dump the fort.4 namelist."""
-        if self.system.path.exists('fort.4'):
-            self.system.subtitle('{:s} : dump namelist <fort.4>'.format(self.realkind))
-            self.system.cat('fort.4', output=False)
+        if self.system.path.exists("fort.4"):
+            self.system.subtitle(
+                "{:s} : dump namelist <fort.4>".format(self.realkind)
+            )
+            self.system.cat("fort.4", output=False)
 
-    _MIXIN_PREPARE_HOOKS = (_prepare_pihook, )
-    _MIXIN_POSTFIX_HOOKS = (_postfix_pihook, )
-    _MIXIN_SPAWN_HOOKS = (_spawn_pihook, )
+    _MIXIN_PREPARE_HOOKS = (_prepare_pihook,)
+    _MIXIN_POSTFIX_HOOKS = (_postfix_pihook,)
+    _MIXIN_SPAWN_HOOKS = (_spawn_pihook,)
 
     def _automatic_cat(self, list_in, list_out):
         """Concatenate the *list_in* and *list_out* input files."""
@@ -877,27 +1127,42 @@ class _DiagPIDecoMixin(AlgoComponentDecoMixin):
             inputs = []
             outputs = []
             intents = []
-            for (seclist, intent) in zip((list_in, list_out), ('in', 'inout')):
+            for seclist, intent in zip((list_in, list_out), ("in", "inout")):
                 for isec in seclist:
-                    tmpin = isec.rh.container.localpath() + '.tmpcat'
-                    self.system.move(isec.rh.container.localpath(), tmpin, fmt='grib')
+                    tmpin = isec.rh.container.localpath() + ".tmpcat"
+                    self.system.move(
+                        isec.rh.container.localpath(), tmpin, fmt="grib"
+                    )
                     inputs.append(tmpin)
                     outputs.append(isec.rh.container.localpath())
                     intents.append(intent)
-            parallel_grib_filter(self.context, inputs, outputs, intents,
-                                 cat=True, nthreads=self.gribfilter_tasks)
+            parallel_grib_filter(
+                self.context,
+                inputs,
+                outputs,
+                intents,
+                cat=True,
+                nthreads=self.gribfilter_tasks,
+            )
             for ifile in inputs:
-                self.system.rm(ifile, fmt='grib')
+                self.system.rm(ifile, fmt="grib")
 
     def _batch_filter(self, candidates):
         """If no promises are made, the GRIB are filtered at once at the end."""
         # We re-serialise data because footprints don't like dictionaries
-        filters = [json.dumps(x.rh.contents.data)
-                   for x in self.context.sequence.effective_inputs(role='GRIBFilteringRequest',
-                                                                   kind='filtering_request')]
-        parallel_grib_filter(self.context,
-                             candidates, [f + '_{filtername:s}' for f in candidates],
-                             filters=FPTuple(filters), nthreads=self.gribfilter_tasks)
+        filters = [
+            json.dumps(x.rh.contents.data)
+            for x in self.context.sequence.effective_inputs(
+                role="GRIBFilteringRequest", kind="filtering_request"
+            )
+        ]
+        parallel_grib_filter(
+            self.context,
+            candidates,
+            [f + "_{filtername:s}" for f in candidates],
+            filters=FPTuple(filters),
+            nthreads=self.gribfilter_tasks,
+        )
 
     def _execute_picommons(self, rh, opts):
         """Loop on the various grib files provided."""
@@ -906,39 +1171,60 @@ class _DiagPIDecoMixin(AlgoComponentDecoMixin):
         gfilter = GRIBFilter(concatenate=False)
         gfilter.add_filters(self.context)
 
-        srcsec = self.context.sequence.effective_inputs(role=('Gridpoint', 'Sources'),
-                                                        kind='gridpoint')
+        srcsec = self.context.sequence.effective_inputs(
+            role=("Gridpoint", "Sources"), kind="gridpoint"
+        )
         srcsec.sort(key=lambda s: s.rh.resource.term)
 
-        outsec = self.context.sequence.effective_inputs(role='GridpointOutputPrepare')
+        outsec = self.context.sequence.effective_inputs(
+            role="GridpointOutputPrepare"
+        )
         if outsec:
             outsec.sort(key=lambda s: s.rh.resource.term)
 
         for sec in srcsec:
             r = sec.rh
-            self.system.title('Loop on domain {:s} and term {:s}'.format(r.resource.geometry.area,
-                                                                         r.resource.term.fmthm))
+            self.system.title(
+                "Loop on domain {:s} and term {:s}".format(
+                    r.resource.geometry.area, r.resource.term.fmthm
+                )
+            )
             # Tweak the namelist
-            namsec = self.setlink(initrole='Namelist', initkind='namelist', initname='fort.4')
-            for nam in [x.rh for x in namsec if 'NAM_PARAM' in x.rh.contents]:
-                logger.info("Substitute the date (%s) to AAAAMMJJHH namelist entry", r.resource.date.ymdh)
-                nam.contents['NAM_PARAM']['AAAAMMJJHH'] = r.resource.date.ymdh
-                logger.info("Substitute the the number of terms to NECH(0) namelist entry")
-                nam.contents['NAM_PARAM']['NECH(0)'] = 1
-                logger.info("Substitute the ressource term to NECH(1) namelist entry")
+            namsec = self.setlink(
+                initrole="Namelist", initkind="namelist", initname="fort.4"
+            )
+            for nam in [x.rh for x in namsec if "NAM_PARAM" in x.rh.contents]:
+                logger.info(
+                    "Substitute the date (%s) to AAAAMMJJHH namelist entry",
+                    r.resource.date.ymdh,
+                )
+                nam.contents["NAM_PARAM"]["AAAAMMJJHH"] = r.resource.date.ymdh
+                logger.info(
+                    "Substitute the the number of terms to NECH(0) namelist entry"
+                )
+                nam.contents["NAM_PARAM"]["NECH(0)"] = 1
+                logger.info(
+                    "Substitute the ressource term to NECH(1) namelist entry"
+                )
                 # NB: term should be expressed in minutes
-                nam.contents['NAM_PARAM']['NECH(1)'] = int(r.resource.term)
+                nam.contents["NAM_PARAM"]["NECH(1)"] = int(r.resource.term)
                 # Add the member number in a dedicated namelist block
                 if r.provider.member is not None:
-                    mblock = nam.contents.newblock('NAM_PARAMPE')
-                    mblock['NMEMBER'] = int(r.provider.member)
+                    mblock = nam.contents.newblock("NAM_PARAMPE")
+                    mblock["NMEMBER"] = int(r.provider.member)
                 # Now, update the model number for the GRIB files
-                if 'NAM_DIAG' in nam.contents:
+                if "NAM_DIAG" in nam.contents:
                     nmod = self.numod
-                    logger.info("Substitute the model number (%d) to namelist entry", nmod)
-                    for namk in ('CONV', 'BR', 'HIV', 'ECHOT', 'ICA', 'PSN'):
-                        if namk in nam.contents['NAM_DIAG'] and nam.contents['NAM_DIAG'][namk] != 0:
-                            nam.contents['NAM_DIAG'][namk] = nmod
+                    logger.info(
+                        "Substitute the model number (%d) to namelist entry",
+                        nmod,
+                    )
+                    for namk in ("CONV", "BR", "HIV", "ECHOT", "ICA", "PSN"):
+                        if (
+                            namk in nam.contents["NAM_DIAG"]
+                            and nam.contents["NAM_DIAG"][namk] != 0
+                        ):
+                            nam.contents["NAM_DIAG"][namk] = nmod
                 # We are done with the namelist
                 nam.save()
 
@@ -948,46 +1234,65 @@ class _DiagPIDecoMixin(AlgoComponentDecoMixin):
             # Expect the input grib file to be here
             if sec.rh.is_expected():
                 cat_list_in.append(sec)
-            self.grab(sec, comment='diagpi source')
+            self.grab(sec, comment="diagpi source")
             if outsec:
                 out = outsec.pop(0)
                 assert out.rh.resource.term == sec.rh.resource.term
                 if out.rh.is_expected():
                     cat_list_out.append(out)
-                self.grab(out, comment='diagpi output')
+                self.grab(out, comment="diagpi output")
 
             # Also link in previous grib files in order to compute some winter diagnostics
-            srcpsec = [x
-                       for x in self.context.sequence.effective_inputs(role=('Preview', 'Previous'),
-                                                                       kind='gridpoint')
-                       if x.rh.resource.term < r.resource.term]
+            srcpsec = [
+                x
+                for x in self.context.sequence.effective_inputs(
+                    role=("Preview", "Previous"), kind="gridpoint"
+                )
+                if x.rh.resource.term < r.resource.term
+            ]
             for pr in srcpsec:
                 if pr.rh.is_expected():
                     cat_list_in.append(pr)
-                self.grab(pr, comment='diagpi additional source for winter diag')
+                self.grab(
+                    pr, comment="diagpi additional source for winter diag"
+                )
 
             self._automatic_cat(cat_list_in, cat_list_out)
 
             # Standard execution
-            opts['loop'] = r.resource.term
+            opts["loop"] = r.resource.term
             super(self.mixin_execute_companion(), self).execute(rh, opts)
 
-            actualname = r'GRIB[-_A-Z]+{:s}\+{:s}(?:_member\d+)?$'.format(r.resource.geometry.area,
-                                                                          r.resource.term.fmthm)
+            actualname = r"GRIB[-_A-Z]+{:s}\+{:s}(?:_member\d+)?$".format(
+                r.resource.geometry.area, r.resource.term.fmthm
+            )
             # Find out the output file and filter it
             filtered_out = list()
             if len(gfilter):
-                for candidate in [f for f in self.system.glob('GRIB*') if re.match(actualname, f)]:
+                for candidate in [
+                    f
+                    for f in self.system.glob("GRIB*")
+                    if re.match(actualname, f)
+                ]:
                     if len(self.promises):
-                        logger.info("Starting GRIB filtering on %s.", candidate)
-                        filtered_out.extend(gfilter(candidate, candidate + '_{filtername:s}'))
+                        logger.info(
+                            "Starting GRIB filtering on %s.", candidate
+                        )
+                        filtered_out.extend(
+                            gfilter(candidate, candidate + "_{filtername:s}")
+                        )
                     else:
                         self._delayed_filtering.append(candidate)
 
             # The diagnostic output may be promised
-            expected = [x for x in self.promises
-                        if (re.match(actualname, x.rh.container.localpath()) or
-                            x.rh.container.localpath() in filtered_out)]
+            expected = [
+                x
+                for x in self.promises
+                if (
+                    re.match(actualname, x.rh.container.localpath())
+                    or x.rh.container.localpath() in filtered_out
+                )
+            ]
             for thispromise in expected:
                 thispromise.put(incache=True)
 
@@ -996,11 +1301,13 @@ class _DiagPIDecoMixin(AlgoComponentDecoMixin):
 
 class DiagPI(BlindRun, _DiagPIDecoMixin, EcGribDecoMixin):
     """Execution of diagnostics on grib input (deterministic forecasts specific)."""
+
     pass
 
 
 class DiagPIMPI(Parallel, _DiagPIDecoMixin, EcGribDecoMixin):
     """Execution of diagnostics on grib input (deterministic forecasts specific)."""
+
     pass
 
 
@@ -1008,23 +1315,23 @@ class Fa2GaussGrib(BlindRun, DrHookDecoMixin):
     """Standard FA conversion, e.g. with GOBPTOUT as a binary resource."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values  = ['fa2gaussgrib'],
+        attr=dict(
+            kind=dict(
+                values=["fa2gaussgrib"],
             ),
-            fortinput = dict(
-                optional = True,
-                default = 'PFFPOS_FIELDS',
+            fortinput=dict(
+                optional=True,
+                default="PFFPOS_FIELDS",
             ),
-            numod = dict(
-                type     = int,
-                optional = True,
-                default  = DelayedEnvValue('VORTEX_GRIB_NUMOD', 212),
+            numod=dict(
+                type=int,
+                optional=True,
+                default=DelayedEnvValue("VORTEX_GRIB_NUMOD", 212),
             ),
-            verbose = dict(
-                type     = bool,
-                optional = True,
-                default  = False,
+            verbose=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
         )
     )
@@ -1032,35 +1339,43 @@ class Fa2GaussGrib(BlindRun, DrHookDecoMixin):
     def execute(self, rh, opts):
         """Loop on the various initial conditions provided."""
 
-        thisoutput = 'GRID_' + self.fortinput[7:14] + '1'
+        thisoutput = "GRID_" + self.fortinput[7:14] + "1"
 
-        gpsec = self.context.sequence.effective_inputs(role=('Historic', 'ModelState'))
+        gpsec = self.context.sequence.effective_inputs(
+            role=("Historic", "ModelState")
+        )
         gpsec.sort(key=lambda s: s.rh.resource.term)
 
         for sec in gpsec:
             r = sec.rh
 
-            self.system.title('Loop on files: {:s}'.format(r.container.localpath()))
+            self.system.title(
+                "Loop on files: {:s}".format(r.container.localpath())
+            )
 
             # Some preventive cleaning
             self.system.remove(thisoutput)
-            self.system.remove('fort.4')
+            self.system.remove("fort.4")
 
             # Build the local namelist block
-            nb = NamelistBlock(name='NAML')
+            nb = NamelistBlock(name="NAML")
             nb.NBDOM = 1
             nb.INUMOD = self.numod
 
-            nb['LLBAVE'] = self.verbose
-            nb['CDNOMF(1)'] = self.fortinput
-            with open('fort.4', 'w') as namfd:
+            nb["LLBAVE"] = self.verbose
+            nb["CDNOMF(1)"] = self.fortinput
+            with open("fort.4", "w") as namfd:
                 namfd.write(nb.dumps())
 
-            self.system.header('{:s} : local namelist {:s} dump'.format(self.realkind, 'fort.4'))
-            self.system.cat('fort.4', output=False)
+            self.system.header(
+                "{:s} : local namelist {:s} dump".format(
+                    self.realkind, "fort.4"
+                )
+            )
+            self.system.cat("fort.4", output=False)
 
             # Expect the input FP file source to be there...
-            self.grab(sec, comment='fullpos source')
+            self.grab(sec, comment="fullpos source")
 
             # Finally set the actual init file
             self.system.softlink(r.container.localpath(), self.fortinput)
@@ -1070,10 +1385,13 @@ class Fa2GaussGrib(BlindRun, DrHookDecoMixin):
 
             # Freeze the current output
             if self.system.path.exists(thisoutput):
-                self.system.move(thisoutput, 'GGRID' + r.container.localpath()[6:], fmt='grib')
+                self.system.move(
+                    thisoutput,
+                    "GGRID" + r.container.localpath()[6:],
+                    fmt="grib",
+                )
             else:
-                logger.warning('Missing some grib output for %s',
-                               thisoutput)
+                logger.warning("Missing some grib output for %s", thisoutput)
 
             # Some cleaning
             self.system.rmall(self.fortinput)
@@ -1081,47 +1399,53 @@ class Fa2GaussGrib(BlindRun, DrHookDecoMixin):
 
 class Reverser(BlindRun, DrHookDecoMixin):
     """Compute the initial state for Ctpini."""
+
     _footprint = dict(
-        info = "Compute initial state for Ctpini.",
-        attr = dict(
-            kind = dict(
-                values  = ['reverser'],
+        info="Compute initial state for Ctpini.",
+        attr=dict(
+            kind=dict(
+                values=["reverser"],
             ),
-            param_iter = dict(
-                type = int,
+            param_iter=dict(
+                type=int,
             ),
-            condlim = dict(
-                type = int,
+            condlim=dict(
+                type=int,
             ),
-            ano_type = dict(
-                type = int,
+            ano_type=dict(
+                type=int,
             ),
-        )
+        ),
     )
 
     def prepare(self, rh, opts):
         # Get info about the directives files directory
-        directives = self.context.sequence.effective_inputs(role='Directives',
-                                                            kind='ctpini_directives_file')
+        directives = self.context.sequence.effective_inputs(
+            role="Directives", kind="ctpini_directives_file"
+        )
         if len(directives) < 1:
             logger.error("No directive file found. Stop")
             raise ValueError("No directive file found.")
         if len(directives) > 1:
-            logger.warning("Multiple directive files found. This is strange...")
+            logger.warning(
+                "Multiple directive files found. This is strange..."
+            )
         # Substitute values in the simili namelist
-        param = self.context.sequence.effective_inputs(role='Param')
+        param = self.context.sequence.effective_inputs(role="Param")
         if len(param) < 1:
             logger.error("No parameter file found. Stop")
             raise ValueError("No parameter file found.")
         elif len(param) > 1:
-            logger.warning("Multiple files for parameter, the first %s is taken",
-                           param[0].rh.container.filename)
+            logger.warning(
+                "Multiple files for parameter, the first %s is taken",
+                param[0].rh.container.filename,
+            )
         param = param[0].rh
         paramct = param.contents
         dictkeyvalue = dict()
-        dictkeyvalue[r'param_iter'] = str(self.param_iter)
-        dictkeyvalue[r'condlim'] = str(self.condlim)
-        dictkeyvalue[r'ano_type'] = str(self.ano_type)
+        dictkeyvalue[r"param_iter"] = str(self.param_iter)
+        dictkeyvalue[r"condlim"] = str(self.condlim)
+        dictkeyvalue[r"ano_type"] = str(self.ano_type)
         paramct.setitems(dictkeyvalue)
         param.save()
         logger.info("Here is the parameter file (after substitution):")
@@ -1132,11 +1456,13 @@ class Reverser(BlindRun, DrHookDecoMixin):
 
 class DegradedEnsembleDiagError(AlgoComponentError):
     """Exception raised when some of the members are missing."""
+
     pass
 
 
 class FailedEnsembleDiagError(DegradedEnsembleDiagError):
     """Exception raised when too many members are missing."""
+
     pass
 
 
@@ -1144,29 +1470,29 @@ class PyEnsembleDiag(Expresso):
     """Execution of diagnostics on grib input (ensemble forecasts specific)."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values = ['py_diag_ens'],
+        attr=dict(
+            kind=dict(
+                values=["py_diag_ens"],
             ),
-            timeout = dict(
-                type     = int,
-                optional = True,
-                default  = 1200,
+            timeout=dict(
+                type=int,
+                optional=True,
+                default=1200,
             ),
-            refreshtime = dict(
-                type     = int,
-                optional = True,
-                default  = 20,
+            refreshtime=dict(
+                type=int,
+                optional=True,
+                default=20,
             ),
-            missinglimit = dict(
-                type     = int,
-                optional = True,
-                default  = 0,
+            missinglimit=dict(
+                type=int,
+                optional=True,
+                default=0,
             ),
-            waitlimit = dict(
-                type     = int,
-                optional = True,
-                default  = 900,
+            waitlimit=dict(
+                type=int,
+                optional=True,
+                default=900,
             ),
         ),
     )
@@ -1179,39 +1505,47 @@ class PyEnsembleDiag(Expresso):
         """Prepare options for the resource's command line."""
         return self._cl_args
 
-    def _actual_execute(self, rh, opts, input_rhs, ** infos):
+    def _actual_execute(self, rh, opts, input_rhs, **infos):
         """Actually run the script for a specific bunch of input files (**inpu_rhs**)."""
-        output_fname = ('ensdiag_{safeblock:s}_{geometry.tag:s}_{term.fmthm}.grib'
-                        .format(** infos))
-        self._cl_args = dict(flowconf='flowconf.json',
-                             output=output_fname)
+        output_fname = (
+            "ensdiag_{safeblock:s}_{geometry.tag:s}_{term.fmthm}.grib".format(
+                **infos
+            )
+        )
+        self._cl_args = dict(flowconf="flowconf.json", output=output_fname)
 
         # Create the JSON file that will be ingested by the script
         self.system.json_dump(
-            dict(date=input_rhs[0].resource.date.ymdhm,
-                 term=infos['term'].fmthm,
-                 geometry=infos['geometry'].tag,
-                 area=infos['geometry'].area,
-                 block=infos['safeblock'],
-                 grib_files=[r.container.localpath() for r in input_rhs],
-                 ),
-            self._cl_args['flowconf']
+            dict(
+                date=input_rhs[0].resource.date.ymdhm,
+                term=infos["term"].fmthm,
+                geometry=infos["geometry"].tag,
+                area=infos["geometry"].area,
+                block=infos["safeblock"],
+                grib_files=[r.container.localpath() for r in input_rhs],
+            ),
+            self._cl_args["flowconf"],
         )
 
         # Actualy run the post-processing script
         super().execute(rh, opts)
 
         # The diagnostic output may be promised
-        for thispromise in [x for x in self.promises
-                            if output_fname == x.rh.container.localpath()]:
+        for thispromise in [
+            x
+            for x in self.promises
+            if output_fname == x.rh.container.localpath()
+        ]:
             thispromise.put(incache=True)
 
     @staticmethod
     def _gang_txt_id(gang):
         """A string that identifies the input data currently being processed."""
-        return ("term={term.fmthm:s}, " +
-                "geometry={geometry.tag:s} " +
-                "and block={safeblock:s}").format(** gang.info)
+        return (
+            "term={term.fmthm:s}, "
+            + "geometry={geometry.tag:s} "
+            + "and block={safeblock:s}"
+        ).format(**gang.info)
 
     def _handle_gang_rescue(self, gang):
         """If some of the entries are missing, create a delayed exception."""
@@ -1220,24 +1554,31 @@ class PyEnsembleDiag(Expresso):
             self.system.subtitle("WARNING: Missing data for " + txt_id)
             for st in (EntrySt.ufo, EntrySt.failed, EntrySt.expected):
                 if gang.members[st]:
-                    print('Here is the list of Resource Handler with status < {:s} >:'
-                          .format(st))
+                    print(
+                        "Here is the list of Resource Handler with status < {:s} >:".format(
+                            st
+                        )
+                    )
                     for i, e in enumerate(gang.members[st]):
                         e.section.rh.quickview(nb=i + 1, indent=1)
             self.delayed_exception_add(
-                FailedEnsembleDiagError("Too many inputs are missing for " + txt_id)
-                if gang.state == GangSt.failed else
-                DegradedEnsembleDiagError("Some of the inputs are missing for " + txt_id),
-                traceback=False
+                FailedEnsembleDiagError(
+                    "Too many inputs are missing for " + txt_id
+                )
+                if gang.state == GangSt.failed
+                else DegradedEnsembleDiagError(
+                    "Some of the inputs are missing for " + txt_id
+                ),
+                traceback=False,
             )
 
     def execute(self, rh, opts):
         """Loop on the various grib files provided."""
 
         # Monitor for the input files
-        bm = BasicInputMonitor(self.context,
-                               caching_freq=self.refreshtime,
-                               role='Gridpoint')
+        bm = BasicInputMonitor(
+            self.context, caching_freq=self.refreshtime, role="Gridpoint"
+        )
 
         # Check that the date is consistent among inputs
         basedates = set()
@@ -1246,12 +1587,18 @@ class PyEnsembleDiag(Expresso):
             basedates.add(rhI.resource.date)
             members.add(rhI.provider.member)
         if len(basedates) > 1:
-            raise AlgoComponentError('The date must be consistent among the input resources')
+            raise AlgoComponentError(
+                "The date must be consistent among the input resources"
+            )
 
         # Setup BasicGangs
         basicmeta = AutoMetaGang()
-        basicmeta.autofill(bm, ('term', 'safeblock', 'geometry'),
-                           allowmissing=self.missinglimit, waitlimit=self.waitlimit)
+        basicmeta.autofill(
+            bm,
+            ("term", "safeblock", "geometry"),
+            allowmissing=self.missinglimit,
+            waitlimit=self.waitlimit,
+        )
 
         # Now, starts monitoring everything
         with bm:
@@ -1263,13 +1610,20 @@ class PyEnsembleDiag(Expresso):
                     available = thegang.members[EntrySt.available]
                     self._handle_gang_rescue(thegang)
 
-                    self._actual_execute(rh, opts,
-                                         [e.section.rh for e in available],
-                                         **thegang.info)
+                    self._actual_execute(
+                        rh,
+                        opts,
+                        [e.section.rh for e in available],
+                        **thegang.info,
+                    )
 
                     self.system.highlight("Done with " + txt_id)
 
-                if not bm.all_done and basicmeta.has_ufo() and not basicmeta.has_pcollectable():
+                if (
+                    not bm.all_done
+                    and basicmeta.has_ufo()
+                    and not basicmeta.has_pcollectable()
+                ):
                     # Timeout ?
                     tmout = bm.is_timedout(self.timeout)
                     if tmout:
@@ -1280,6 +1634,8 @@ class PyEnsembleDiag(Expresso):
 
         # Warn for failed gangs
         if basicmeta.members[GangSt.failed]:
-            self.system.title("One or several (term, geometry, block) group(s) could not be processed")
+            self.system.title(
+                "One or several (term, geometry, block) group(s) could not be processed"
+            )
             for thegang in basicmeta.members[GangSt.failed]:
                 self._handle_gang_rescue(thegang)

--- a/src/vortex/nwp/data/__init__.py
+++ b/src/vortex/nwp/data/__init__.py
@@ -3,20 +3,28 @@ Data resources (mostly NWP).
 """
 
 # Recursive inclusion of packages with potential FootprintBase classes
-from . import boundaries, climfiles, consts, diagnostics, executables, fields
-from . import (
-    assim,
-    gridfiles,
-    logs,
-    modelstates,
-    namelists,
-    obs,
-    surfex,
-    eps,
-    eda,
-)
-from . import providers, stores, query, monitoring, ctpini
-from . import oopsexec, configfiles
+from . import boundaries as boundaries
+from . import climfiles as climfiles
+from . import consts as consts
+from . import diagnostics as diagnostics
+from . import executables as executables
+from . import fields as fields
+from . import assim as assim
+from . import gridfiles as gridfiles
+from . import logs as logs
+from . import modelstates as modelstates
+from . import namelists as namelists
+from . import obs as obs
+from . import surfex as surfex
+from . import eps as eps
+from . import eda as eda
+from . import providers as providers
+from . import stores as stores
+from . import query as query
+from . import monitoring as monitoring
+from . import ctpini as ctpini
+from . import oopsexec as oopsexec
+from . import configfiles as configfiles
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/nwp/data/__init__.py
+++ b/src/vortex/nwp/data/__init__.py
@@ -4,7 +4,17 @@ Data resources (mostly NWP).
 
 # Recursive inclusion of packages with potential FootprintBase classes
 from . import boundaries, climfiles, consts, diagnostics, executables, fields
-from . import assim, gridfiles, logs, modelstates, namelists, obs, surfex, eps, eda
+from . import (
+    assim,
+    gridfiles,
+    logs,
+    modelstates,
+    namelists,
+    obs,
+    surfex,
+    eps,
+    eda,
+)
 from . import providers, stores, query, monitoring, ctpini
 from . import oopsexec, configfiles
 

--- a/src/vortex/nwp/data/assim.py
+++ b/src/vortex/nwp/data/assim.py
@@ -18,7 +18,9 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class _BackgroundErrorInfo(GeoFlowResource):
     """
     A generic class for data in grib format related to the background error.
@@ -29,25 +31,20 @@ class _BackgroundErrorInfo(GeoFlowResource):
         term_deco,
         gvar,
         dict(
-            info='Background standard deviation',
+            info="Background standard deviation",
             attr=dict(
-                term=dict(
-                    optional=True,
-                    default=3
-                ),
+                term=dict(optional=True, default=3),
                 nativefmt=dict(
-                    default='grib',
+                    default="grib",
                 ),
-                gvar = dict(
-                    default = 'errgrib_t[geometry:truncation]'
-                ),
+                gvar=dict(default="errgrib_t[geometry:truncation]"),
             ),
-        )
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'bgstdinfo'
+        return "bgstdinfo"
 
 
 class BackgroundStdError(_BackgroundErrorInfo):
@@ -66,77 +63,73 @@ class BackgroundStdError(_BackgroundErrorInfo):
     """
 
     _footprint = dict(
-        info='Background error standard deviation',
+        info="Background error standard deviation",
         attr=dict(
             kind=dict(
-                values=['bgstderr', 'bg_stderr', 'bgerrstd'],
-                remap=dict(autoremap='first'),
+                values=["bgstderr", "bg_stderr", "bgerrstd"],
+                remap=dict(autoremap="first"),
             ),
             stage=dict(
                 optional=True,
-                default='unbal',
-                values=['scr', 'vor', 'full', 'unbal', 'profile'],
-                remap=dict(vor='unbal'),
+                default="unbal",
+                values=["scr", "vor", "full", "unbal", "profile"],
+                remap=dict(vor="unbal"),
             ),
             origin=dict(
                 optional=True,
-                values=['ens', 'diag'],
-                default = 'ens',
+                values=["ens", "diag"],
+                default="ens",
             ),
-            gvar = dict(
-                default = 'errgrib_vor_monthly'
-            ),
+            gvar=dict(default="errgrib_vor_monthly"),
             nativefmt=dict(
-                values=['grib', 'ascii'],
-                default='grib',
+                values=["grib", "ascii"],
+                default="grib",
             ),
         ),
     )
 
     @property
     def realkind(self):
-        return 'bgstderr'
+        return "bgstderr"
 
     def namebuilding_info(self):
         """Generic information for names fabric, with radical = ``bcor``."""
         infos = super().namebuilding_info()
-        infos['src'].append(self.stage)
-        if self.stage != 'scr':
-            infos['src'].append(self.origin)
+        infos["src"].append(self.stage)
+        if self.stage != "scr":
+            infos["src"].append(self.origin)
         return infos
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        if self.stage in ('unbal',):
-            return '(errgribfix:igakey)'
+        if self.stage in ("unbal",):
+            return "(errgribfix:igakey)"
         else:
-            return 'errgrib_' + self.stage
+            return "errgrib_" + self.stage
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        if self.stage in ('unbal',):
-            return 'errgribvor'
+        if self.stage in ("unbal",):
+            return "errgribvor"
         else:
-            return 'sigma_b'
+            return "sigma_b"
 
     def gget_basename(self):
         """GGET specific naming convention."""
-        return dict(suffix='.m{:02d}'.format(self.date.month))
+        return dict(suffix=".m{:02d}".format(self.date.month))
 
 
-@namebuilding_append('src', lambda s: s.variable)
+@namebuilding_append("src", lambda s: s.variable)
 class SplitBackgroundStdError(BackgroundStdError):
     """Background error standard deviation, for a given variable."""
 
     _footprint = dict(
-        info='Background error standard deviation',
+        info="Background error standard deviation",
         attr=dict(
             variable=dict(
-                info = "Variable contained in this resource.",
+                info="Variable contained in this resource.",
             ),
-            gvar = dict(
-                default = 'errgrib_vor_[variable]_monthly'
-            ),
+            gvar=dict(default="errgrib_vor_[variable]_monthly"),
         ),
     )
 
@@ -146,30 +139,28 @@ class BackgroundErrorNorm(_BackgroundErrorInfo):
 
     _footprint = [
         dict(
-            info='Background error normalisation data for wavelet covariances',
+            info="Background error normalisation data for wavelet covariances",
             attr=dict(
                 kind=dict(
-                    values=['bgstdrenorm', 'bgerrnorm'],
-                    remap=dict(autoremap='first'),
+                    values=["bgstdrenorm", "bgerrnorm"],
+                    remap=dict(autoremap="first"),
                 ),
-                gvar = dict(
-                    default = 'srenorm_t[geometry:truncation]'
-                ),
+                gvar=dict(default="srenorm_t[geometry:truncation]"),
             ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'bgstdrenorm'
+        return "bgstdrenorm"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'srenorm.{!s}'.format(self.geometry.truncation)
+        return "srenorm.{!s}".format(self.geometry.truncation)
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'srenorm.t{!s}'.format(self.geometry.truncation)
+        return "srenorm.t{!s}".format(self.geometry.truncation)
 
     def archive_pathinfo(self):
         """Op Archive specific pathname needs."""
@@ -178,11 +169,13 @@ class BackgroundErrorNorm(_BackgroundErrorInfo):
             model=self.model,
             date=self.date,
             cutoff=self.cutoff,
-            arpege_aearp_directory='wavelet',
+            arpege_aearp_directory="wavelet",
         )
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class Wavelet(GeoFlowResource):
     """Background error wavelet covariances."""
 
@@ -190,34 +183,29 @@ class Wavelet(GeoFlowResource):
         term_deco,
         gvar,
         dict(
-            info = 'Background error wavelet covariances',
-            attr = dict(
-                kind = dict(
-                    values   = ['wavelet', 'waveletcv'],
-                    remap    = dict(autoremap = 'first'),
+            info="Background error wavelet covariances",
+            attr=dict(
+                kind=dict(
+                    values=["wavelet", "waveletcv"],
+                    remap=dict(autoremap="first"),
                 ),
-                gvar = dict(
-                    default = 'wavelet_cv_t[geometry:truncation]'
-                ),
-                term=dict(
-                    optional=True,
-                    default=3
-                ),
-            )
-        )
+                gvar=dict(default="wavelet_cv_t[geometry:truncation]"),
+                term=dict(optional=True, default=3),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'wavelet'
+        return "wavelet"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'wavelet.cv.{!s}'.format(self.geometry.truncation)
+        return "wavelet.cv.{!s}".format(self.geometry.truncation)
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'wavelet.cv.t{!s}'.format(self.geometry.truncation)
+        return "wavelet.cv.t{!s}".format(self.geometry.truncation)
 
     def archive_pathinfo(self):
         """Op Archive specific pathname needs."""
@@ -230,139 +218,143 @@ class Wavelet(GeoFlowResource):
         )
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class RawControlVector(GeoFlowResource):
     """Raw Control Vector as issued by minimisation, playing the role of an Increment."""
 
     _footprint = dict(
-        info = 'Raw Control Vector',
-        attr = dict(
-            kind = dict(
-                values   = ['rawcv', 'rcv', 'increment', 'minimcv'],
-                remap    = dict(autoremap = 'first'),
+        info="Raw Control Vector",
+        attr=dict(
+            kind=dict(
+                values=["rawcv", "rcv", "increment", "minimcv"],
+                remap=dict(autoremap="first"),
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rawcv'
+        return "rawcv"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'MININCR'
+        return "MININCR"
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class InternalMinim(GeoFlowResource):
     """Generic class for resources internal to minimisation."""
 
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            nativefmt = dict(
-                values  = ['fa', 'lfi', 'grib'],
-                default = 'fa',
+        attr=dict(
+            nativefmt=dict(
+                values=["fa", "lfi", "grib"],
+                default="fa",
             ),
-            term = dict(
-                type     = Time,
-                optional = True,
-                default  = Time(-3),
+            term=dict(
+                type=Time,
+                optional=True,
+                default=Time(-3),
             ),
         )
     )
 
     def olive_suffixtr(self):
         """Return BR or HR specific OLIVE suffix according to geo streching."""
-        return 'HR' if self.geometry.stretching > 1 else 'BR'
+        return "HR" if self.geometry.stretching > 1 else "BR"
 
 
 class StartingPointMinim(InternalMinim):
     """Guess as reprocessed by the minimisation."""
 
     _footprint = dict(
-        info = 'Starting Point Output Minim',
-        attr = dict(
-            kind = dict(
-                values  = ['stpmin'],
+        info="Starting Point Output Minim",
+        attr=dict(
+            kind=dict(
+                values=["stpmin"],
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'stpmin'
+        return "stpmin"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'STPMIN' + self.olive_suffixtr()
+        return "STPMIN" + self.olive_suffixtr()
 
 
 class AnalysedStateMinim(InternalMinim):
     """Analysed state as produced by the minimisation."""
 
     _footprint = dict(
-        info = 'Analysed Output Minim',
-        attr = dict(
-            kind = dict(
-                values  = ['anamin'],
+        info="Analysed Output Minim",
+        attr=dict(
+            kind=dict(
+                values=["anamin"],
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'anamin'
+        return "anamin"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'ANAMIN' + self.olive_suffixtr()
+        return "ANAMIN" + self.olive_suffixtr()
 
 
 class PrecevMap(FlowResource):
     """Map of the precondionning eigenvectors as produced by minimisation."""
 
     _footprint = dict(
-        info = 'Prec EV Map',
-        attr = dict(
-            kind = dict(
-                values   = ['precevmap'],
+        info="Prec EV Map",
+        attr=dict(
+            kind=dict(
+                values=["precevmap"],
             ),
-            clscontents = dict(
-                default = JsonDictContent,
+            clscontents=dict(
+                default=JsonDictContent,
             ),
-            nativefmt   = dict(
-                values  = ['json'],
-                default = 'json',
+            nativefmt=dict(
+                values=["json"],
+                default="json",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'precevmap'
+        return "precevmap"
 
 
-@namebuilding_append('src', lambda s: str(s.evnum))
+@namebuilding_append("src", lambda s: str(s.evnum))
 class Precev(FlowResource):
     """Precondionning eigenvectors as produced by minimisation."""
 
     _footprint = dict(
-        info = 'Starting Point Output Minim',
-        attr = dict(
-            kind = dict(
-                values   = ['precev'],
+        info="Starting Point Output Minim",
+        attr=dict(
+            kind=dict(
+                values=["precev"],
             ),
-            evnum = dict(
-                type    = FmtInt,
-                args    = dict(fmt = '03'),
+            evnum=dict(
+                type=FmtInt,
+                args=dict(fmt="03"),
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'precev'
+        return "precev"
 
 
 class IOassignScript(Script):
@@ -371,22 +363,18 @@ class IOassignScript(Script):
     _footprint = [
         gvar,
         dict(
-            info = 'Script for IOASSIGN',
-            attr = dict(
-                kind = dict(
-                    values = ['ioassign_script']
-                ),
-                gvar = dict(
-                    default = 'ioassign_script_[purpose]'
-                ),
+            info="Script for IOASSIGN",
+            attr=dict(
+                kind=dict(values=["ioassign_script"]),
+                gvar=dict(default="ioassign_script_[purpose]"),
                 purpose=dict(
-                    info = "The purpose of the script",
-                    values = ['merge', 'create']
+                    info="The purpose of the script",
+                    values=["merge", "create"],
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'ioassign_script'
+        return "ioassign_script"

--- a/src/vortex/nwp/data/boundaries.py
+++ b/src/vortex/nwp/data/boundaries.py
@@ -8,7 +8,11 @@ from bronx.stdtypes import date
 import footprints
 from vortex.tools import env
 from vortex.data.flow import GeoFlowResource, GeoPeriodFlowResource
-from vortex.syntax.stddeco import namebuilding_append, namebuilding_insert, overwrite_realkind
+from vortex.syntax.stddeco import (
+    namebuilding_append,
+    namebuilding_insert,
+    overwrite_realkind,
+)
 from vortex.syntax.stdattrs import term_deco, timeperiod_deco, a_cutoff
 from vortex.data.geometries import LonlatGeometry
 
@@ -18,8 +22,8 @@ from ..tools.igastuff import archive_suffix
 __all__ = []
 
 
-@namebuilding_insert('radical', lambda s: 'cpl')
-@namebuilding_insert('src', lambda s: s._mysrc)
+@namebuilding_insert("radical", lambda s: "cpl")
+@namebuilding_insert("src", lambda s: s._mysrc)
 class _AbstractLAMBoundary(GeoFlowResource):
     """
     Class of a coupling file for a Limited Area Model.
@@ -30,23 +34,30 @@ class _AbstractLAMBoundary(GeoFlowResource):
     _footprint = [
         term_deco,
         dict(
-            info = 'Coupling file for a limited area model',
-            attr = dict(
-                kind = dict(
-                    values  = ['boundary', 'elscf', 'coupled'],
-                    remap   = dict(autoremap = 'first'),
+            info="Coupling file for a limited area model",
+            attr=dict(
+                kind=dict(
+                    values=["boundary", "elscf", "coupled"],
+                    remap=dict(autoremap="first"),
                 ),
-                nativefmt = dict(
-                    values  = ['fa', 'grib', 'netcdf', 'ascii', 'wbcpack', 'unknown'],
-                    default = 'fa',
+                nativefmt=dict(
+                    values=[
+                        "fa",
+                        "grib",
+                        "netcdf",
+                        "ascii",
+                        "wbcpack",
+                        "unknown",
+                    ],
+                    default="fa",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'boundary'
+        return "boundary"
 
     @property
     def _mysrc(self):
@@ -54,41 +65,43 @@ class _AbstractLAMBoundary(GeoFlowResource):
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        if self.mailbox.get('block', '-') == 'surfan':
+        if self.mailbox.get("block", "-") == "surfan":
             hhreal = self.term
         else:
             e = env.current()
-            if 'HHDELTA_CPL' in e:
-                actualbase = self.date - date.Time(e.HHDELTA_CPL + 'H')
+            if "HHDELTA_CPL" in e:
+                actualbase = self.date - date.Time(e.HHDELTA_CPL + "H")
             else:
                 actualbase = date.synop(base=self.date)
             hhreal = (self.date - actualbase).time() + self.term
-        return 'ELSCFALAD_' + self.geometry.area + '+' + hhreal.fmthour
+        return "ELSCFALAD_" + self.geometry.area + "+" + hhreal.fmthour
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
         suffix = archive_suffix(self.model, self.cutoff, self.date)
-        prefix = 'COUPL'
-        source = self._mysrc[0] if isinstance(self._mysrc, list) else self._mysrc
-        if re.match('assist1bis|testms1', self.geometry.area):
-            prefix = 'COUPL1'
-        if re.match('ifs|ecmwf', source) and '16km' in self.geometry.rnice:
-            prefix = 'COUPLIFS'
+        prefix = "COUPL"
+        source = (
+            self._mysrc[0] if isinstance(self._mysrc, list) else self._mysrc
+        )
+        if re.match("assist1bis|testms1", self.geometry.area):
+            prefix = "COUPL1"
+        if re.match("ifs|ecmwf", source) and "16km" in self.geometry.rnice:
+            prefix = "COUPLIFS"
 
-        if self.model == 'mocage':
+        if self.model == "mocage":
             valid = (self.date + self.term).ymd
-            return 'SM' + self.geometry.area + '+' + valid
+            return "SM" + self.geometry.area + "+" + valid
 
-        return prefix + self.term.fmthour + '.r{!s}'.format(suffix)
+        return prefix + self.term.fmthour + ".r{!s}".format(suffix)
 
     def iga_pathinfo(self):
         """Standard path information for IGA inline cache."""
-        if self.model == 'arome':
-            directory = 'fic_day'
-        elif self.model == 'mfwam':
-            directory = 'guess'
+        if self.model == "arome":
+            directory = "fic_day"
+        elif self.model == "mfwam":
+            directory = "guess"
         else:
-            directory = 'autres'
+            directory = "autres"
         return dict(
             fmt=directory,
             model=self.model,
@@ -111,11 +124,18 @@ class LAMBoundary(_AbstractLAMBoundary):
     """
 
     _footprint = dict(
-        attr = dict(
-            source = dict(
-                values  = [
-                    'arpege', 'aladin', 'arome', 'ifs', 'ecmwf', 'psy4',
-                    'mercator_global', 'glo12', 'mfwam'
+        attr=dict(
+            source=dict(
+                values=[
+                    "arpege",
+                    "aladin",
+                    "arome",
+                    "ifs",
+                    "ecmwf",
+                    "psy4",
+                    "mercator_global",
+                    "glo12",
+                    "mfwam",
                 ]
             ),
         )
@@ -127,9 +147,9 @@ class LAMBoundary(_AbstractLAMBoundary):
 
 
 _a_source_cutoff = a_cutoff
-del _a_source_cutoff['alias']
-_a_source_cutoff['optional'] = True
-_a_source_cutoff['default'] = 'production'
+del _a_source_cutoff["alias"]
+_a_source_cutoff["optional"] = True
+_a_source_cutoff["default"] = "production"
 
 
 class EnhancedLAMBoundary(_AbstractLAMBoundary):
@@ -140,33 +160,46 @@ class EnhancedLAMBoundary(_AbstractLAMBoundary):
     """
 
     _footprint = dict(
-        attr = dict(
-            source_app = dict(),
-            source_conf = dict(),
-            source_cutoff = _a_source_cutoff,
+        attr=dict(
+            source_app=dict(),
+            source_conf=dict(),
+            source_cutoff=_a_source_cutoff,
         )
     )
 
     @property
     def _mysrc(self):
-        return [self.source_app, self.source_conf,
-                {'cutoff': self.source_cutoff}]
+        return [
+            self.source_app,
+            self.source_conf,
+            {"cutoff": self.source_cutoff},
+        ]
 
 
 _abs_forcing_fp = footprints.DecorativeFootprint(
-    info='Coupling file for any offline model.',
+    info="Coupling file for any offline model.",
     attr=dict(
         kind=dict(
-            values=['forcing', ],
+            values=[
+                "forcing",
+            ],
         ),
         filling=dict(),
         source_app=dict(),
         source_conf=dict(),
         source_cutoff=_a_source_cutoff,
     ),
-    decorator=[namebuilding_insert('src', lambda s: [s.source_app, s.source_conf,
-                                                     {'cutoff': s.source_cutoff}]),
-               overwrite_realkind('forcing'), ]
+    decorator=[
+        namebuilding_insert(
+            "src",
+            lambda s: [
+                s.source_app,
+                s.source_conf,
+                {"cutoff": s.source_cutoff},
+            ],
+        ),
+        overwrite_realkind("forcing"),
+    ],
 )
 
 
@@ -174,25 +207,31 @@ class _AbstractForcing(GeoFlowResource):
     """Abstract class for date-based coupling file for any offline model."""
 
     _abstract = True
-    _footprint = [_abs_forcing_fp, ]
+    _footprint = [
+        _abs_forcing_fp,
+    ]
 
 
 class _AbstractPeriodForcing(GeoPeriodFlowResource):
     """Abstract class for period-based coupling file for any offline model."""
 
     _abstract = True
-    _footprint = [_abs_forcing_fp, ]
+    _footprint = [
+        _abs_forcing_fp,
+    ]
 
 
 _abs_external_forcing_fp = footprints.DecorativeFootprint(
     dict(
         attr=dict(
             model=dict(
-                outcast=['surfex', ],
+                outcast=[
+                    "surfex",
+                ],
             ),
         ),
     ),
-    decorator=[namebuilding_append('src', lambda s: s.filling)],
+    decorator=[namebuilding_append("src", lambda s: s.filling)],
 )
 
 
@@ -216,24 +255,30 @@ class ExternalTimePeriodForcing(_AbstractForcing):
 
 _abs_surfex_forcing_fp = footprints.DecorativeFootprint(
     dict(
-        info='Coupling/Forcing file for Surfex.',
+        info="Coupling/Forcing file for Surfex.",
         attr=dict(
             model=dict(
-                values=['surfex', ],
+                values=[
+                    "surfex",
+                ],
             ),
             filling=dict(
                 optional=True,
-                default='atm',
+                default="atm",
             ),
             nativefmt=dict(
-                values=['netcdf', 'ascii', 'tar'],
-                default='netcdf',
+                values=["netcdf", "ascii", "tar"],
+                default="netcdf",
             ),
-        )
+        ),
     ),
-    decorator=[namebuilding_append('src',
-                                   lambda s: None if s.filling == 'atm' else s.filling,
-                                   none_discard=True)]
+    decorator=[
+        namebuilding_append(
+            "src",
+            lambda s: None if s.filling == "atm" else s.filling,
+            none_discard=True,
+        )
+    ],
 )
 
 
@@ -243,7 +288,10 @@ class SurfexForcing(_AbstractForcing):
     This class takes an optional **term** attribute.
     """
 
-    _footprint = [term_deco, _abs_surfex_forcing_fp, ]
+    _footprint = [
+        term_deco,
+        _abs_surfex_forcing_fp,
+    ]
 
 
 class SurfexTimePeriodForcing(_AbstractForcing):
@@ -252,10 +300,15 @@ class SurfexTimePeriodForcing(_AbstractForcing):
     This class needs a **begintime**/**endtime** attribute.
     """
 
-    _footprint = [timeperiod_deco, _abs_surfex_forcing_fp, ]
+    _footprint = [
+        timeperiod_deco,
+        _abs_surfex_forcing_fp,
+    ]
 
 
 class SurfexPeriodForcing(_AbstractPeriodForcing):
     """Class for period-based coupling file for Surfex."""
 
-    _footprint = [_abs_surfex_forcing_fp, ]
+    _footprint = [
+        _abs_surfex_forcing_fp,
+    ]

--- a/src/vortex/nwp/data/climfiles.py
+++ b/src/vortex/nwp/data/climfiles.py
@@ -12,32 +12,31 @@ from ..syntax.stdattrs import gvar, gdomain
 __all__ = []
 
 
-@namebuilding_insert('radical', lambda s: 'clim')
+@namebuilding_insert("radical", lambda s: "clim")
 class GenericClim(ModelGeoResource):
     """Abstract class for a model climatology.
 
     An HorizontalGeometry object is needed. A Genvkey can be given.
     """
+
     _abstract = True
     _footprint = [
         gvar,
         dict(
-            info = 'Model climatology',
-            attr = dict(
-                kind = dict(
-                    values = ['clim_model']
+            info="Model climatology",
+            attr=dict(
+                kind=dict(values=["clim_model"]),
+                nativefmt=dict(
+                    values=["fa"],
+                    default="fa",
                 ),
-                nativefmt = dict(
-                    values = ['fa'],
-                    default = 'fa',
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'clim_model'
+        return "clim_model"
 
     @property
     def truncation(self):
@@ -46,7 +45,7 @@ class GenericClim(ModelGeoResource):
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'Const.Clim'
+        return "Const.Clim"
 
 
 class GlobalClim(GenericClim):
@@ -54,16 +53,13 @@ class GlobalClim(GenericClim):
 
     A SpectralGeometry object is needed. A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Model climatology for Global Models',
-        attr = dict(
-            model = dict(
-                values = ['arpege']
-            ),
-            gvar = dict(
-                default = 'clim_[model]_[geometry::gco_grid_def]'
-            ),
-        )
+        info="Model climatology for Global Models",
+        attr=dict(
+            model=dict(values=["arpege"]),
+            gvar=dict(default="clim_[model]_[geometry::gco_grid_def]"),
+        ),
     )
 
 
@@ -76,8 +72,8 @@ class MonthlyGlobalClim(GlobalClim):
     _footprint = [
         month_deco,
         dict(
-            info = 'Monthly model climatology for Global Models',
-        )
+            info="Monthly model climatology for Global Models",
+        ),
     ]
 
 
@@ -87,19 +83,18 @@ class ClimLAM(GenericClim):
     A SpectralGeometry object is needed. A Genvkey can be given
     with a default name retrieved thanks to a GenvDomain object.
     """
+
     _footprint = [
         gdomain,
         dict(
-            info = 'Model climatology for Local Area Models',
-            attr = dict(
-                model = dict(
-                    values = ['aladin', 'arome', 'alaro', 'harmoniearome']
+            info="Model climatology for Local Area Models",
+            attr=dict(
+                model=dict(
+                    values=["aladin", "arome", "alaro", "harmoniearome"]
                 ),
-                gvar = dict(
-                    default = 'clim_[geometry::gco_grid_def]'
-                ),
-            )
-        )
+                gvar=dict(default="clim_[geometry::gco_grid_def]"),
+            ),
+        ),
     ]
 
 
@@ -113,8 +108,8 @@ class MonthlyClimLAM(ClimLAM):
     _footprint = [
         month_deco,
         dict(
-            info = 'Monthly model climatology for Local Area Models',
-        )
+            info="Monthly model climatology for Local Area Models",
+        ),
     ]
 
 
@@ -124,27 +119,24 @@ class ClimBDAP(GenericClim):
     A LonlatGeometry object is needed. A Genvkey can be given
     with a default name retrieved thanks to a GenvDomain object.
     """
+
     _footprint = [
         gdomain,
         dict(
-            info = 'Bdap climatology',
-            attr = dict(
-                kind = dict(
-                    values = ['clim_bdap']
+            info="Bdap climatology",
+            attr=dict(
+                kind=dict(values=["clim_bdap"]),
+                geometry=dict(
+                    type=LonlatGeometry,
                 ),
-                geometry = dict(
-                    type = LonlatGeometry,
-                ),
-                gvar = dict(
-                    default = 'clim_dap_[gdomain]'
-                ),
-            )
-        )
+                gvar=dict(default="clim_dap_[gdomain]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'clim_bdap'
+        return "clim_bdap"
 
 
 class MonthlyClimBDAP(ClimBDAP):
@@ -157,8 +149,8 @@ class MonthlyClimBDAP(ClimBDAP):
     _footprint = [
         month_deco,
         dict(
-            info = 'Monthly Bdap climatology',
-        )
+            info="Monthly Bdap climatology",
+        ),
     ]
 
 
@@ -170,30 +162,29 @@ class GTOPO30DerivedDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for GTOPO30-derived parameters.',
-            attr = dict(
-                kind = dict(
-                    values = ['misc_orography'],
+            info="Database for GTOPO30-derived parameters.",
+            attr=dict(
+                kind=dict(
+                    values=["misc_orography"],
                 ),
-                source = dict(
-                    values = ['GTOPO30'],
+                source=dict(
+                    values=["GTOPO30"],
                 ),
-                geometry = dict(
-                    values = ['global2m5'],
+                geometry=dict(
+                    values=["global2m5"],
                 ),
-                gvar = dict(
-                    default = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'misc_orography'
+        return "misc_orography"
 
 
 class UrbanisationDB(StaticGeoResource):
@@ -201,30 +192,29 @@ class UrbanisationDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for urbanisation.',
-            attr = dict(
-                kind = dict(
-                    values   = ['urbanisation'],
+            info="Database for urbanisation.",
+            attr=dict(
+                kind=dict(
+                    values=["urbanisation"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global2m5'],
+                geometry=dict(
+                    values=["global2m5"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'urbanisation'
+        return "urbanisation"
 
 
 class WaterPercentageDB(StaticGeoResource):
@@ -232,30 +222,29 @@ class WaterPercentageDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for water percentage.',
-            attr = dict(
-                kind = dict(
-                    values   = ['water_percentage'],
+            info="Database for water percentage.",
+            attr=dict(
+                kind=dict(
+                    values=["water_percentage"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global2m5'],
+                geometry=dict(
+                    values=["global2m5"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'water_percentage'
+        return "water_percentage"
 
 
 class SoilANdVegDB(StaticGeoResource):
@@ -263,30 +252,29 @@ class SoilANdVegDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for Soil and Vegetation.',
-            attr = dict(
-                kind = dict(
-                    values   = ['soil_and_veg'],
+            info="Database for Soil and Vegetation.",
+            attr=dict(
+                kind=dict(
+                    values=["soil_and_veg"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global1dg', 'europeb01'],
+                geometry=dict(
+                    values=["global1dg", "europeb01"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'soil_and_veg'
+        return "soil_and_veg"
 
 
 class MonthlyLAIDB(StaticGeoResource):
@@ -294,31 +282,30 @@ class MonthlyLAIDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         month_deco,
         dict(
-            info = 'Database for monthly LAI.',
-            attr = dict(
-                kind = dict(
-                    values   = ['LAI'],
+            info="Database for monthly LAI.",
+            attr=dict(
+                kind=dict(
+                    values=["LAI"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global1dg', 'europeb01'],
+                geometry=dict(
+                    values=["global1dg", "europeb01"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'LAI'
+        return "LAI"
 
 
 class MonthlyVegDB(StaticGeoResource):
@@ -326,31 +313,30 @@ class MonthlyVegDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         month_deco,
         dict(
-            info = 'Database for monthly vegetation.',
-            attr = dict(
-                kind = dict(
-                    values   = ['vegetation'],
+            info="Database for monthly vegetation.",
+            attr=dict(
+                kind=dict(
+                    values=["vegetation"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global1dg', 'europeb01'],
+                geometry=dict(
+                    values=["global1dg", "europeb01"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'vegetation'
+        return "vegetation"
 
 
 class SoilClimatologyDB(StaticGeoResource):
@@ -360,30 +346,29 @@ class SoilClimatologyDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for soil climatology parameters.',
-            attr = dict(
-                kind = dict(
-                    values   = ['soil_clim'],
+            info="Database for soil climatology parameters.",
+            attr=dict(
+                kind=dict(
+                    values=["soil_clim"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['globaln108', 'global1dg'],
+                geometry=dict(
+                    values=["globaln108", "global1dg"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'soil_clim'
+        return "soil_clim"
 
 
 class SurfGeopotentialDB(StaticGeoResource):
@@ -393,30 +378,29 @@ class SurfGeopotentialDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for surface geopotential.',
-            attr = dict(
-                kind = dict(
-                    values   = ['surfgeopotential'],
+            info="Database for surface geopotential.",
+            attr=dict(
+                kind=dict(
+                    values=["surfgeopotential"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global1dg'],
+                geometry=dict(
+                    values=["global1dg"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'surfgeopotential'
+        return "surfgeopotential"
 
 
 class MonthlySoilClimatologyDB(SoilClimatologyDB):
@@ -426,11 +410,12 @@ class MonthlySoilClimatologyDB(SoilClimatologyDB):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         month_deco,
         dict(
-            info = 'Database for monthly soil climatology parameters.',
-        )
+            info="Database for monthly soil climatology parameters.",
+        ),
     ]
 
 
@@ -441,26 +426,25 @@ class MonthlyChemicalDB(StaticGeoResource):
 
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         month_deco,
         dict(
-            info = 'Database for monthly chemicals.',
-            attr = dict(
-                kind = dict(
-                    values   = ['ozone', 'aerosols'],
+            info="Database for monthly chemicals.",
+            attr=dict(
+                kind=dict(
+                    values=["ozone", "aerosols"],
                 ),
-                source = dict(
-                    type = str,
+                source=dict(
+                    type=str,
                 ),
-                geometry = dict(
-                    values = ['global2dg5', 'global5x4'],
+                geometry=dict(
+                    values=["global2dg5", "global5x4"],
                 ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
@@ -472,23 +456,23 @@ class GeometryIllustration(StaticGeoResource):
     """Illustration of a domain geographic coverage."""
 
     _footprint = dict(
-        info = 'Illustration of a domain geographic coverage.',
-        attr = dict(
-            kind = dict(
-                values   = ['geometry_plot'],
+        info="Illustration of a domain geographic coverage.",
+        attr=dict(
+            kind=dict(
+                values=["geometry_plot"],
             ),
-            nativefmt = dict(
-                values = ['png', 'pdf'],
+            nativefmt=dict(
+                values=["png", "pdf"],
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'geometry_plot'
+        return "geometry_plot"
 
 
-@namebuilding_append('src', lambda s: [s.stat, s.level, s.nbfiles])
+@namebuilding_append("src", lambda s: [s.stat, s.level, s.nbfiles])
 class Stabal(ModelGeoResource):
     """Spectral covariance operators.
 
@@ -503,35 +487,33 @@ class Stabal(ModelGeoResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Spectral covariance operators',
-            attr = dict(
-                kind = dict(
-                    values = ['stabal'],
+            info="Spectral covariance operators",
+            attr=dict(
+                kind=dict(
+                    values=["stabal"],
                 ),
-                stat = dict(
-                    values = ['bal', 'cv', 'cvt'],
+                stat=dict(
+                    values=["bal", "cv", "cvt"],
                 ),
-                level = dict(
-                    type     = int,
-                    optional = True,
-                    default  = 96,
-                    values   = [41, 96],
+                level=dict(
+                    type=int,
+                    optional=True,
+                    default=96,
+                    values=[41, 96],
                 ),
-                nbfiles = dict(
-                    default = 0,
-                    optional = True,
-                    type = int,
+                nbfiles=dict(
+                    default=0,
+                    optional=True,
+                    type=int,
                 ),
-                gvar = dict(
-                    default  = 'stabal[level]_[stat]'
-                ),
-            )
-        )
+                gvar=dict(default="stabal[level]_[stat]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'stabal'
+        return "stabal"
 
     @property
     def truncation(self):

--- a/src/vortex/nwp/data/configfiles.py
+++ b/src/vortex/nwp/data/configfiles.py
@@ -11,7 +11,7 @@ from vortex.syntax.stddeco import namebuilding_append
 __all__ = []
 
 
-@namebuilding_append('src', lambda self: [self.scope, self.source])
+@namebuilding_append("src", lambda self: [self.scope, self.source])
 class GenericConfig(StaticResource):
     """Generic class to access a pack of configuration files."""
 
@@ -19,131 +19,135 @@ class GenericConfig(StaticResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Configuration file from a pack',
-            attr = dict(
-                kind = dict(
-                    values = ['config']
+            info="Configuration file from a pack",
+            attr=dict(
+                kind=dict(values=["config"]),
+                gvar=dict(default="config_[scope]"),
+                scope=dict(info="The configuration pack purpose"),
+                source=dict(
+                    info="The config name within the config pack.",
                 ),
-                gvar = dict(
-                    default = 'config_[scope]'
-                ),
-                scope=dict(
-                    info = "The configuration pack purpose"
-                ),
-                source = dict(
-                    info = 'The config name within the config pack.',
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'config'
+        return "config"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self.source
+        return "extract=" + self.source
 
 
 class AsciiConfig(GenericConfig):
     """Generic class to access a pack of ASCII configuration files."""
+
     _footprint = dict(
-        info = 'ASCII Configuration file from a pack',
-        attr = dict(
-            nativefmt = dict(
-                values = ['ascii', ]
+        info="ASCII Configuration file from a pack",
+        attr=dict(
+            nativefmt=dict(
+                values=[
+                    "ascii",
+                ]
             ),
-            clscontents = dict(
-                default  = DataRaw
-            ),
-        )
+            clscontents=dict(default=DataRaw),
+        ),
     )
 
 
 class IniConfig(GenericConfig):
     """Generic class to access a ini configuration file (e.g. for mkjob)."""
+
     _footprint = dict(
-        info = 'Ini configuration file',
-        attr = dict(
-            nativefmt = dict(
-                values = ['ini', ]
+        info="Ini configuration file",
+        attr=dict(
+            nativefmt=dict(
+                values=[
+                    "ini",
+                ]
             ),
-        )
+        ),
     )
 
 
 class JsonConfig(GenericConfig):
     """Generic class to access a pack of JSON configuration files."""
+
     _footprint = dict(
-        info = 'JSON Configuration file from a pack',
-        attr = dict(
+        info="JSON Configuration file from a pack",
+        attr=dict(
             scope=dict(
-                outcast = ['oops', ]
+                outcast=[
+                    "oops",
+                ]
             ),
-            nativefmt = dict(
-                values = ['json', ]
+            nativefmt=dict(
+                values=[
+                    "json",
+                ]
             ),
-            clscontents = dict(
-                default  = JsonDictContent
-            ),
-        )
+            clscontents=dict(default=JsonDictContent),
+        ),
     )
 
 
 class OopsJsonConfig(JsonConfig):
     """Configuration files for OOPS, defining the oops objects to be built"""
+
     _footprint = dict(
-        info = 'OOPS JSON Configuration file from a pack',
-        attr = dict(
+        info="OOPS JSON Configuration file from a pack",
+        attr=dict(
             scope=dict(
-                values = ['oops', ],
-                outcast = []
+                values=[
+                    "oops",
+                ],
+                outcast=[],
             ),
-            objects = dict(
-                info        = 'The OOPS objects to be built.',
+            objects=dict(
+                info="The OOPS objects to be built.",
             ),
-            source = dict(
-                info        = 'The config name within the config pack.',
-                optional    = True,
-                default     = '[objects].json',
+            source=dict(
+                info="The config name within the config pack.",
+                optional=True,
+                default="[objects].json",
             ),
-        )
+        ),
     )
 
 
 class YamlConfig(GenericConfig):
     """Generic class to access a pack of YAML configuration files."""
+
     _footprint = dict(
-        info = 'YAML Configuration file from a pack',
-        attr = dict(
-            nativefmt = dict(
-                values = ['yaml', ]
+        info="YAML Configuration file from a pack",
+        attr=dict(
+            nativefmt=dict(
+                values=[
+                    "yaml",
+                ]
             ),
-        )
+        ),
     )
 
 
 class Bundle(StaticResource):
     """Contains bundling of source codes."""
+
     _footprint = [
         gvar,
         dict(
-            info = 'Contains bundling of source codes.',
-            attr = dict(
-                kind = dict(
-                    values = ['bundle']
+            info="Contains bundling of source codes.",
+            attr=dict(
+                kind=dict(values=["bundle"]),
+                gvar=dict(
+                    default="bundle",
                 ),
-                gvar = dict(
-                    default = 'bundle',
-                ),
-                nativefmt = dict(
-                    values = ['yml', 'yaml']
-                ),
-            )
-        )
+                nativefmt=dict(values=["yml", "yaml"]),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'bundle'
+        return "bundle"

--- a/src/vortex/nwp/data/consts.py
+++ b/src/vortex/nwp/data/consts.py
@@ -8,7 +8,11 @@ from vortex.data.contents import DataRaw, JsonDictContent, TextContent
 from vortex.data.geometries import GaussGeometry, LonlatGeometry
 from vortex.data.outflow import ModelGeoResource, ModelResource, StaticResource
 from vortex.syntax.stdattrs import month_deco
-from vortex.syntax.stddeco import namebuilding_append, namebuilding_delete, namebuilding_insert
+from vortex.syntax.stddeco import (
+    namebuilding_append,
+    namebuilding_delete,
+    namebuilding_insert,
+)
 
 #: No automatic export
 __all__ = []
@@ -18,159 +22,162 @@ class GenvModelResource(ModelResource):
     """Abstract class for gget driven resources."""
 
     _abstract = True
-    _footprint = [gvar, ]
+    _footprint = [
+        gvar,
+    ]
 
 
 class GenvModelGeoResource(ModelGeoResource):
     """Abstract class for gget driven resources."""
 
     _abstract = True
-    _footprint = [gvar, ]
+    _footprint = [
+        gvar,
+    ]
 
 
 class GPSList(GenvModelResource):
     """
     Class of a GPS satellite ground coefficients. A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Set of GPS coefficients',
-        attr = dict(
-            kind = dict(
-                values  = ['gpslist', 'listgpssol'],
-                remap   = dict(listgpssol = 'gpslist'),
+        info="Set of GPS coefficients",
+        attr=dict(
+            kind=dict(
+                values=["gpslist", "listgpssol"],
+                remap=dict(listgpssol="gpslist"),
             ),
-            clscontents = dict(
-                default = TextContent,
+            clscontents=dict(
+                default=TextContent,
             ),
-            gvar = dict(
-                default = 'list_gpssol'
-            ),
-        )
+            gvar=dict(default="list_gpssol"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'gpslist'
+        return "gpslist"
 
 
 class MODESList(GenvModelResource):
     """
     Class of a MODE-S satellite white list for Bator.
     """
+
     _footprint = dict(
-        info = 'Set of MODE-S coefficients',
-        attr = dict(
-            kind = dict(
-                values  = ['modeslist', 'listmodes'],
-                remap   = dict(listmodes = 'modeslist'),
+        info="Set of MODE-S coefficients",
+        attr=dict(
+            kind=dict(
+                values=["modeslist", "listmodes"],
+                remap=dict(listmodes="modeslist"),
             ),
-            clscontents = dict(
-                default = TextContent,
+            clscontents=dict(
+                default=TextContent,
             ),
-            gvar = dict(
-                default = 'list_modes',
+            gvar=dict(
+                default="list_modes",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'modeslist'
+        return "modeslist"
 
 
 class BatodbConf(GenvModelResource):
     """
     Default parameters for BATOR execution. A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Batodb parametrization',
-        attr = dict(
-            kind = dict(
-                values  = ['batodbconf', 'batorconf', 'parambator'],
-                remap   = dict(
-                    parambator = 'batodbconf',
-                    batorconf  = 'batodbconf',
+        info="Batodb parametrization",
+        attr=dict(
+            kind=dict(
+                values=["batodbconf", "batorconf", "parambator"],
+                remap=dict(
+                    parambator="batodbconf",
+                    batorconf="batodbconf",
                 ),
             ),
-            clscontents = dict(
-                default = TextContent,
+            clscontents=dict(
+                default=TextContent,
             ),
-            gvar = dict(
-                default = 'param_bator_cfg'
-            ),
-        )
+            gvar=dict(default="param_bator_cfg"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'batodbconf'
+        return "batodbconf"
 
 
 class BatorAveragingMask(GenvModelResource):
     """
     Configuration file that drives the averaging of radiances in Bator.'''
     """
+
     _footprint = dict(
-        info = 'Definition file for the bator averaging',
-        attr = dict(
-            kind = dict(
-                values  = ['avgmask', ]
+        info="Definition file for the bator averaging",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "avgmask",
+                ]
             ),
-            sensor = dict(
+            sensor=dict(),
+            clscontents=dict(
+                default=TextContent,
             ),
-            clscontents = dict(
-                default = TextContent,
+            gvar=dict(
+                default="MASK_[sensor]",
             ),
-            gvar = dict(
-                default = 'MASK_[sensor]',
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'avgmask'
+        return "avgmask"
 
 
 class AtmsMask(BatorAveragingMask):
     """Kept for backward compatibility with cy40 (see BatorAveragingMask)."""
+
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values   = ['atms', 'atmsmask'],
-                remap    = dict(atms='atmsmask'),
+        attr=dict(
+            kind=dict(
+                values=["atms", "atmsmask"],
+                remap=dict(atms="atmsmask"),
             ),
-            sensor = dict(
-                default  = 'atms',
-                optional = True,
+            sensor=dict(
+                default="atms",
+                optional=True,
             ),
         )
     )
 
     @property
     def realkind(self):
-        return 'atmsmask'
+        return "atmsmask"
 
 
 class RtCoef(GenvModelResource):
     """
     Class of a tar-zip file of satellite coefficients. A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Set of satellite  coefficients',
-        attr = dict(
-            kind = dict(
-                values  = ['rtcoef', 'mwave_rtcoef']
-            ),
-            gvar = dict(
-                default = '[kind]_tgz'
-            ),
-        )
+        info="Set of satellite  coefficients",
+        attr=dict(
+            kind=dict(values=["rtcoef", "mwave_rtcoef"]),
+            gvar=dict(default="[kind]_tgz"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rtcoef'
+        return "rtcoef"
 
 
 class RRTM(GenvModelResource):
@@ -178,21 +185,22 @@ class RRTM(GenvModelResource):
     Class of a tar-zip file of coefficients for radiative transfers computations.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients of RRTM scheme',
-        attr = dict(
-            kind = dict(
-                values  = ['rrtm', ]
+        info="Coefficients of RRTM scheme",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "rrtm",
+                ]
             ),
-            gvar = dict(
-                default = 'rrtm_const'
-            ),
-        )
+            gvar=dict(default="rrtm_const"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rrtm'
+        return "rrtm"
 
 
 class CoefModel(GenvModelResource):
@@ -200,22 +208,21 @@ class CoefModel(GenvModelResource):
     TODO.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['coef_model', 'coefmodel'],
-                remap   = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["coef_model", "coefmodel"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default = 'coef_model'
-            ),
-        )
+            gvar=dict(default="coef_model"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'coef_model'
+        return "coef_model"
 
 
 class ScatCMod5(GenvModelResource):
@@ -223,22 +230,21 @@ class ScatCMod5(GenvModelResource):
     TODO.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['cmod5', 'cmod5table', 'scat_cmod5', 'scatcmod5'],
-                remap   = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["cmod5", "cmod5table", "scat_cmod5", "scatcmod5"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default = 'scat_cmod5_table'
-            ),
-        )
+            gvar=dict(default="scat_cmod5_table"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'cmod5'
+        return "cmod5"
 
 
 class BcorIRSea(GenvModelResource):
@@ -246,24 +252,23 @@ class BcorIRSea(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Some bias ?',
-        attr = dict(
-            kind = dict(
-                values  = ['bcor'],
+        info="Some bias ?",
+        attr=dict(
+            kind=dict(
+                values=["bcor"],
             ),
-            scope = dict(
-                values  = ['irsea'],
+            scope=dict(
+                values=["irsea"],
             ),
-            gvar = dict(
-                default = 'bcor_meto_[scope]'
-            ),
-        )
+            gvar=dict(default="bcor_meto_[scope]"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bcor_irsea'
+        return "bcor_irsea"
 
 
 class RmtbError(GenvModelResource):
@@ -271,24 +276,23 @@ class RmtbError(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Some bias ?',
-        attr = dict(
-            kind = dict(
-                values  = ['rmtberr'],
+        info="Some bias ?",
+        attr=dict(
+            kind=dict(
+                values=["rmtberr"],
             ),
-            scope = dict(
-                values  = ['airs', 'noaa'],
+            scope=dict(
+                values=["airs", "noaa"],
             ),
-            gvar = dict(
-                default = '[scope]_rmtberr'
-            ),
-        )
+            gvar=dict(default="[scope]_rmtberr"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rmtberr'
+        return "rmtberr"
 
 
 class ChanSpectral(GenvModelResource):
@@ -296,27 +300,26 @@ class ChanSpectral(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values   = ['chanspec', 'chan_spec'],
-                remap    = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["chanspec", "chan_spec"],
+                remap=dict(autoremap="first"),
             ),
-            scope = dict(
-                optional = True,
-                default  = 'noaa',
-                values   = ['noaa'],
+            scope=dict(
+                optional=True,
+                default="noaa",
+                values=["noaa"],
             ),
-            gvar = dict(
-                default  = '[scope]_chanspec'
-            ),
-        )
+            gvar=dict(default="[scope]_chanspec"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'chanspec'
+        return "chanspec"
 
 
 class Correl(GenvModelResource):
@@ -324,25 +327,24 @@ class Correl(GenvModelResource):
     TODO.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values   = ['correl'],
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["correl"],
             ),
-            scope = dict(
-                optional = True,
-                default  = 'misc',
+            scope=dict(
+                optional=True,
+                default="misc",
             ),
-            gvar = dict(
-                default  = '[scope]_correl'
-            ),
-        )
+            gvar=dict(default="[scope]_correl"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'correl'
+        return "correl"
 
 
 class CstLim(GenvModelResource):
@@ -350,27 +352,26 @@ class CstLim(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values   = ['cstlim', 'cst_lim'],
-                remap    = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["cstlim", "cst_lim"],
+                remap=dict(autoremap="first"),
             ),
-            scope = dict(
-                optional = True,
-                default  = 'noaa',
-                values   = ['noaa'],
+            scope=dict(
+                optional=True,
+                default="noaa",
+                values=["noaa"],
             ),
-            gvar = dict(
-                default  = '[scope]_cstlim'
-            ),
-        )
+            gvar=dict(default="[scope]_cstlim"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'cstlim'
+        return "cstlim"
 
 
 class RszCoef(GenvModelResource):
@@ -378,22 +379,21 @@ class RszCoef(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['rszcoef', 'rsz_coef'],
-                remap   = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["rszcoef", "rsz_coef"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default = 'rszcoef_fmt'
-            ),
-        )
+            gvar=dict(default="rszcoef_fmt"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rszcoef'
+        return "rszcoef"
 
 
 class RtCoefAirs(GenvModelResource):
@@ -401,21 +401,20 @@ class RtCoefAirs(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['rtcoef_airs'],
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["rtcoef_airs"],
             ),
-            gvar = dict(
-                default = 'rtcoef_airs_ieee'
-            ),
-        )
+            gvar=dict(default="rtcoef_airs_ieee"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rtcoef_airs'
+        return "rtcoef_airs"
 
 
 class RtCoefAtovs(GenvModelResource):
@@ -423,21 +422,20 @@ class RtCoefAtovs(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['rtcoef_atovs'],
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["rtcoef_atovs"],
             ),
-            gvar = dict(
-                default = 'rtcoef_ieee_atovs'
-            ),
-        )
+            gvar=dict(default="rtcoef_ieee_atovs"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'rtcoef_atovs'
+        return "rtcoef_atovs"
 
 
 class SigmaB(GenvModelResource):
@@ -445,42 +443,47 @@ class SigmaB(GenvModelResource):
     Obsolete.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Coefficients for some purpose... but which one ?',
-        attr = dict(
-            kind = dict(
-                values  = ['sigmab', 'sigma', 'sigma_b'],
-                remap   = dict(autoremap = 'first'),
+        info="Coefficients for some purpose... but which one ?",
+        attr=dict(
+            kind=dict(
+                values=["sigmab", "sigma", "sigma_b"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default = 'misc_sigmab'
-            ),
-        )
+            gvar=dict(default="misc_sigmab"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'sigmab'
+        return "sigmab"
 
 
 class AtlasEmissivity(GenvModelResource):
     """
     Abstract class for any Emissivity atlas.
     """
+
     _abstract = True
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values  = ['atlas_emissivity', 'atlasemissivity', 'atlasemiss', 'emiss',
-                           'emissivity_atlas'],
-                remap   = dict(autoremap = 'first'),
+        attr=dict(
+            kind=dict(
+                values=[
+                    "atlas_emissivity",
+                    "atlasemissivity",
+                    "atlasemiss",
+                    "emiss",
+                    "emissivity_atlas",
+                ],
+                remap=dict(autoremap="first"),
             ),
         )
     )
 
     @property
     def realkind(self):
-        return 'atlas_emissivity'
+        return "atlas_emissivity"
 
 
 class AtlasEmissivityGeneric(AtlasEmissivity):
@@ -488,23 +491,24 @@ class AtlasEmissivityGeneric(AtlasEmissivity):
     A yearly emissivity atlas from a specific source.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Yearly emissivity atlas from a given source.',
-        attr = dict(
-            source = dict(
-                values         = ['uwir', 'telsem'],
+        info="Yearly emissivity atlas from a given source.",
+        attr=dict(
+            source=dict(
+                values=["uwir", "telsem"],
             ),
-            gvar = dict(
-                default        = '[source]_emis_atlas'
-            ),
-            month = dict(
+            gvar=dict(default="[source]_emis_atlas"),
+            month=dict(
                 # This is a fake attribute that avoid warnings...
-                values         = [None, ],
-                optional       = True,
-                default        = None,
-                doc_visibility = footprints.doc.visibility.GURU,
-            )
-        )
+                values=[
+                    None,
+                ],
+                optional=True,
+                default=None,
+                doc_visibility=footprints.doc.visibility.GURU,
+            ),
+        ),
     )
 
 
@@ -513,24 +517,33 @@ class AtlasEmissivityInstrument(AtlasEmissivity):
     A yearly emissivity atlas for a specific instrument/sensor.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Yearly emissivity atlas for a given instrument(s).',
-        attr = dict(
-            instrument = dict(
-                values         = ['seviri', 'ssmis', 'iasi', 'amsua', 'amsub', 'an1', 'an2'],
-                remap          = dict(an1='amsua', an2='amsub')
+        info="Yearly emissivity atlas for a given instrument(s).",
+        attr=dict(
+            instrument=dict(
+                values=[
+                    "seviri",
+                    "ssmis",
+                    "iasi",
+                    "amsua",
+                    "amsub",
+                    "an1",
+                    "an2",
+                ],
+                remap=dict(an1="amsua", an2="amsub"),
             ),
-            gvar = dict(
-                default        = 'emissivity_atlas_[instrument]'
-            ),
-            month = dict(
+            gvar=dict(default="emissivity_atlas_[instrument]"),
+            month=dict(
                 # This is a fake attribute that avoid warnings...
-                values         = [None, ],
-                optional       = True,
-                default        = None,
-                doc_visibility = footprints.doc.visibility.GURU,
-            )
-        )
+                values=[
+                    None,
+                ],
+                optional=True,
+                default=None,
+                doc_visibility=footprints.doc.visibility.GURU,
+            ),
+        ),
     )
 
 
@@ -539,15 +552,14 @@ class AtlasMonthlyEmissivityInstrument(AtlasEmissivityInstrument):
     A monthly emissivity atlas for a specific instrument/sensor.
     A Genvkey can be given.
     """
+
     _footprint = [
         month_deco,
         dict(
-            info = 'Monthly emissivity atlas for a given instrument(s).',
-            attr = dict(
-                gvar = dict(
-                    default = 'emissivity_atlas_[instrument]_monthly'
-                ),
-            )
+            info="Monthly emissivity atlas for a given instrument(s).",
+            attr=dict(
+                gvar=dict(default="emissivity_atlas_[instrument]_monthly"),
+            ),
         ),
     ]
 
@@ -557,16 +569,15 @@ class AtlasEmissivityPack(AtlasEmissivity):
     Legacy yearly emissivity atlases for Amsu-A/B. DEPRECIATED.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = 'Atlas of emissivity according to some pack of instrument(s).',
-        attr = dict(
-            pack   = dict(
-                values   = ['1', '2'],
+        info="Atlas of emissivity according to some pack of instrument(s).",
+        attr=dict(
+            pack=dict(
+                values=["1", "2"],
             ),
-            gvar = dict(
-                default  = 'emissivity[pack]'
-            ),
-        )
+            gvar=dict(default="emissivity[pack]"),
+        ),
     )
 
 
@@ -575,16 +586,13 @@ class SeaIceLonLat(GenvModelGeoResource):
     Coordinates of the file containing sea ice observations.
     It is used to create the ice_content file.
     """
+
     _footprint = dict(
-        info = 'Coordinates used for ice_concent creation.',
-        attr = dict(
-            kind = dict(
-                values = ['seaice_lonlat']
-            ),
-            gvar = dict(
-                default  = 'sea_ice_lonlat'
-            ),
-        )
+        info="Coordinates used for ice_concent creation.",
+        attr=dict(
+            kind=dict(values=["seaice_lonlat"]),
+            gvar=dict(default="sea_ice_lonlat"),
+        ),
     )
 
 
@@ -593,37 +601,47 @@ class ODBRaw(GenvModelResource):
     Class for static ODB layouts RSTBIAS, COUNTRYRSTRHBIAS, SONDETYPERSTRHBIAS.
     A GenvKey can be given.
     """
+
     _footprint = dict(
-        info = 'ODB Raw bias',
-        attr = dict(
-            kind = dict(
-                values  = ['odbraw'],
+        info="ODB Raw bias",
+        attr=dict(
+            kind=dict(
+                values=["odbraw"],
             ),
-            layout = dict(
-                values  = [
-                    'rstbias', 'countryrstrhbias', 'sondetyperstrhbias',
-                    'RSTBIAS', 'COUNTRYRSTRHBIAS', 'SONDETYPERSTRHBIAS',
+            layout=dict(
+                values=[
+                    "rstbias",
+                    "countryrstrhbias",
+                    "sondetyperstrhbias",
+                    "RSTBIAS",
+                    "COUNTRYRSTRHBIAS",
+                    "SONDETYPERSTRHBIAS",
                 ],
-                remap   = dict(
-                    RSTBIAS            = 'rstbias',
-                    COUNTRYRSTRHBIAS   = 'countryrstrhbias',
-                    SONDETYPERSTRHBIAS = 'sondetyperstrhbias',
+                remap=dict(
+                    RSTBIAS="rstbias",
+                    COUNTRYRSTRHBIAS="countryrstrhbias",
+                    SONDETYPERSTRHBIAS="sondetyperstrhbias",
                 ),
             ),
-            gvar = dict(
-                default = 'rs_bias_odbtable_[layout]',
-            )
-        )
+            gvar=dict(
+                default="rs_bias_odbtable_[layout]",
+            ),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'odbraw'
+        return "odbraw"
 
 
-@namebuilding_delete('fmt')
-@namebuilding_insert('radical', lambda s: 'matfil')
-@namebuilding_append('geo', lambda s: [s.scope.area, ])
+@namebuilding_delete("fmt")
+@namebuilding_insert("radical", lambda s: "matfil")
+@namebuilding_append(
+    "geo",
+    lambda s: [
+        s.scope.area,
+    ],
+)
 class MatFilter(GenvModelGeoResource):
     """
     Class of a filtering matrix. A GaussGeometry object is needed,
@@ -633,35 +651,32 @@ class MatFilter(GenvModelGeoResource):
     """
 
     _footprint = dict(
-        info = 'Filtering matrix',
-        attr = dict(
-            model = dict(
-                optional = True,
+        info="Filtering matrix",
+        attr=dict(
+            model=dict(
+                optional=True,
             ),
-            kind = dict(
-                values   = ['matfilter']
+            kind=dict(values=["matfilter"]),
+            geometry=dict(type=GaussGeometry),
+            scope=dict(
+                type=LonlatGeometry,
             ),
-            geometry = dict(
-                type     = GaussGeometry
-            ),
-            scope = dict(
-                type     = LonlatGeometry,
-            ),
-            gvar = dict(
-                default  = 'mat_filter_[scope::area]'
-            )
-        )
+            gvar=dict(default="mat_filter_[scope::area]"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'matfilter'
+        return "matfilter"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return ('matrix.fil.' + self.scope.area +
-                '.t{!s}'.format(self.geometry.truncation) +
-                '.c{!s}'.format(self.geometry.stretching))
+        return (
+            "matrix.fil."
+            + self.scope.area
+            + ".t{!s}".format(self.geometry.truncation)
+            + ".c{!s}".format(self.geometry.stretching)
+        )
 
 
 class WaveletTable(GenvModelGeoResource):
@@ -671,21 +686,25 @@ class WaveletTable(GenvModelGeoResource):
     """
 
     _footprint = dict(
-        info = 'Wavelet covariance operators',
-        attr = dict(
-            kind = dict(
-                values   = ['wtable', 'wavelettable', 'wavelet_table', 'rtable', 'rtabwavelet'],
-                remap    = dict(autoremap = 'first'),
+        info="Wavelet covariance operators",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "wtable",
+                    "wavelettable",
+                    "wavelet_table",
+                    "rtable",
+                    "rtabwavelet",
+                ],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default  = 'RTABLE_WAVELET'
-            ),
-        )
+            gvar=dict(default="RTABLE_WAVELET"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'wtable'
+        return "wtable"
 
 
 class AmvError(GenvModelGeoResource):
@@ -693,26 +712,27 @@ class AmvError(GenvModelGeoResource):
     TODO.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info='AMV Tracking Error',
+        info="AMV Tracking Error",
         attr=dict(
             kind=dict(
-                values=['amvtrackingerror', 'amvtr', 'amverror', 'amv_error'],
+                values=["amvtrackingerror", "amvtr", "amverror", "amv_error"],
                 remap=dict(
-                    amvtrackingerror='amv_error',
-                    amvtr='amv_error',
-                    amverror='amv_error',
+                    amvtrackingerror="amv_error",
+                    amvtr="amv_error",
+                    amverror="amv_error",
                 ),
             ),
             gvar=dict(
-                default='amv_tracking_error',
+                default="amv_tracking_error",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'amv_error'
+        return "amv_error"
 
 
 class AmvBias(GenvModelGeoResource):
@@ -720,108 +740,111 @@ class AmvBias(GenvModelGeoResource):
     TODO.
     A Genvkey can be given.
     """
+
     _footprint = dict(
-        info='AMV Tracking Error',
+        info="AMV Tracking Error",
         attr=dict(
             kind=dict(
-                values=['amvbias', 'amv_bias'],
-                remap=dict(amvbias='amv_bias'),
+                values=["amvbias", "amv_bias"],
+                remap=dict(amvbias="amv_bias"),
             ),
-            gvar=dict(
-                default='amv_bias_info'
-            ),
-        )
+            gvar=dict(default="amv_bias_info"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'amv_bias'
+        return "amv_bias"
 
 
 class LFIScripts(StaticResource):
     """
     The LFI scripts. A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info='LFI scripts',
+            info="LFI scripts",
             attr=dict(
                 kind=dict(
-                    values=['lfiscripts', ],
+                    values=[
+                        "lfiscripts",
+                    ],
                 ),
-                gvar=dict(
-                    default='tools_lfi'
-                ),
-            )
-        )
+                gvar=dict(default="tools_lfi"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'lfiscripts'
+        return "lfiscripts"
 
 
 class FilteringRequest(GenvModelResource):
     """
     Class of a JSON file that describes a resource filter. A Genvkey can be given.
     """
+
     _footprint = dict(
-        info = "Description of a resource's data filter",
-        attr = dict(
-            kind = dict(
-                values  = ['filtering_request', ],
+        info="Description of a resource's data filter",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "filtering_request",
+                ],
             ),
-            filtername = dict(
+            filtername=dict(),
+            nativefmt=dict(
+                values=[
+                    "json",
+                ],
+                default="json",
             ),
-            nativefmt = dict(
-                values  = ['json', ],
-                default = 'json',
+            clscontents=dict(
+                default=JsonDictContent,
             ),
-            clscontents = dict(
-                default = JsonDictContent,
-            ),
-            gvar = dict(
-                default = 'filtering_request'
-            ),
-        )
+            gvar=dict(default="filtering_request"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'filtering_request'
+        return "filtering_request"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=filter_{:s}.json'.format(self.filtername)
+        return "extract=filter_{:s}.json".format(self.filtername)
 
 
 class GribAPIConfig(StaticResource):
     """
     Configuration files for the Grib-API (samples or definitions)
     """
+
     _footprint = [
         gvar,
         dict(
-            info='Grib-API configuration files',
+            info="Grib-API configuration files",
             attr=dict(
                 kind=dict(
-                    values  = ['gribapiconf', ],
+                    values=[
+                        "gribapiconf",
+                    ],
                 ),
-                target = dict(
-                    values  = ['samples', 'def', 'definitions'],
-                    remap   = dict(definitions='def'),
+                target=dict(
+                    values=["samples", "def", "definitions"],
+                    remap=dict(definitions="def"),
                 ),
-                gvar=dict(
-                    default = 'grib_api_[target]'
-                ),
-            )
-        )
+                gvar=dict(default="grib_api_[target]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'gribapiconf'
+        return "gribapiconf"
 
 
 class StdPressure(GenvModelGeoResource):
@@ -831,26 +854,24 @@ class StdPressure(GenvModelGeoResource):
     """
 
     _footprint = dict(
-        info = 'Standard pressure profile',
-        attr = dict(
-            kind = dict(
-                values   = ['stdpressure'],
+        info="Standard pressure profile",
+        attr=dict(
+            kind=dict(
+                values=["stdpressure"],
             ),
-            level = dict(
-                type     = int,
-                optional = True,
-                default  = 60,
-                values   = [60],
+            level=dict(
+                type=int,
+                optional=True,
+                default=60,
+                values=[60],
             ),
-            gvar = dict(
-                default  = 'std_pressure'
-            ),
-        )
+            gvar=dict(default="std_pressure"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'stdpressure'
+        return "stdpressure"
 
 
 class TruncObj(GenvModelGeoResource):
@@ -860,20 +881,18 @@ class TruncObj(GenvModelGeoResource):
     """
 
     _footprint = dict(
-        info = 'Standard error truncation',
-        attr = dict(
-            kind = dict(
-                values  = ['truncobj', 'stderr_trunc'],
+        info="Standard error truncation",
+        attr=dict(
+            kind=dict(
+                values=["truncobj", "stderr_trunc"],
             ),
-            gvar = dict(
-                default = 'trunc_obj'
-            ),
-        )
+            gvar=dict(default="trunc_obj"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'truncobj'
+        return "truncobj"
 
 
 class InterChannelsCorrelations(GenvModelResource):
@@ -883,47 +902,53 @@ class InterChannelsCorrelations(GenvModelResource):
     """
 
     _footprint = dict(
-        info = 'Inter channel correlations for a given instrument.',
-        attr = dict(
-            kind = dict(
-                values  = ['correlations', ],
+        info="Inter channel correlations for a given instrument.",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "correlations",
+                ],
             ),
-            instrument = dict(
-                values  = ['cris', 'iasi', ],
+            instrument=dict(
+                values=[
+                    "cris",
+                    "iasi",
+                ],
             ),
-            gvar = dict(
-                default = 'correlations_[instrument]'
-            ),
-            clscontents = dict(
-                default = DataRaw,
+            gvar=dict(default="correlations_[instrument]"),
+            clscontents=dict(
+                default=DataRaw,
             ),
         ),
     )
 
     @property
     def realkind(self):
-        return 'correlations'
+        return "correlations"
 
 
 class SunMoonPositionCoeff(StaticResource):
     """
     Coefficients of the Chebyshev polynomials used to calculate the position of the moon and the sun.
     """
+
     _footprint = [
         gvar,
         dict(
-            info='Chebyshev polynomials for the moon and sun position',
+            info="Chebyshev polynomials for the moon and sun position",
             attr=dict(
                 kind=dict(
-                    values  = ['sunmoonpositioncoeffs', ],
+                    values=[
+                        "sunmoonpositioncoeffs",
+                    ],
                 ),
                 gvar=dict(
-                    default = 'sun_moon_position_tgz',
+                    default="sun_moon_position_tgz",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'sunmoonpositioncoeffs'
+        return "sunmoonpositioncoeffs"

--- a/src/vortex/nwp/data/ctpini.py
+++ b/src/vortex/nwp/data/ctpini.py
@@ -22,15 +22,15 @@ class CtpiniDirectiveFile(GeoFlowResource):
     """
 
     _footprint = dict(
-        info = "Ctpini directive file",
-        attr = dict(
-            kind = dict(
-                values = ["ctpini_directives_file", ],
+        info="Ctpini directive file",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ctpini_directives_file",
+                ],
             ),
-            nativefmt = dict(
-                default = "ascii"
-            )
-        )
+            nativefmt=dict(default="ascii"),
+        ),
     )
 
     @property
@@ -47,8 +47,8 @@ class AsciiFiles(StaticResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Abstract class for ascii files from genv.',
-        )
+            info="Abstract class for ascii files from genv.",
+        ),
     ]
 
 
@@ -59,21 +59,19 @@ class CtpiniAsciiFiles(AsciiFiles):
 
     _footprint = [
         dict(
-            info = "Ctpini Genv ascii files.",
-            attr = dict(
-                kind = dict(
-                    values = ["ctpini_ascii_file"],
+            info="Ctpini Genv ascii files.",
+            attr=dict(
+                kind=dict(
+                    values=["ctpini_ascii_file"],
                 ),
-                source = dict(
-                    values = ["levels", "covano", "fort61", "coor", "cov46"],
+                source=dict(
+                    values=["levels", "covano", "fort61", "coor", "cov46"],
                 ),
-                gvar = dict(
-                    default = "tsr_misc_[source]",
+                gvar=dict(
+                    default="tsr_misc_[source]",
                 ),
-                clscontents=dict(
-                    default = DataTemplate
-                ),
-            )
+                clscontents=dict(default=DataTemplate),
+            ),
         )
     ]
 
@@ -88,31 +86,49 @@ class GridPointCtpini(GridPoint):
     """
 
     _footprint = dict(
-        info = 'Ctpini Gridpoint Fields',
-        attr = dict(
-            kind = dict(
-                values = ['ctpini_gridpoint', ],
+        info="Ctpini Gridpoint Fields",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ctpini_gridpoint",
+                ],
             ),
-            origin = dict(
-                values = ['oper', 'PS', 'dble', 'PX', 'ctpini', 'PTSR', ],
-                remap = dict(
-                    PS = 'oper',
-                    PX = 'dble',
-                    PTSR = 'ctpini',
+            origin=dict(
+                values=[
+                    "oper",
+                    "PS",
+                    "dble",
+                    "PX",
+                    "ctpini",
+                    "PTSR",
+                ],
+                remap=dict(
+                    PS="oper",
+                    PX="dble",
+                    PTSR="ctpini",
                 ),
             ),
-            parameter = dict(
-                values = ['PMERSOL', 'T850HPA', 'Z15PVU', 'Z20PVU', 'Z07PVU', 'TROPO'],
+            parameter=dict(
+                values=[
+                    "PMERSOL",
+                    "T850HPA",
+                    "Z15PVU",
+                    "Z20PVU",
+                    "Z07PVU",
+                    "TROPO",
+                ],
             ),
-            run_ctpini = dict(
-                optional = True,
-                default = None,
+            run_ctpini=dict(
+                optional=True,
+                default=None,
             ),
-            nativefmt = dict(
-                values = ['geo', ],
-                default = 'geo',
+            nativefmt=dict(
+                values=[
+                    "geo",
+                ],
+                default="geo",
             ),
-        )
+        ),
     )
 
     @property
@@ -122,12 +138,12 @@ class GridPointCtpini(GridPoint):
     def namebuilding_info(self):
         """Generic information, radical = ``grid``."""
         ninfo = super().namebuilding_info()
-        if self.origin == 'ctpini' and self.run_ctpini is not None:
+        if self.origin == "ctpini" and self.run_ctpini is not None:
             source = [self.model, self.origin, self.parameter, self.run_ctpini]
         else:
             source = [self.model, self.origin, self.parameter]
         ninfo.update(
-            radical='ctpini-grid',
+            radical="ctpini-grid",
             src=source,
         )
         return ninfo

--- a/src/vortex/nwp/data/diagnostics.py
+++ b/src/vortex/nwp/data/diagnostics.py
@@ -6,7 +6,11 @@ import footprints
 
 from vortex.data.flow import GeoFlowResource, GeoPeriodFlowResource
 from vortex.syntax.stdattrs import term_deco
-from vortex.syntax.stddeco import namebuilding_append, namebuilding_insert, overwrite_realkind
+from vortex.syntax.stddeco import (
+    namebuilding_append,
+    namebuilding_insert,
+    overwrite_realkind,
+)
 
 #: No automatic export
 __all__ = []
@@ -16,51 +20,49 @@ class ISP(GeoFlowResource):
     """Class for Forecasted Satellite Image resource. Obsolete."""
 
     _footprint = dict(
-        info = 'Forecasted Satellite Image',
-        attr = dict(
-            kind = dict(
-                values = ['isp', 'fsi']
+        info="Forecasted Satellite Image",
+        attr=dict(
+            kind=dict(values=["isp", "fsi"]),
+            nativefmt=dict(
+                values=[
+                    "foo",
+                ],
+                default="foo",
             ),
-            nativefmt = dict(
-                values = ['foo', ],
-                default = 'foo',
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'isp'
+        return "isp"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'anim0'
+        return "anim0"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'ISP' + self.model[:4].upper()
+        return "ISP" + self.model[:4].upper()
 
 
-@namebuilding_insert('radical', lambda s: 'ddh')
-@namebuilding_append('src', lambda s: s.scope)
+@namebuilding_insert("radical", lambda s: "ddh")
+@namebuilding_append("src", lambda s: s.scope)
 class _DDHcommon(GeoFlowResource):
     """
     Abstract class for Horizontal Diagnostics.
     """
+
     _abstract = True
     _footprint = dict(
-        info = 'Diagnostic on Horizontal Domains',
-        attr = dict(
-            kind = dict(
-                values = ['ddh', 'dhf'],
-                remap = dict(dhf='ddh')
+        info="Diagnostic on Horizontal Domains",
+        attr=dict(
+            kind=dict(values=["ddh", "dhf"], remap=dict(dhf="ddh")),
+            nativefmt=dict(),
+            scope=dict(
+                values=["limited", "dlimited", "global", "zonal"],
+                remap=dict(limited="dlimited"),
             ),
-            nativefmt = dict(),
-            scope = dict(
-                values = ['limited', 'dlimited', 'global', 'zonal'],
-                remap = dict(limited='dlimited')
-            ),
-        )
+        ),
     )
 
 
@@ -69,30 +71,35 @@ class DDH(_DDHcommon):
     Class for Horizontal Diagnostics.
     Used to be a ``dhf`` !
     """
+
     _footprint = [
         term_deco,
         dict(
-            info = 'Diagnostic on Horizontal Domains',
-            attr = dict(
-                nativefmt = dict(
-                    values = ['lfi', 'lfa'],
-                    default = 'lfi',
+            info="Diagnostic on Horizontal Domains",
+            attr=dict(
+                nativefmt=dict(
+                    values=["lfi", "lfa"],
+                    default="lfi",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'ddh'
+        return "ddh"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'dhf{:s}{:s}+{:s}'.format(self.scope[:2].lower(), self.model[:4].lower(), self.term.fmth)
+        return "dhf{:s}{:s}+{:s}".format(
+            self.scope[:2].lower(), self.model[:4].lower(), self.term.fmth
+        )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'DHF{:s}{:s}+{:s}'.format(self.scope[:2].upper(), self.model[:4].upper(), self.term.fmth)
+        return "DHF{:s}{:s}+{:s}".format(
+            self.scope[:2].upper(), self.model[:4].upper(), self.term.fmth
+        )
 
 
 class DDHpack(_DDHcommon):
@@ -100,43 +107,56 @@ class DDHpack(_DDHcommon):
     Class for Horizontal Diagnostics with all terms packed in a single directory.
     Used to be a ``dhf`` !
     """
+
     _footprint = dict(
-        info = 'Diagnostic on Horizontal Domains packed in a single directory',
-        attr = dict(
-            nativefmt = dict(
-                values = ['ddhpack', ],
+        info="Diagnostic on Horizontal Domains packed in a single directory",
+        attr=dict(
+            nativefmt=dict(
+                values=[
+                    "ddhpack",
+                ],
             ),
-        )
+        ),
     )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'DHF{:s}{:s}.tar'.format(self.scope[:2].upper(), self.model[:4].upper())
+        return "DHF{:s}{:s}.tar".format(
+            self.scope[:2].upper(), self.model[:4].upper()
+        )
 
     @property
     def realkind(self):
-        return 'ddhpack'
+        return "ddhpack"
 
 
 _surfex_diag_decofp = footprints.DecorativeFootprint(
-    info='Diagnostic files outputed by surfex during a model run',
+    info="Diagnostic files outputed by surfex during a model run",
     attr=dict(
         kind=dict(
-            values=['diagnostics', ]
+            values=[
+                "diagnostics",
+            ]
         ),
-        scope=dict(
-        ),
+        scope=dict(),
         model=dict(
-            values=['surfex', ]
+            values=[
+                "surfex",
+            ]
         ),
         nativefmt=dict(
-            values=['netcdf', 'grib', ],
-            default='netcdf',
-            optional=True
+            values=[
+                "netcdf",
+                "grib",
+            ],
+            default="netcdf",
+            optional=True,
         ),
     ),
-    decorator=[namebuilding_append('src', lambda s: s.scope),
-               overwrite_realkind('diagnostics')]
+    decorator=[
+        namebuilding_append("src", lambda s: s.scope),
+        overwrite_realkind("diagnostics"),
+    ],
 )
 
 
@@ -149,33 +169,41 @@ class SurfexDiagnostics(GeoFlowResource):
 class SurfexPeriodDiagnostics(GeoPeriodFlowResource):
     """Diagnostic files outputed by surfex during a model run (period version)."""
 
-    _footprint = [_surfex_diag_decofp, ]
+    _footprint = [
+        _surfex_diag_decofp,
+    ]
 
 
 class ObjTrack(GeoFlowResource):
     """Class for Object Tracks."""
 
     _footprint = dict(
-        info = 'Object Tracks json file',
-        attr = dict(
-            kind = dict(
-                values = ['objtrack']
+        info="Object Tracks json file",
+        attr=dict(
+            kind=dict(values=["objtrack"]),
+            nativefmt=dict(
+                values=[
+                    "json",
+                    "hdf5",
+                    "foo",
+                ],
+                default="foo",
             ),
-            nativefmt = dict(
-                values = ['json', 'hdf5', 'foo', ],
-                default = 'foo',
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'objtrack'
+        return "objtrack"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'track{:s}{:s}+{:s}'.format(self.scope[:2].lower(), self.model[:4].lower(), self.term.fmth)
+        return "track{:s}{:s}+{:s}".format(
+            self.scope[:2].lower(), self.model[:4].lower(), self.term.fmth
+        )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'track{:s}{:s}+{:s}'.format(self.scope[:2].upper(), self.model[:4].upper(), self.term.fmth)
+        return "track{:s}{:s}+{:s}".format(
+            self.scope[:2].upper(), self.model[:4].upper(), self.term.fmth
+        )

--- a/src/vortex/nwp/data/eda.py
+++ b/src/vortex/nwp/data/eda.py
@@ -16,7 +16,9 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class RawFiles(GeoFlowResource):
     """Input files for wavelet covariances estimation. To be removed soon."""
 
@@ -24,23 +26,21 @@ class RawFiles(GeoFlowResource):
         term_deco,
         gvar,
         dict(
-            info = 'Input files for wavelet covariances estimation',
-            attr = dict(
-                kind = dict(
-                    values   = ['rawfiles'],
+            info="Input files for wavelet covariances estimation",
+            attr=dict(
+                kind=dict(
+                    values=["rawfiles"],
                 ),
-                nativefmt   = dict(
-                    values  = ['rawfiles', 'unknown'],
+                nativefmt=dict(
+                    values=["rawfiles", "unknown"],
                 ),
-                gvar = dict(
-                    default = 'aearp_rawfiles_t[geometry:truncation]'
+                gvar=dict(default="aearp_rawfiles_t[geometry:truncation]"),
+                ipert=dict(
+                    type=int,
+                    optional=True,
                 ),
-                ipert = dict(
-                    type = int,
-                    optional = True,
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
@@ -49,7 +49,9 @@ class RawFiles(GeoFlowResource):
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'RAWFILEP(memberfix:member)+{:s}.{:d}'.format(self.term.fmthour, self.geometry.truncation)
+        return "RAWFILEP(memberfix:member)+{:s}.{:d}".format(
+            self.term.fmthour, self.geometry.truncation
+        )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
@@ -58,11 +60,13 @@ class RawFiles(GeoFlowResource):
     def gget_basename(self):
         """GGET specific naming convention."""
         if self.ipert is None:
-            raise ValueError('ipert is mandatory with the GCO provider')
-        return dict(suffix='.{:03d}.tar'.format(self.ipert))
+            raise ValueError("ipert is mandatory with the GCO provider")
+        return dict(suffix=".{:03d}.tar".format(self.ipert))
 
 
-@namebuilding_insert('geo', lambda s: s._geo2basename_info(add_stretching=False))
+@namebuilding_insert(
+    "geo", lambda s: s._geo2basename_info(add_stretching=False)
+)
 class RandBFiles(GeoFlowResource):
     """Input files for wavelet covariances estimation."""
 
@@ -70,33 +74,33 @@ class RandBFiles(GeoFlowResource):
         term_deco,
         gvar,
         dict(
-            info = 'Input files for wavelet covariances estimation',
-            attr = dict(
-                kind = dict(
-                    values   = ['randbfiles', 'famembers'],
-                    remap    = dict(autoremap = 'first')
+            info="Input files for wavelet covariances estimation",
+            attr=dict(
+                kind=dict(
+                    values=["randbfiles", "famembers"],
+                    remap=dict(autoremap="first"),
                 ),
-                nativefmt   = dict(
-                    values  = ['fa', 'unknown'],
+                nativefmt=dict(
+                    values=["fa", "unknown"],
                 ),
-                gvar = dict(
-                    default = 'aearp_randb_t[geometry:truncation]'
+                gvar=dict(default="aearp_randb_t[geometry:truncation]"),
+                ipert=dict(
+                    type=int,
+                    optional=True,
                 ),
-                ipert = dict(
-                    type = int,
-                    optional = True,
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'randbfiles'
+        return "randbfiles"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'famember(memberfix:member)+{:s}.{:d}'.format(self.term.fmthour, self.geometry.truncation)
+        return "famember(memberfix:member)+{:s}.{:d}".format(
+            self.term.fmthour, self.geometry.truncation
+        )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
@@ -105,8 +109,8 @@ class RandBFiles(GeoFlowResource):
     def gget_basename(self):
         """GGET specific naming convention."""
         if self.ipert is None:
-            raise ValueError('ipert is mandatory with the GCO provider')
-        return dict(suffix='.{:03d}.{}'.format(self.ipert, 'fa'))
+            raise ValueError("ipert is mandatory with the GCO provider")
+        return dict(suffix=".{:03d}.{}".format(self.ipert, "fa"))
 
 
 class InflationFactor(_BackgroundErrorInfo):
@@ -115,29 +119,24 @@ class InflationFactor(_BackgroundErrorInfo):
     """
 
     _footprint = dict(
-        info='Inflation factor profiles',
+        info="Inflation factor profiles",
         attr=dict(
             kind=dict(
-                values=['infl_factor', 'infl', 'inflation_factor'],
-                remap=dict(autoremap='first'),
+                values=["infl_factor", "infl", "inflation_factor"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                default = 'inflation_factor'
-            ),
+            gvar=dict(default="inflation_factor"),
             nativefmt=dict(
-                values=['ascii'],
-                default='ascii',
+                values=["ascii"],
+                default="ascii",
             ),
-            term=dict(
-                optional=True,
-                default=3
-            ),
+            term=dict(optional=True, default=3),
         ),
     )
 
     @property
     def realkind(self):
-        return 'inflation_factor'
+        return "inflation_factor"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""

--- a/src/vortex/nwp/data/eps.py
+++ b/src/vortex/nwp/data/eps.py
@@ -22,7 +22,10 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-@namebuilding_insert('radical', lambda s: {'unit': 'u', 'normed': 'n'}.get(s.processing, '') + s.realkind)
+@namebuilding_insert(
+    "radical",
+    lambda s: {"unit": "u", "normed": "n"}.get(s.processing, "") + s.realkind,
+)
 class PerturbedState(Historic):
     """
     Class for numbered historic resources, for example perturbations or perturbed states of the EPS.
@@ -31,77 +34,95 @@ class PerturbedState(Historic):
     _footprint = [
         number_deco,
         dict(
-            info = 'Perturbation or perturbed state',
-            attr = dict(
-                kind = dict(
-                    values  = ['perturbation', 'perturbed_historic', 'perturbed_state', 'pert'],
-                    remap = dict(autoremap = 'first')
+            info="Perturbation or perturbed state",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "perturbation",
+                        "perturbed_historic",
+                        "perturbed_state",
+                        "pert",
+                    ],
+                    remap=dict(autoremap="first"),
                 ),
-                term = dict(
-                    optional = True,
-                    default = Time(0)
+                term=dict(optional=True, default=Time(0)),
+                processing=dict(
+                    values=["unit", "normed"],
+                    optional=True,
                 ),
-                processing = dict(
-                    values = ['unit', 'normed'],
-                    optional = True,
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'pert'
+        return "pert"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        raise NotImplementedError("Perturbations were previously tar files, not supported yet.")
+        raise NotImplementedError(
+            "Perturbations were previously tar files, not supported yet."
+        )
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        raise NotImplementedError("Perturbations were previously tar files, not supported yet.")
+        raise NotImplementedError(
+            "Perturbations were previously tar files, not supported yet."
+        )
 
 
-@namebuilding_insert('radical', lambda s: s.realkind + '-' + s.zone)
+@namebuilding_insert("radical", lambda s: s.realkind + "-" + s.zone)
 class SingularVector(Historic):
     """
     Generic class for resources internal to singular vectors.
     """
+
     _footprint = [
         number_deco,
         dict(
-            info = 'Singular vector',
-            attr = dict(
-                kind = dict(
-                    values  = ['svector'],
+            info="Singular vector",
+            attr=dict(
+                kind=dict(
+                    values=["svector"],
                 ),
-                zone = dict(
-                    values  = ['ateur', 'hnc', 'hs', 'pno', 'oise', 'an', 'pne',
-                               'oiso', 'ps', 'oin', 'trop1', 'trop2', 'trop3', 'trop4'],
+                zone=dict(
+                    values=[
+                        "ateur",
+                        "hnc",
+                        "hs",
+                        "pno",
+                        "oise",
+                        "an",
+                        "pne",
+                        "oiso",
+                        "ps",
+                        "oin",
+                        "trop1",
+                        "trop2",
+                        "trop3",
+                        "trop4",
+                    ],
                 ),
-                term = dict(
-                    optional = True,
-                    default = Time(0)
+                term=dict(optional=True, default=Time(0)),
+                optime=dict(
+                    type=Time,
+                    optional=True,
                 ),
-                optime = dict(
-                    type = Time,
-                    optional = True,
-                )
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'svector'
+        return "svector"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'SVARPE' + '{:03d}'.format(self.number) + '+0000'
+        return "SVARPE" + "{:03d}".format(self.number) + "+0000"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'SVARPE' + '{:03d}'.format(self.number) + '+0000'
+        return "SVARPE" + "{:03d}".format(self.number) + "+0000"
 
 
 @use_flow_logs_stack
@@ -111,30 +132,30 @@ class NormCoeff(FlowResource):
     """
 
     _footprint = dict(
-        info = 'Perturbations coefficient',
-        attr = dict(
-            kind = dict(
-                values   = ['coeffnorm', 'coeffpert'],
-                remap = dict(autoremap = 'first'),
+        info="Perturbations coefficient",
+        attr=dict(
+            kind=dict(
+                values=["coeffnorm", "coeffpert"],
+                remap=dict(autoremap="first"),
             ),
-            clscontents = dict(
-                default = JsonDictContent,
+            clscontents=dict(
+                default=JsonDictContent,
             ),
-            nativefmt   = dict(
-                values  = ['json'],
-                default = 'json',
+            nativefmt=dict(
+                values=["json"],
+                default="json",
             ),
-            pertkind     = dict(
-                values   = ['sv', 'bd'],
-                optional = True,
-                default  = 'sv',
+            pertkind=dict(
+                values=["sv", "bd"],
+                optional=True,
+                default="sv",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'coeff' + self.pertkind
+        return "coeff" + self.pertkind
 
 
 class SampleContent(JsonDictContent):
@@ -142,8 +163,16 @@ class SampleContent(JsonDictContent):
 
     def drawing(self, g, x):
         """Return the number of a sampled element according to the local number."""
-        n = g.get('number', x.get('number', None))
-        virgin = g.get('untouched', x.get('untouched', [0, ]))
+        n = g.get("number", x.get("number", None))
+        virgin = g.get(
+            "untouched",
+            x.get(
+                "untouched",
+                [
+                    0,
+                ],
+            ),
+        )
         if n is None:
             return None
         else:
@@ -159,17 +188,21 @@ class SampleContent(JsonDictContent):
                 return n
             else:
                 try:
-                    return self.data['drawing'][n - 1]
+                    return self.data["drawing"][n - 1]
                 except KeyError:
                     return None
 
     @secure_getattr
     def __getattr__(self, attr):
         # Return an access function that corresponds to the key in "drawing"
-        drawing_keys = {item
-                        for d in self.data.get('drawing', []) if isinstance(d, dict)
-                        for item in d.keys()}
+        drawing_keys = {
+            item
+            for d in self.data.get("drawing", [])
+            if isinstance(d, dict)
+            for item in d.keys()
+        }
         if attr in drawing_keys:
+
             def _attr_access(g, x):
                 elt = self.drawing(g, x)
                 # drawing may returns
@@ -177,52 +210,68 @@ class SampleContent(JsonDictContent):
                 # * An integer if 'number' is in the 'untouched' list
                 # * A dictionary
                 if elt is None:
-                    choices = {d[attr] for d in self.data['drawing']}
+                    choices = {d[attr] for d in self.data["drawing"]}
                     return None if len(choices) > 1 else choices.pop()
                 else:
                     return elt[attr] if isinstance(elt, dict) else None
+
             return _attr_access
         # Return an access function that corresponds to the key in "population"
-        population_keys = {item
-                           for d in self.data.get('population', []) if isinstance(d, dict)
-                           for item in d.keys()}
+        population_keys = {
+            item
+            for d in self.data.get("population", [])
+            if isinstance(d, dict)
+            for item in d.keys()
+        }
         if attr in population_keys:
+
             def _attr_access(g, x):
-                n = g.get('number', x.get('number', None))
+                n = g.get("number", x.get("number", None))
                 if n is None:
                     return None
                 else:
-                    return self.data['population'][n - 1][attr]
+                    return self.data["population"][n - 1][attr]
+
             return _attr_access
         # Returns the list of drawn keys
-        listing_keys = {item + 's'
-                        for d in self.data.get('drawing', []) if isinstance(d, dict)
-                        for item in d.keys()}
+        listing_keys = {
+            item + "s"
+            for d in self.data.get("drawing", [])
+            if isinstance(d, dict)
+            for item in d.keys()
+        }
         if attr in listing_keys:
-            return [d[attr[:-1]] for d in self.data['drawing']]
+            return [d[attr[:-1]] for d in self.data["drawing"]]
         # Return the list of available keys
-        listing_keys = {item + 's'
-                        for d in self.data['population'] if isinstance(d, dict)
-                        for item in d.keys()}
+        listing_keys = {
+            item + "s"
+            for d in self.data["population"]
+            if isinstance(d, dict)
+            for item in d.keys()
+        }
         if attr in listing_keys:
-            return [d[attr[:-1]] for d in self.data['population']]
+            return [d[attr[:-1]] for d in self.data["population"]]
         raise AttributeError()
 
     def targetdate(self, g, x):
-        targetdate = g.get('targetdate', x.get('targetdate', None))
+        targetdate = g.get("targetdate", x.get("targetdate", None))
         if targetdate is None:
-            raise ValueError("A targetdate attribute must be present if targetdate is used")
+            raise ValueError(
+                "A targetdate attribute must be present if targetdate is used"
+            )
         return Date(targetdate)
 
     def targetterm(self, g, x):
-        targetterm = g.get('targetterm', x.get('targetterm', None))
+        targetterm = g.get("targetterm", x.get("targetterm", None))
         if targetterm is None:
-            raise ValueError("A targetterm attribute must be present if targetterm is used")
+            raise ValueError(
+                "A targetterm attribute must be present if targetterm is used"
+            )
         return Time(targetterm)
 
     def timedelta(self, g, x):
         """Find the time difference between the resource's date and the targetdate."""
-        targetterm = Time(g.get('targetterm', x.get('targetterm', 0)))
+        targetterm = Time(g.get("targetterm", x.get("targetterm", 0)))
         thedate = Date(self.date(g, x))
         period = (self.targetdate(g, x) + targetterm) - thedate
         return period.time()
@@ -230,13 +279,15 @@ class SampleContent(JsonDictContent):
     def _actual_diff(self, ref):
         me = copy.copy(self.data)
         other = copy.copy(ref.data)
-        me.pop('experiment', None)  # Do not compare the experiment ID (if present)
-        other.pop('experiment', None)
+        me.pop(
+            "experiment", None
+        )  # Do not compare the experiment ID (if present)
+        other.pop("experiment", None)
         return me == other
 
 
 @use_flow_logs_stack
-@namebuilding_delete('src')
+@namebuilding_delete("src")
 class PopulationList(FlowResource):
     """
     Description of available data
@@ -244,60 +295,58 @@ class PopulationList(FlowResource):
 
     _abstract = True
     _footprint = dict(
-        info = 'A Population List',
-        attr = dict(
-            clscontents = dict(
-                default = SampleContent,
+        info="A Population List",
+        attr=dict(
+            clscontents=dict(
+                default=SampleContent,
             ),
-            nativefmt   = dict(
-                values  = ['json'],
-                default = 'json',
+            nativefmt=dict(
+                values=["json"],
+                default="json",
             ),
-            nbsample = dict(
-                optional = True,
-                type = int,
+            nbsample=dict(
+                optional=True,
+                type=int,
             ),
-            checkrole = dict(
-                optional = True
-            )
-        )
+            checkrole=dict(optional=True),
+        ),
     )
 
 
 class MembersPopulation(PopulationList):
-
     _footprint = dict(
-        info = 'Members population',
-        attr = dict(
-            kind = dict(
-                values   = ['mbpopulation', ],
+        info="Members population",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "mbpopulation",
+                ],
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'mbpopulation'
+        return "mbpopulation"
 
 
-@namebuilding_insert('radical', lambda s: '{:s}of{:d}'.format(s.realkind, s.nbsample))
+@namebuilding_insert(
+    "radical", lambda s: "{:s}of{:d}".format(s.realkind, s.nbsample)
+)
 class Sample(PopulationList):
     """
     Lot drawn out of a set.
     """
 
-    _abstract = True,
+    _abstract = (True,)
     _footprint = dict(
-        info = 'Sample',
-        attr = dict(
-            nbsample = dict(
-                optional = False,
+        info="Sample",
+        attr=dict(
+            nbsample=dict(
+                optional=False,
             ),
-            population = dict(
-                type = footprints.stdtypes.FPList,
-                optional = True
-            ),
-        )
+            population=dict(type=footprints.stdtypes.FPList, optional=True),
+        ),
     )
 
 
@@ -307,18 +356,18 @@ class MembersSample(Sample):
     """
 
     _footprint = dict(
-        info = 'Members sample',
-        attr = dict(
-            kind = dict(
-                values   = ['mbsample', 'mbselect', 'mbdrawing', 'members_select'],
-                remap = dict(autoremap = 'first'),
+        info="Members sample",
+        attr=dict(
+            kind=dict(
+                values=["mbsample", "mbselect", "mbdrawing", "members_select"],
+                remap=dict(autoremap="first"),
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'mbsample'
+        return "mbsample"
 
 
 class MultiphysicsSample(Sample):
@@ -327,18 +376,18 @@ class MultiphysicsSample(Sample):
     """
 
     _footprint = dict(
-        info = 'Physical packages sample',
-        attr = dict(
-            kind = dict(
-                values   = ['physample', 'physelect', 'phydrawing'],
-                remap = dict(autoremap = 'first'),
+        info="Physical packages sample",
+        attr=dict(
+            kind=dict(
+                values=["physample", "physelect", "phydrawing"],
+                remap=dict(autoremap="first"),
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'physample'
+        return "physample"
 
 
 class ClustContent(TextContent):
@@ -349,35 +398,35 @@ class ClustContent(TextContent):
 
 
 @use_flow_logs_stack
-@namebuilding_delete('src')
+@namebuilding_delete("src")
 class GeneralCluster(FlowResource):
     """
     Files produced by the clustering step of the LAM PE.
     """
 
     _footprint = dict(
-        info = 'Clustering stuff',
-        attr = dict(
-            kind = dict(
-                values   = ['clustering', 'clust', 'members_select'],
-                remap = dict(autoremap = 'first'),
+        info="Clustering stuff",
+        attr=dict(
+            kind=dict(
+                values=["clustering", "clust", "members_select"],
+                remap=dict(autoremap="first"),
             ),
-            clscontents = dict(
-                default = ClustContent,
+            clscontents=dict(
+                default=ClustContent,
             ),
-            nativefmt = dict(
-                values   = ['ascii', 'txt'],
-                default  = 'txt',
-                remap    = dict(ascii = 'txt'),
+            nativefmt=dict(
+                values=["ascii", "txt"],
+                default="txt",
+                remap=dict(ascii="txt"),
             ),
-            filling = dict(
-                values   = ['population', 'pop', 'members', 'full'],
-                remap    = dict(population = 'pop'),
-                default  = '',
+            filling=dict(
+                values=["population", "pop", "members", "full"],
+                remap=dict(population="pop"),
+                default="",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'clustering' + '_' + self.filling
+        return "clustering" + "_" + self.filling

--- a/src/vortex/nwp/data/executables.py
+++ b/src/vortex/nwp/data/executables.py
@@ -4,8 +4,20 @@ Various Resources for executables used in NWP.
 
 import vortex
 
-from vortex.data.executables import Script, GnuScript, BlackBox, NWPModel, SurfaceModel, OceanographicModel
-from ..syntax.stdattrs import gvar, arpifs_cycle, gmkpack_compiler_identification_deco, executable_flavour_deco
+from vortex.data.executables import (
+    Script,
+    GnuScript,
+    BlackBox,
+    NWPModel,
+    SurfaceModel,
+    OceanographicModel,
+)
+from ..syntax.stdattrs import (
+    gvar,
+    arpifs_cycle,
+    gmkpack_compiler_identification_deco,
+    executable_flavour_deco,
+)
 from ..syntax.stdattrs import ArpIfsSimplifiedCycle
 
 #: No automatic export
@@ -14,22 +26,29 @@ __all__ = []
 
 def gmkpack_bin_deco(cls):
     """Add the necessary method to look into gmkpack directories."""
+
     def guess_binary_sources(self, provider):
         """Return the sources location baseld on gmkpack layout."""
         sh = vortex.ticket().sh
         srcdirs = []
-        if provider.realkind == 'remote' and provider.tube in ('file', 'symlink'):
+        if provider.realkind == "remote" and provider.tube in (
+            "file",
+            "symlink",
+        ):
             packroot = sh.path.dirname(provider.pathname(self))
-            srcroot = sh.path.join(packroot, 'src')
+            srcroot = sh.path.join(packroot, "src")
             if sh.path.exists(srcroot):
                 insrc = sh.listdir(srcroot)
-                if 'local' in insrc:
-                    srcdirs.append('local')
-                for inter in [d for d in sorted(insrc, reverse=True)
-                              if d.startswith('inter')]:
+                if "local" in insrc:
+                    srcdirs.append("local")
+                for inter in [
+                    d
+                    for d in sorted(insrc, reverse=True)
+                    if d.startswith("inter")
+                ]:
                     srcdirs.append(inter)
-                if 'main' in insrc:
-                    srcdirs.append('main')
+                if "main" in insrc:
+                    srcdirs.append("main")
             srcdirs = [sh.path.join(srcroot, d) for d in srcdirs]
         return srcdirs
 
@@ -47,66 +66,79 @@ class IFSModel(NWPModel):
         gmkpack_compiler_identification_deco,
         gvar,
         dict(
-            info = 'IFS Model',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_[model]'
+            info="IFS Model",
+            attr=dict(
+                gvar=dict(default="master_[model]"),
+                kind=dict(
+                    values=["ifsmodel", "mfmodel"],
                 ),
-                kind = dict(
-                    values   = ['ifsmodel', 'mfmodel'],
+                model=dict(
+                    outcast=["aladin", "arome"],
                 ),
-                model = dict(
-                    outcast  = ['aladin', 'arome'],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'ifsmodel'
+        return "ifsmodel"
 
     def iga_pathinfo(self):
         """Standard path information for IGA inline cache."""
-        return dict(
-            model=self.model
-        )
+        return dict(model=self.model)
 
     def iga_basename(self):
         """Standard expected basename for IGA inline cache."""
-        return 'ARPEGE'
+        return "ARPEGE"
 
-    def command_line(self, model='arpifs', vmodel='meteo',
-                     name='XRUN', conf=1, timescheme='sli',
-                     timestep=600, fcterm=0, fcunit='h'):
+    def command_line(
+        self,
+        model="arpifs",
+        vmodel="meteo",
+        name="XRUN",
+        conf=1,
+        timescheme="sli",
+        timestep=600,
+        fcterm=0,
+        fcunit="h",
+    ):
         """
         Build command line for execution as a single string.
         Depending on the cycle it may returns nothing.
         """
-        if self.cycle < 'cy41':
-            return '-v{:s} -e{:s} -c{:d} -a{:s} -t{:g} -f{:s}{:d} -m{:s}'.format(
-                vmodel, name, conf, timescheme, timestep, fcunit, fcterm, model
+        if self.cycle < "cy41":
+            return (
+                "-v{:s} -e{:s} -c{:d} -a{:s} -t{:g} -f{:s}{:d} -m{:s}".format(
+                    vmodel,
+                    name,
+                    conf,
+                    timescheme,
+                    timestep,
+                    fcunit,
+                    fcterm,
+                    model,
+                )
             )
         else:
-            return ''
+            return ""
 
 
 class Arome(IFSModel):
     """Dedicated to local area model."""
 
     _footprint = dict(
-        info = 'ALADIN / AROME Local Area Model',
-        attr = dict(
-            model = dict(
-                values  = ['aladin', 'arome'],
-                outcast = set(),
+        info="ALADIN / AROME Local Area Model",
+        attr=dict(
+            model=dict(
+                values=["aladin", "arome"],
+                outcast=set(),
             ),
-        )
+        ),
     )
 
     def command_line(self, **kw):
         """Enforce aladin model option."""
-        kw.setdefault('model', 'aladin')
+        kw.setdefault("model", "aladin")
         return super().command_line(**kw)
 
 
@@ -116,24 +148,26 @@ class NemoModel(OceanographicModel):
     _footprint = [
         gvar,
         dict(
-            info = 'NEMO',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_[model]'
+            info="NEMO",
+            attr=dict(
+                gvar=dict(default="master_[model]"),
+                kind=dict(
+                    values=[
+                        "nemomodel",
+                    ],
                 ),
-                kind = dict(
-                    values   = ['nemomodel', ],
+                model=dict(
+                    values=[
+                        "nemo",
+                    ],
                 ),
-                model = dict(
-                    values   = ['nemo', ],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'nemo'
+        return "nemo"
 
 
 @gmkpack_bin_deco
@@ -144,21 +178,21 @@ class Prep(BlackBox):
         arpifs_cycle,
         gvar,
         dict(
-            info = 'Prep utility to interpolate Surfex files',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_prep'
+            info="Prep utility to interpolate Surfex files",
+            attr=dict(
+                gvar=dict(default="master_prep"),
+                kind=dict(
+                    values=[
+                        "prep",
+                    ],
                 ),
-                kind = dict(
-                    values   = ['prep', ],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'prep'
+        return "prep"
 
 
 @gmkpack_bin_deco
@@ -168,21 +202,21 @@ class PGD(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'PGD utility to create Surfex clim files',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_pgd'
+            info="PGD utility to create Surfex clim files",
+            attr=dict(
+                gvar=dict(default="master_pgd"),
+                kind=dict(
+                    values=[
+                        "buildpgd",
+                    ],
                 ),
-                kind = dict(
-                    values   = ['buildpgd', ],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'buildpgd'
+        return "buildpgd"
 
 
 @gmkpack_bin_deco
@@ -192,24 +226,24 @@ class OfflineSurfex(SurfaceModel):
     _footprint = [
         gvar,
         dict(
-            info = 'Surfex executable',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_offline'
+            info="Surfex executable",
+            attr=dict(
+                gvar=dict(default="master_offline"),
+                kind=dict(
+                    values=["offline", "soda"],
                 ),
-                kind = dict(
-                    values   = ['offline', 'soda'],
+                model=dict(
+                    values=[
+                        "surfex",
+                    ],
                 ),
-                model = dict(
-                    values   = ['surfex', ],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'offline'
+        return "offline"
 
 
 @gmkpack_bin_deco
@@ -219,22 +253,20 @@ class ProGrid(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'ProGrid utility for grib conversion',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_progrid'
+            info="ProGrid utility for grib conversion",
+            attr=dict(
+                gvar=dict(default="master_progrid"),
+                kind=dict(
+                    values=["progrid", "gribtool"],
+                    remap=dict(gribtool="progrid"),
                 ),
-                kind = dict(
-                    values   = ['progrid', 'gribtool'],
-                    remap    = dict(gribtool = 'progrid'),
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'progrid'
+        return "progrid"
 
 
 @gmkpack_bin_deco
@@ -244,22 +276,20 @@ class ProTool(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'ProTool utility for field manipulation',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_addsurf'
+            info="ProTool utility for field manipulation",
+            attr=dict(
+                gvar=dict(default="master_addsurf"),
+                kind=dict(
+                    values=["protool", "addsurf"],
+                    remap=dict(addsurf="protool"),
                 ),
-                kind = dict(
-                    values   = ['protool', 'addsurf'],
-                    remap    = dict(addsurf='protool'),
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'protool'
+        return "protool"
 
 
 @gmkpack_bin_deco
@@ -269,16 +299,14 @@ class SstNetcdf2Ascii(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool to change the format of NetCDF sst files',
-            attr = dict(
-                gvar = dict(
-                    default = "master_sst_netcdf"
+            info="Tool to change the format of NetCDF sst files",
+            attr=dict(
+                gvar=dict(default="master_sst_netcdf"),
+                kind=dict(
+                    values=["sst_netcdf"],
                 ),
-                kind = dict(
-                    values = ['sst_netcdf'],
-                )
-            )
-        )
+            ),
+        ),
     ]
 
 
@@ -289,21 +317,19 @@ class SstGrb2Ascii(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool to change the format of grib sst files',
-            attr = dict(
-                gvar = dict(
-                    default = "master_lectbdap"
+            info="Tool to change the format of grib sst files",
+            attr=dict(
+                gvar=dict(default="master_lectbdap"),
+                kind=dict(
+                    values=["lectbdap"],
                 ),
-                kind = dict(
-                    values = ['lectbdap'],
-                )
-            )
-        )
+            ),
+        ),
     ]
 
     def command_line(self, year, month, day, hour, lon, lat):
         """Build the command line to launch the executable."""
-        return '-y{year} -m{month} -d{day} -r{hour} -o{lon} -a{lat}'.format(
+        return "-y{year} -m{month} -d{day} -r{hour} -o{lon} -a{lat}".format(
             year=year, month=month, day=day, hour=hour, lon=lon, lat=lat
         )
 
@@ -315,16 +341,12 @@ class IceGrb2Ascii(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Ice_grib executable to convert sea ice grib files into ascii files',
-            attr = dict(
-                gvar = dict(
-                    default = 'master_ice_grb'
-                ),
-                kind = dict(
-                    values = ['ice_grb']
-                )
-            )
-        )
+            info="Ice_grib executable to convert sea ice grib files into ascii files",
+            attr=dict(
+                gvar=dict(default="master_ice_grb"),
+                kind=dict(values=["ice_grb"]),
+            ),
+        ),
     ]
 
 
@@ -335,25 +357,21 @@ class IceNCDF2Ascii(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Ice_netcdf executable to convert sea ice NetCDF files into obsoul files',
-            attr = dict(
-                gvar = dict(
-                    default = 'master_ice_netcdf'
-                ),
-                kind = dict(
-                    values = ['ice_netcdf']
-                )
-            )
-        )
+            info="Ice_netcdf executable to convert sea ice NetCDF files into obsoul files",
+            attr=dict(
+                gvar=dict(default="master_ice_netcdf"),
+                kind=dict(values=["ice_netcdf"]),
+            ),
+        ),
     ]
 
     def command_line(self, file_in_hn, file_in_hs, param, file_out):
         """Build the command line to launch the executable."""
-        return '{file_in_hn} {file_in_hs} {param} {file_out}'.format(
+        return "{file_in_hn} {file_in_hs} {param} {file_out}".format(
             file_in_hn=file_in_hn,
             file_in_hs=file_in_hs,
             param=param,
-            file_out=file_out
+            file_out=file_out,
         )
 
 
@@ -363,27 +381,25 @@ class IOAssign(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'ProTool utility for field manipulation',
-            attr = dict(
-                kind = dict(
-                    values   = ['ioassign', 'odbioassign'],
-                    remap    = dict(odbioassign = 'ioassign'),
+            info="ProTool utility for field manipulation",
+            attr=dict(
+                kind=dict(
+                    values=["ioassign", "odbioassign"],
+                    remap=dict(odbioassign="ioassign"),
                 ),
-                gvar = dict(
-                    default  = 'master_ioassign'
+                gvar=dict(default="master_ioassign"),
+                iotool=dict(
+                    optional=True,
+                    default="create_ioassign",
+                    access="rwx",
                 ),
-                iotool = dict(
-                    optional = True,
-                    default  = 'create_ioassign',
-                    access   = 'rwx',
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'ioassign'
+        return "ioassign"
 
 
 @gmkpack_bin_deco
@@ -394,29 +410,27 @@ class Batodb(BlackBox):
         arpifs_cycle,
         gvar,
         dict(
-            info = 'Batodb conversion program',
-            attr = dict(
-                kind = dict(
-                    values   = ['bator', 'batodb'],
-                    remap    = dict(bator = 'batodb'),
+            info="Batodb conversion program",
+            attr=dict(
+                kind=dict(
+                    values=["bator", "batodb"],
+                    remap=dict(bator="batodb"),
                 ),
-                gvar = dict(
-                    default  = 'master_batodb'
-                ),
-            )
-        )
+                gvar=dict(default="master_batodb"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'batodb'
+        return "batodb"
 
     def command_line(self, dataid=None, date=None):
         """Build the command-line."""
         cmdstuff = list()
-        if dataid == 'hh' and date is not None:
-            cmdstuff.append('{0.hh:s}'.format(date))
-        return ' '.join(cmdstuff)
+        if dataid == "hh" and date is not None:
+            cmdstuff.append("{0.hh:s}".format(date))
+        return " ".join(cmdstuff)
 
 
 @gmkpack_bin_deco
@@ -426,31 +440,40 @@ class Odbtools(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Odbtools shuffle program',
-            attr = dict(
-                kind = dict(
-                    values   = ['odbtools'],
+            info="Odbtools shuffle program",
+            attr=dict(
+                kind=dict(
+                    values=["odbtools"],
                 ),
-                gvar = dict(
-                    default  = 'master_odbtools'
-                ),
-            )
-        )
+                gvar=dict(default="master_odbtools"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'odbtools'
+        return "odbtools"
 
-    def command_line(self, dbin='ECMA', dbout='CCMA', npool=1, nslot=1, fcma=None, masksize=None, date=None):
+    def command_line(
+        self,
+        dbin="ECMA",
+        dbout="CCMA",
+        npool=1,
+        nslot=1,
+        fcma=None,
+        masksize=None,
+        date=None,
+    ):
         """Build command line for execution as a single string."""
-        cmdline = '-i{:s} -o{:s} -b1 -a{:d} -T{:d}'.format(dbin.upper(), dbout.upper(), npool, nslot)
+        cmdline = "-i{:s} -o{:s} -b1 -a{:d} -T{:d}".format(
+            dbin.upper(), dbout.upper(), npool, nslot
+        )
         if fcma is not None:
-            cmdline = cmdline + ' -F{:s}'.format(fcma.upper())
+            cmdline = cmdline + " -F{:s}".format(fcma.upper())
         if masksize is not None:
-            cmdline = cmdline + ' -n{:d}'.format(int(masksize))
+            cmdline = cmdline + " -n{:d}".format(int(masksize))
         if date is not None:
-            cmdline = cmdline + ' -B' + date.ymdh
+            cmdline = cmdline + " -B" + date.ymdh
         return cmdline
 
 
@@ -461,16 +484,14 @@ class FcqODB(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Flags calculation program',
-            attr = dict(
-                kind = dict(
-                    values = ['fcqodb'],
+            info="Flags calculation program",
+            attr=dict(
+                kind=dict(
+                    values=["fcqodb"],
                 ),
-                gvar = dict(
-                    default = 'master_fcqodb'
-                )
+                gvar=dict(default="master_fcqodb"),
             ),
-        )
+        ),
     ]
 
 
@@ -481,21 +502,19 @@ class VarBCTool(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'VarBC merger program',
-            attr = dict(
-                kind = dict(
-                    values   = ['varbctool'],
+            info="VarBC merger program",
+            attr=dict(
+                kind=dict(
+                    values=["varbctool"],
                 ),
-                gvar = dict(
-                    default  = 'master_merge_varbc'
-                ),
-            )
-        )
+                gvar=dict(default="master_merge_varbc"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'varbctool'
+        return "varbctool"
 
 
 class LopezMix(BlackBox):
@@ -504,22 +523,20 @@ class LopezMix(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Surface mix',
-            attr = dict(
-                kind = dict(
-                    values   = ['lopezmix', 'lopez', 'mastsurf', 'surfmix'],
-                    remap    = dict(autoremap = 'first'),
+            info="Surface mix",
+            attr=dict(
+                kind=dict(
+                    values=["lopezmix", "lopez", "mastsurf", "surfmix"],
+                    remap=dict(autoremap="first"),
                 ),
-                gvar = dict(
-                    default  = 'master_surfmix'
-                ),
-            )
-        )
+                gvar=dict(default="master_surfmix"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'lopezmix'
+        return "lopezmix"
 
 
 class MasterDiag(BlackBox):
@@ -530,42 +547,38 @@ class MasterDiag(BlackBox):
         arpifs_cycle,
         gvar,
         dict(
-            info = 'MasterDiag abstract class utility for diagnostics computation',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_diag_[diagnostic]'
+            info="MasterDiag abstract class utility for diagnostics computation",
+            attr=dict(
+                gvar=dict(default="master_diag_[diagnostic]"),
+                kind=dict(
+                    values=["masterdiag", "masterdiagpi"],
+                    remap=dict(masterdiagpi="masterdiag"),
                 ),
-                kind = dict(
-                    values   = ['masterdiag', 'masterdiagpi'],
-                    remap    = dict(masterdiagpi='masterdiag'),
+                diagnostic=dict(
+                    info="The type of diagnostic to be performed.",
+                    optional=True,
+                    values=["voisin", "neighbour", "aromepi", "labo"],
+                    remap=dict(neighbour="voisin"),
                 ),
-                diagnostic = dict(
-                    info     = "The type of diagnostic to be performed.",
-                    optional = True,
-                    values   = ['voisin', 'neighbour', 'aromepi', 'labo'],
-                    remap    = dict(neighbour='voisin'),
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'masterdiag'
+        return "masterdiag"
 
 
 class MasterDiagLabo(MasterDiag):
     """binary to compute a diagnostic with some gribs for cycle after the 46th."""
 
     _footprint = dict(
-        attr = dict(
-            diagnostic = dict(
-                default  = 'labo',
+        attr=dict(
+            diagnostic=dict(
+                default="labo",
             )
         ),
-        only = dict(
-            after_cycle = ArpIfsSimplifiedCycle('cy46')
-        )
+        only=dict(after_cycle=ArpIfsSimplifiedCycle("cy46")),
     )
 
 
@@ -573,14 +586,12 @@ class MasterDiagPi(MasterDiag):
     """binary to compute a diagnostic with some gribs for cycle before the 46th."""
 
     _footprint = dict(
-        attr = dict(
-            diagnostic = dict(
-                default  = 'aromepi',
+        attr=dict(
+            diagnostic=dict(
+                default="aromepi",
             )
         ),
-        only=dict(
-            before_cycle = ArpIfsSimplifiedCycle('cy46')
-        )
+        only=dict(before_cycle=ArpIfsSimplifiedCycle("cy46")),
     )
 
 
@@ -588,26 +599,27 @@ class IOPoll(Script):
     """
     The IOPoll script. A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info='IOPoll script',
+            info="IOPoll script",
             attr=dict(
                 kind=dict(
-                    optional = False,
-                    values=['iopoll', 'io_poll'],
-                    remap=dict(autoremap='first'),
+                    optional=False,
+                    values=["iopoll", "io_poll"],
+                    remap=dict(autoremap="first"),
                 ),
                 gvar=dict(
-                    default='tools_io_poll',
+                    default="tools_io_poll",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'iopoll'
+        return "iopoll"
 
 
 class LFITools(BlackBox):
@@ -616,21 +628,21 @@ class LFITools(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool to handle LFI/FA files',
-            attr = dict(
-                kind = dict(
-                    values   = ['lfitools', ],
+            info="Tool to handle LFI/FA files",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "lfitools",
+                    ],
                 ),
-                gvar = dict(
-                    default  = 'master_lfitools'
-                ),
-            )
-        )
+                gvar=dict(default="master_lfitools"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'lfitools'
+        return "lfitools"
 
 
 class SFXTools(BlackBox):
@@ -639,21 +651,21 @@ class SFXTools(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool that handles Surfex files',
-            attr = dict(
-                kind = dict(
-                    values   = ['sfxtools', ],
+            info="Tool that handles Surfex files",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "sfxtools",
+                    ],
                 ),
-                gvar = dict(
-                    default  = 'master_sfxtools'
-                ),
-            )
-        )
+                gvar=dict(default="master_sfxtools"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'sfxtools'
+        return "sfxtools"
 
 
 @gmkpack_bin_deco
@@ -663,21 +675,19 @@ class Combi(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool to build EPS initial conditions',
-            attr = dict(
-                kind = dict(
-                    values   = ['combi'],
+            info="Tool to build EPS initial conditions",
+            attr=dict(
+                kind=dict(
+                    values=["combi"],
                 ),
-                gvar = dict(
-                    default  = 'master_combi'
-                ),
-            )
-        )
+                gvar=dict(default="master_combi"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'combi'
+        return "combi"
 
 
 @gmkpack_bin_deco
@@ -687,21 +697,19 @@ class Gobptout(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Gobptout utility for grib conversion',
-            attr = dict(
-                gvar = dict(
-                    default  = 'master_gobtout'
+            info="Gobptout utility for grib conversion",
+            attr=dict(
+                gvar=dict(default="master_gobtout"),
+                kind=dict(
+                    values=["gobptout"],
                 ),
-                kind = dict(
-                    values   = ['gobptout'],
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'gobptout'
+        return "gobptout"
 
 
 @gmkpack_bin_deco
@@ -711,21 +719,19 @@ class Clust(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool that selects a subset of EPS members using the Clustering method',
-            attr = dict(
-                kind = dict(
-                    values   = ['clust'],
+            info="Tool that selects a subset of EPS members using the Clustering method",
+            attr=dict(
+                kind=dict(
+                    values=["clust"],
                 ),
-                gvar = dict(
-                    default  = 'master_clust'
-                ),
-            )
-        )
+                gvar=dict(default="master_clust"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'clust'
+        return "clust"
 
 
 @gmkpack_bin_deco
@@ -735,21 +741,19 @@ class PertSurf(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool that adds perturbations to surface fields',
-            attr = dict(
-                kind = dict(
-                    values   = ['pertsurf'],
+            info="Tool that adds perturbations to surface fields",
+            attr=dict(
+                kind=dict(
+                    values=["pertsurf"],
                 ),
-                gvar = dict(
-                    default  = 'master_pertsurf'
-                ),
-            )
-        )
+                gvar=dict(default="master_pertsurf"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'pertsurf'
+        return "pertsurf"
 
 
 @gmkpack_bin_deco
@@ -762,21 +766,19 @@ class AddPearp(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Tool that adds perturbations taken from a given PEARP member',
-            attr = dict(
-                kind = dict(
-                    values   = ['addpearp'],
+            info="Tool that adds perturbations taken from a given PEARP member",
+            attr=dict(
+                kind=dict(
+                    values=["addpearp"],
                 ),
-                gvar = dict(
-                    default  = 'master_addpearp'
-                ),
-            )
-        )
+                gvar=dict(default="master_addpearp"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'addpearp'
+        return "addpearp"
 
 
 class BDMExecutableBUFR(Script):
@@ -785,45 +787,47 @@ class BDMExecutableBUFR(Script):
     _footprint = [
         gvar,
         dict(
-            info = 'Executable to extract BDM files using Oulan',
-            attr = dict(
-                source = dict(
-                    values  = ['alim.awk', 'alim_olive.awk'],
+            info="Executable to extract BDM files using Oulan",
+            attr=dict(
+                source=dict(
+                    values=["alim.awk", "alim_olive.awk"],
                 ),
-                kind = dict(
-                    optional = False,
-                    values   = ['bdm_bufr_extract', ],
+                kind=dict(
+                    optional=False,
+                    values=[
+                        "bdm_bufr_extract",
+                    ],
                 ),
                 gvar=dict(
-                    values=['extract_stuff'],
-                    default='extract_stuff',
+                    values=["extract_stuff"],
+                    default="extract_stuff",
                 ),
-                language = dict(
-                    default = 'awk',
-                    values = ['awk'],
-                    optional = True,
-                )
-            )
-        )
+                language=dict(
+                    default="awk",
+                    values=["awk"],
+                    optional=True,
+                ),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'bdm_bufr_extract'
+        return "bdm_bufr_extract"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self.source
+        return "extract=" + self.source
 
     def command_line(self, **opts):
         """Returns optional attribute :attr:`rawopts`."""
         args = []
-        if 'query' in opts:
-            args.append(opts['query'])  # The query name
+        if "query" in opts:
+            args.append(opts["query"])  # The query name
         superraw = super().command_line(**opts)
         if superraw:
             args.append(superraw)  # Other arguments provided by the user
-        return ' '.join(args)
+        return " ".join(args)
 
 
 class BDMExecutableOulan(BlackBox):
@@ -832,22 +836,24 @@ class BDMExecutableOulan(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Executable to extract BDM BUFR files',
-            attr = dict(
-                kind = dict(
-                    values   = ['bdm_oulan_extract', ],
+            info="Executable to extract BDM BUFR files",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "bdm_oulan_extract",
+                    ],
                 ),
                 gvar=dict(
-                    values=['master_oulan'],
-                    default='master_oulan',
+                    values=["master_oulan"],
+                    default="master_oulan",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'bdm_obsoul_extract'
+        return "bdm_obsoul_extract"
 
 
 class ExecMonitoring(BlackBox):
@@ -856,16 +862,14 @@ class ExecMonitoring(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Executable to compute monitoring statistics',
-            attr = dict(
-                gvar = dict(
-                    default = "master_monitoring"
+            info="Executable to compute monitoring statistics",
+            attr=dict(
+                gvar=dict(default="master_monitoring"),
+                kind=dict(
+                    values=["exec_monitoring"],
                 ),
-                kind = dict(
-                    values = ['exec_monitoring'],
-                )
-            )
-        )
+            ),
+        ),
     ]
 
 
@@ -875,21 +879,19 @@ class ExecReverser(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info='Executable to compute initial state for Ctpini',
+            info="Executable to compute initial state for Ctpini",
             attr=dict(
-                gvar=dict(
-                    default="master_involive_km"
-                ),
+                gvar=dict(default="master_involive_km"),
                 kind=dict(
-                    values=['exec_reverser'],
+                    values=["exec_reverser"],
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'exec_reverser'
+        return "exec_reverser"
 
 
 @gmkpack_bin_deco
@@ -899,28 +901,30 @@ class Rgrid(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Executable to make a gaussian reduced grid',
-            attr = dict(
-                kind = dict(
-                    values   = ['rgrid', ],
+            info="Executable to make a gaussian reduced grid",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "rgrid",
+                    ],
                 ),
                 gvar=dict(
-                    values=['master_rgrid'],
-                    default='master_rgrid',
+                    values=["master_rgrid"],
+                    default="master_rgrid",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'rgrid'
+        return "rgrid"
 
     def command_line(self, **opts):
         args = []
         for k, v in opts.items():
-            args.extend(['-' + k, v])
-        return ' '.join(args)
+            args.extend(["-" + k, v])
+        return " ".join(args)
 
 
 @gmkpack_bin_deco
@@ -930,16 +934,18 @@ class Festat(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Executable to compute the B matrix',
-            attr = dict(
-                kind = dict(
-                    values = ["festat", ],
+            info="Executable to compute the B matrix",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "festat",
+                    ],
                 ),
-                gvar = dict(
-                    optional = True,
+                gvar=dict(
+                    optional=True,
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
 
@@ -949,21 +955,25 @@ class EnsembleDiagScript(GnuScript):
     _footprint = [
         gvar,
         dict(
-            info='Script to compute some ensemble diagnostics.',
+            info="Script to compute some ensemble diagnostics.",
             attr=dict(
                 kind=dict(
-                    values = ["ens_diag_script", ],
+                    values=[
+                        "ens_diag_script",
+                    ],
                 ),
                 scope=dict(
-                    values = ["generic", ],
-                    optional = True,
-                    default = "generic",
+                    values=[
+                        "generic",
+                    ],
+                    optional=True,
+                    default="generic",
                 ),
                 gvar=dict(
-                    default = "master_ensdiag_[scope]",
+                    default="master_ensdiag_[scope]",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
 
@@ -973,21 +983,19 @@ class DomeoForcing(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'Some binary that tweak forcing files for domeo use',
-            attr = dict(
-                kind = dict(
-                    values   = ['domeo_forcing'],
+            info="Some binary that tweak forcing files for domeo use",
+            attr=dict(
+                kind=dict(
+                    values=["domeo_forcing"],
                 ),
-                gvar = dict(
-                    default  = 'master_domeo_forcing'
-                ),
-            )
-        )
+                gvar=dict(default="master_domeo_forcing"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'domeo_forcing'
+        return "domeo_forcing"
 
 
 class DomeoScriptDataCor(Script):
@@ -996,24 +1004,22 @@ class DomeoScriptDataCor(Script):
     _footprint = [
         gvar,
         dict(
-            info = 'correction script',
-            attr = dict(
-                kind = dict(
-                    values = ['domeo_cor_script']
+            info="correction script",
+            attr=dict(
+                kind=dict(values=["domeo_cor_script"]),
+                purpose=dict(
+                    values=["forcing", "crop"],
                 ),
-                purpose = dict(
-                    values  = ['forcing', 'crop'],
+                gvar=dict(
+                    default="scr_domeo_cor_[purpose]",
                 ),
-                gvar = dict(
-                    default = 'scr_domeo_cor_[purpose]',
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'domeo_cor_script'
+        return "domeo_cor_script"
 
 
 class Xios(BlackBox):
@@ -1022,18 +1028,18 @@ class Xios(BlackBox):
     _footprint = [
         gvar,
         dict(
-            info = 'The XIOS I/O Server.',
-            attr = dict(
-                kind = dict(
-                    values   = ['xios', ],
+            info="The XIOS I/O Server.",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "xios",
+                    ],
                 ),
-                gvar = dict(
-                    default  = 'master_xios'
-                ),
-            )
-        )
+                gvar=dict(default="master_xios"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'xios'
+        return "xios"

--- a/src/vortex/nwp/data/fields.py
+++ b/src/vortex/nwp/data/fields.py
@@ -11,86 +11,101 @@ from vortex.syntax.stddeco import namebuilding_delete, namebuilding_insert
 __all__ = []
 
 
-@namebuilding_insert('radical', lambda s: s.fields)
-@namebuilding_insert('src', lambda s: [s.origin, ])
-@namebuilding_delete('fmt')
+@namebuilding_insert("radical", lambda s: s.fields)
+@namebuilding_insert(
+    "src",
+    lambda s: [
+        s.origin,
+    ],
+)
+@namebuilding_delete("fmt")
 class RawFields(StaticResource):
-
     _footprint = [
-        date_deco, cutoff_deco,
+        date_deco,
+        cutoff_deco,
         dict(
-            info = 'File containing a limited list of observations fields',
-            attr = dict(
-                kind = dict(
-                    values = ['rawfields']
-                ),
-                origin = dict(
-                    values = [
-                        'bdm', 'nesdis', 'ostia', 'psy4',
-                        'mercator_global', 'bdpe', 'safosi',
-                        'safosi_hn', 'safosi_hs',
+            info="File containing a limited list of observations fields",
+            attr=dict(
+                kind=dict(values=["rawfields"]),
+                origin=dict(
+                    values=[
+                        "bdm",
+                        "nesdis",
+                        "ostia",
+                        "psy4",
+                        "mercator_global",
+                        "bdpe",
+                        "safosi",
+                        "safosi_hn",
+                        "safosi_hs",
                     ]
                 ),
-                fields = dict(
-                    values = ['sst', 'seaice', 'ocean', 'seaice_conc', 'seaice_thick']
+                fields=dict(
+                    values=[
+                        "sst",
+                        "seaice",
+                        "ocean",
+                        "seaice_conc",
+                        "seaice_thick",
+                    ]
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'rawfields'
+        return "rawfields"
 
     def olive_basename(self):
-        if self.origin == 'nesdis' and self.fields == 'sst':
-            bname = '.'.join((self.fields, self.origin, 'bdap'))
-        elif self.fields == 'seaice':
-            bname = 'ice_concent'
+        if self.origin == "nesdis" and self.fields == "sst":
+            bname = ".".join((self.fields, self.origin, "bdap"))
+        elif self.fields == "seaice":
+            bname = "ice_concent"
         else:
-            bname = '.'.join((self.fields, self.origin))
+            bname = ".".join((self.fields, self.origin))
         return bname
 
     def archive_basename(self):
-        if self.origin == 'nesdis' and self.fields == 'sst':
-            bname = '.'.join((self.fields, self.origin, 'bdap'))
-        elif self.fields == 'seaice':
-            bname = 'ice_concent'
+        if self.origin == "nesdis" and self.fields == "sst":
+            bname = ".".join((self.fields, self.origin, "bdap"))
+        elif self.fields == "seaice":
+            bname = "ice_concent"
         else:
-            bname = '.'.join((self.fields, self.origin))
+            bname = ".".join((self.fields, self.origin))
         return bname
 
 
-@namebuilding_insert('radical', lambda s: s.fields)
+@namebuilding_insert("radical", lambda s: s.fields)
 class GeoFields(GeoFlowResource):
-
     _footprint = [
         dict(
-            info = 'File containing a limited list of fields in a specific geometry',
-            attr = dict(
-                kind = dict(
-                    values  = ['geofields']
+            info="File containing a limited list of fields in a specific geometry",
+            attr=dict(
+                kind=dict(values=["geofields"]),
+                fields=dict(
+                    values=[
+                        "sst",
+                        "seaice",
+                        "ocean",
+                        "seaice_conc",
+                        "seaice_thick",
+                    ]
                 ),
-                fields = dict(
-                    values  = ['sst', 'seaice', 'ocean', 'seaice_conc', 'seaice_thick']
-                ),
-                nativefmt = dict(
-                    values  = ['fa'],
-                    default = 'fa'
-                ),
-            )
+                nativefmt=dict(values=["fa"], default="fa"),
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'geofields'
+        return "geofields"
 
     def olive_basename(self):
-        bname = 'icmshanal' + self.fields
-        if self.fields == 'seaice':
+        bname = "icmshanal" + self.fields
+        if self.fields == "seaice":
             bname = bname.upper()
         return bname
 
     def archive_basename(self):
-        return 'icmshanal' + self.fields
+        return "icmshanal" + self.fields

--- a/src/vortex/nwp/data/gridfiles.py
+++ b/src/vortex/nwp/data/gridfiles.py
@@ -21,7 +21,7 @@ _ORIGIN_INFO = """Describes where the data originaly comes from. The most common
 values are: ana (that stands for analysis), fcst (that stands for
 forecast), hst (that stands for Historic file. i.e a file that contains a
 full model state variable), stat_ad (that stands for statistical adapatation)."""
-_ORIGIN_INFO = _ORIGIN_INFO.replace('\n', ' ')
+_ORIGIN_INFO = _ORIGIN_INFO.replace("\n", " ")
 
 
 class AbstractGridpoint(GeoFlowResource):
@@ -35,48 +35,67 @@ class AbstractGridpoint(GeoFlowResource):
 
     _abstract = True
     _footprint = dict(
-        info = 'Any kind of GridPoint file.',
-        attr = dict(
-            origin = dict(
-                info = _ORIGIN_INFO,
-                values = [
-                    'analyse', 'ana', 'guess', 'gss', 'arpege', 'arp', 'arome', 'aro',
-                    'aladin', 'ald', 'historic', 'hst', 'forecast', 'fcst', 'era40', 'e40',
-                    'era15', 'e15', 'interp', 'sumo', 'filter', 'stat_ad',
+        info="Any kind of GridPoint file.",
+        attr=dict(
+            origin=dict(
+                info=_ORIGIN_INFO,
+                values=[
+                    "analyse",
+                    "ana",
+                    "guess",
+                    "gss",
+                    "arpege",
+                    "arp",
+                    "arome",
+                    "aro",
+                    "aladin",
+                    "ald",
+                    "historic",
+                    "hst",
+                    "forecast",
+                    "fcst",
+                    "era40",
+                    "e40",
+                    "era15",
+                    "e15",
+                    "interp",
+                    "sumo",
+                    "filter",
+                    "stat_ad",
                 ],
-                remap = dict(
-                    analyse = 'ana',
-                    guess = 'gss',
-                    arpege = 'arp',
-                    aladin = 'ald',
-                    arome = 'aro',
-                    historic = 'hst',
-                    forecast = 'fcst',
-                    era40 = 'e40',
-                    era15 = 'e15'
-                )
+                remap=dict(
+                    analyse="ana",
+                    guess="gss",
+                    arpege="arp",
+                    aladin="ald",
+                    arome="aro",
+                    historic="hst",
+                    forecast="fcst",
+                    era40="e40",
+                    era15="e15",
+                ),
             ),
-            kind = dict(
-                values = ['gridpoint', 'gribfile', 'fullpos'],
-                remap = dict(
-                    fullpos = 'gridpoint'
-                )
+            kind=dict(
+                values=["gridpoint", "gribfile", "fullpos"],
+                remap=dict(fullpos="gridpoint"),
             ),
-            nativefmt   = dict(
-                values  = ['grib', 'grib1', 'grib2', 'netcdf', 'fa'],
+            nativefmt=dict(
+                values=["grib", "grib1", "grib2", "netcdf", "fa"],
             ),
-            filtername = dict(
+            filtername=dict(
                 # Dummy argument but avoid priority related messages with footprints
-                info = 'With GridPoint files, leave filtername empty...',
-                optional = True,
-                values = [None, ],
+                info="With GridPoint files, leave filtername empty...",
+                optional=True,
+                values=[
+                    None,
+                ],
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'gridpoint'
+        return "gridpoint"
 
     def olive_basename(self):
         """OLIVE specific naming convention (abstract)."""
@@ -89,35 +108,32 @@ class AbstractGridpoint(GeoFlowResource):
     def namebuilding_info(self):
         """Generic information, radical = ``grid``."""
         ninfo = super().namebuilding_info()
-        if self.origin in ('stat_ad', ):
+        if self.origin in ("stat_ad",):
             # For new ``origin`` please use this code path... Please, no more
             # weird logic like the one hard-coded in the else statement !
             source = self.origin
         else:
-            if self.model == 'mocage':
-                if self.origin == 'hst':
-                    source = 'forecast'
+            if self.model == "mocage":
+                if self.origin == "hst":
+                    source = "forecast"
                 else:
-                    source = 'sumo'
-            elif self.model in ('hycom', 'mfwam'):
-                if self.origin == 'ana':
-                    source = 'analysis'
+                    source = "sumo"
+            elif self.model in ("hycom", "mfwam"):
+                if self.origin == "ana":
+                    source = "analysis"
                 else:
-                    source = 'forecast'
+                    source = "forecast"
             else:
-                source = 'forecast'
+                source = "forecast"
         ninfo.update(
-            radical='grid',
+            radical="grid",
             src=[self.model, source],
         )
         return ninfo
 
     def iga_pathinfo(self):
         """Standard path information for IGA inline cache."""
-        directory = dict(
-            fa='fic_day',
-            grib='bdap'
-        )
+        directory = dict(fa="fic_day", grib="bdap")
         return dict(
             fmt=directory[self.nativefmt],
             nativefmt=self.nativefmt,
@@ -132,7 +148,9 @@ class GridPoint(AbstractGridpoint):
     """
 
     _abstract = True
-    _footprint = [term_deco, ]
+    _footprint = [
+        term_deco,
+    ]
 
 
 class TimePeriodGridPoint(AbstractGridpoint):
@@ -145,33 +163,48 @@ class TimePeriodGridPoint(AbstractGridpoint):
     _footprint = [
         timeperiod_deco,
         dict(
-            attr = dict(
-                begintime = dict(
-                    optional = True,
-                    default = Time(0),
+            attr=dict(
+                begintime=dict(
+                    optional=True,
+                    default=Time(0),
                 )
             )
-        )
+        ),
     ]
 
 
 # A bunch of generic footprint declaration to ease with class creation
 _NATIVEFMT_FULLPOS_FP = footprints.Footprint(
-    info='Abstract nativefmt for fullpos files.',
-    attr=dict(nativefmt=dict(values=['fa'],
-                             default='fa', ))
+    info="Abstract nativefmt for fullpos files.",
+    attr=dict(
+        nativefmt=dict(
+            values=["fa"],
+            default="fa",
+        )
+    ),
 )
 _NATIVEFMT_GENERIC_FP = footprints.Footprint(
-    info='Abstract nativefmt for any other gridpoint files.',
-    attr=dict(nativefmt=dict(values=['grib', 'grib1', 'grib2', 'netcdf'],
-                             default='grib'))
+    info="Abstract nativefmt for any other gridpoint files.",
+    attr=dict(
+        nativefmt=dict(
+            values=["grib", "grib1", "grib2", "netcdf"], default="grib"
+        )
+    ),
 )
 _FILTERNAME_AWARE_FPDECO = footprints.DecorativeFootprint(
     footprints.Footprint(
-        info='Abstract filtering attribute (used when the filtername attribute is allowed).',
-        attr=dict(filtername=dict(info="The filter used to obtain this data.",
-                                  optional=False, values=[],))),
-    decorator=[namebuilding_insert('filtername', lambda s: s.filtername), ]
+        info="Abstract filtering attribute (used when the filtername attribute is allowed).",
+        attr=dict(
+            filtername=dict(
+                info="The filter used to obtain this data.",
+                optional=False,
+                values=[],
+            )
+        ),
+    ),
+    decorator=[
+        namebuilding_insert("filtername", lambda s: s.filtername),
+    ],
 )
 
 
@@ -179,25 +212,27 @@ class GridPointMap(FlowResource):
     """Map of the gridpoint files as produced by fullpos."""
 
     _footprint = dict(
-        info = 'Gridpoint Files Map',
-        attr = dict(
-            kind = dict(
-                values   = ['gridpointmap', 'gribfilemap', 'fullposmap'],
-                remap = dict(fullposmap = 'gridpointmap', )
+        info="Gridpoint Files Map",
+        attr=dict(
+            kind=dict(
+                values=["gridpointmap", "gribfilemap", "fullposmap"],
+                remap=dict(
+                    fullposmap="gridpointmap",
+                ),
             ),
-            clscontents = dict(
-                default = JsonDictContent,
+            clscontents=dict(
+                default=JsonDictContent,
             ),
-            nativefmt   = dict(
-                values  = ['json'],
-                default = 'json',
+            nativefmt=dict(
+                values=["json"],
+                default="json",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'gridpointmap'
+        return "gridpointmap"
 
 
 class GridPointFullPos(GridPoint):
@@ -205,7 +240,7 @@ class GridPointFullPos(GridPoint):
 
     _footprint = [
         _NATIVEFMT_FULLPOS_FP,
-        dict(info='GridPoint file produced by Fullpos (with a single term)'),
+        dict(info="GridPoint file produced by Fullpos (with a single term)"),
     ]
 
     def olive_basename(self):
@@ -213,46 +248,60 @@ class GridPointFullPos(GridPoint):
 
         t = self.term.hour
         e = env.current()
-        if 'VORTEX_ANA_TERMSHIFT' not in e and self.origin == 'ana':
+        if "VORTEX_ANA_TERMSHIFT" not in e and self.origin == "ana":
             t = 0
 
         name = None
-        if self.model == 'mocage':
-            if self.origin == 'hst':
-                name = 'HM' + self.geometry.area + '+' + self.term.fmthour
-            elif self.origin == 'sumo':
-                deltastr = 'PT{!s}H'.format(self.term.hour)
+        if self.model == "mocage":
+            if self.origin == "hst":
+                name = "HM" + self.geometry.area + "+" + self.term.fmthour
+            elif self.origin == "sumo":
+                deltastr = "PT{!s}H".format(self.term.hour)
                 deltadate = self.date + deltastr
-                name = 'SM' + self.geometry.area + '_void' + '+' + deltadate.ymd
-            elif self.origin == 'interp':
-                deltastr = 'PT{!s}H'.format(self.term.hour)
+                name = (
+                    "SM" + self.geometry.area + "_void" + "+" + deltadate.ymd
+                )
+            elif self.origin == "interp":
+                deltastr = "PT{!s}H".format(self.term.hour)
                 deltadate = self.date + deltastr
-                name = 'SM' + self.geometry.area + '_interp' + '+' + deltadate.ymd
+                name = (
+                    "SM" + self.geometry.area + "_interp" + "+" + deltadate.ymd
+                )
         else:
-            name = 'PFFPOS' + self.origin.upper() + self.geometry.area + '+' + self.term.nice(t)
+            name = (
+                "PFFPOS"
+                + self.origin.upper()
+                + self.geometry.area
+                + "+"
+                + self.term.nice(t)
+            )
 
         if name is None:
-            raise ValueError('Could not build a proper olive name: {!s}'.format(self))
+            raise ValueError(
+                "Could not build a proper olive name: {!s}".format(self)
+            )
 
         return name
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
 
-        deltastr = 'PT{!s}H'.format(self.term.hour)
+        deltastr = "PT{!s}H".format(self.term.hour)
         deltadate = self.date + deltastr
 
         name = None
-        if self.origin == 'hst':
-            if self.model == 'ifs':
-                name = 'PFFPOS' + self.geometry.area + '+' + self.term.fmthour
+        if self.origin == "hst":
+            if self.model == "ifs":
+                name = "PFFPOS" + self.geometry.area + "+" + self.term.fmthour
             else:
-                name = 'HM' + self.geometry.area + '+' + deltadate.ymdh
-        elif self.origin == 'interp':
-            name = 'SM' + self.geometry.area + '+' + deltadate.ymd
+                name = "HM" + self.geometry.area + "+" + deltadate.ymdh
+        elif self.origin == "interp":
+            name = "SM" + self.geometry.area + "+" + deltadate.ymd
 
         if name is None:
-            raise ValueError('Could not build a proper archive name: {!s}'.format(self))
+            raise ValueError(
+                "Could not build a proper archive name: {!s}".format(self)
+            )
 
         return name
 
@@ -262,7 +311,7 @@ class GridPointExport(GridPoint):
 
     _footprint = [
         _NATIVEFMT_GENERIC_FP,
-        dict(info='Generic gridpoint file (with a single term)'),
+        dict(info="Generic gridpoint file (with a single term)"),
     ]
 
     def olive_basename(self):
@@ -270,39 +319,62 @@ class GridPointExport(GridPoint):
 
         t = self.term.hour
         e = env.current()
-        if 'VORTEX_ANA_TERMSHIFT' not in e and self.origin == 'ana':
+        if "VORTEX_ANA_TERMSHIFT" not in e and self.origin == "ana":
             t = 0
-        return 'GRID' + self.origin.upper() + self.geometry.area + '+' + self.term.nice(t)
+        return (
+            "GRID"
+            + self.origin.upper()
+            + self.geometry.area
+            + "+"
+            + self.term.nice(t)
+        )
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
 
         name = None
-        if re.match('aladin|arome', self.model):
-            name = 'GRID' + self.geometry.area + 'r{!s}'.format(self.date.hour) + '_' + self.term.fmthour
-        elif re.match('arp|hycom|surcotes', self.model):
-            name = '(gribfix:igakey)'
-        elif self.model == 'ifs':
-            deltastr = 'PT{!s}H'.format(self.term.hour)
+        if re.match("aladin|arome", self.model):
+            name = (
+                "GRID"
+                + self.geometry.area
+                + "r{!s}".format(self.date.hour)
+                + "_"
+                + self.term.fmthour
+            )
+        elif re.match("arp|hycom|surcotes", self.model):
+            name = "(gribfix:igakey)"
+        elif self.model == "ifs":
+            deltastr = "PT{!s}H".format(self.term.hour)
             deltadate = self.date + deltastr
-            name = 'MET' + deltadate.ymd + '.' + self.geometry.area + '.grb'
+            name = "MET" + deltadate.ymd + "." + self.geometry.area + ".grb"
 
         if name is None:
-            raise ValueError('Could not build a proper archive name: {!s}'.format(self))
+            raise ValueError(
+                "Could not build a proper archive name: {!s}".format(self)
+            )
 
         return name
 
 
 class FilteredGridPointExport(GridPointExport):
     """Generic single term gridpoint file using a standard format."""
-    _footprint = [_FILTERNAME_AWARE_FPDECO, ]
+
+    _footprint = [
+        _FILTERNAME_AWARE_FPDECO,
+    ]
 
 
 class TimePeriodGridPointExport(TimePeriodGridPoint):
     """Generic multi term gridpoint file using a standard format."""
-    _footprint = [_NATIVEFMT_GENERIC_FP, ]
+
+    _footprint = [
+        _NATIVEFMT_GENERIC_FP,
+    ]
 
 
 class FilteredTimePeriodGridPointExport(TimePeriodGridPointExport):
     """Generic multi term gridpoint file using a standard format."""
-    _footprint = [_FILTERNAME_AWARE_FPDECO, ]
+
+    _footprint = [
+        _FILTERNAME_AWARE_FPDECO,
+    ]

--- a/src/vortex/nwp/data/logs.py
+++ b/src/vortex/nwp/data/logs.py
@@ -24,77 +24,84 @@ class FlowLogsStack(Resource):
         date_deco,
         cutoff_deco,
         dict(
-            info = 'Stack of miscellaneous log files.',
-            attr = dict(
-                kind = dict(
-                    values   = ['flow_logs']
-                ),
-                nativefmt = dict(
-                    values   = ['filespack', ],
-                    default  = 'filespack',
+            info="Stack of miscellaneous log files.",
+            attr=dict(
+                kind=dict(values=["flow_logs"]),
+                nativefmt=dict(
+                    values=[
+                        "filespack",
+                    ],
+                    default="filespack",
                 ),
             ),
-        )
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'flow_logs'
+        return "flow_logs"
 
 
 def use_flow_logs_stack(cls):
     """Setup the decorated class to work with the FlowLogsStack resource."""
     fpattrs = set(cls.footprint_retrieve().attr.keys())
-    fpcheck = all([k in fpattrs for k in ('date', 'cutoff')])
+    fpcheck = all([k in fpattrs for k in ("date", "cutoff")])
     if not fpcheck:
-        raise ImportError('The "{!s}" class is not compatible with the FlowLogsStack class.'
-                          .format(cls))
+        raise ImportError(
+            'The "{!s}" class is not compatible with the FlowLogsStack class.'.format(
+                cls
+            )
+        )
 
     def stackedstorage_resource(self):
         """Use the FlowLogsStack resource for stacked storage."""
-        return FlowLogsStack(kind='flow_logs', date=self.date, cutoff=self.cutoff), False
+        return FlowLogsStack(
+            kind="flow_logs", date=self.date, cutoff=self.cutoff
+        ), False
 
     cls.stackedstorage_resource = stackedstorage_resource
     return cls
 
 
 @use_flow_logs_stack
-@namebuilding_insert('src', lambda s: [s.binary, '-'.join(s.task.split('/')[s.task_start:s.task_stop])])
-@namebuilding_insert('compute', lambda s: s.part)
-@namebuilding_delete('fmt')
+@namebuilding_insert(
+    "src",
+    lambda s: [
+        s.binary,
+        "-".join(s.task.split("/")[s.task_start : s.task_stop]),
+    ],
+)
+@namebuilding_insert("compute", lambda s: s.part)
+@namebuilding_delete("fmt")
 class Listing(FlowResource):
     """Miscellaneous application output from a task processing."""
+
     _footprint = [
         dict(
-            info = 'Listing',
-            attr = dict(
-                task = dict(
-                    optional = True,
-                    default  = 'anonymous'
+            info="Listing",
+            attr=dict(
+                task=dict(optional=True, default="anonymous"),
+                task_start=dict(
+                    optional=True,
+                    type=int,
+                    default=-1,
                 ),
-                task_start = dict(
-                    optional = True,
-                    type     = int,
-                    default  = -1,
+                task_stop=dict(
+                    optional=True,
+                    type=int,
+                    default=None,
                 ),
-                task_stop = dict(
-                    optional = True,
-                    type     = int,
-                    default  = None,
+                kind=dict(values=["listing"]),
+                part=dict(
+                    optional=True,
+                    default="all",
                 ),
-                kind = dict(
-                    values   = ['listing']
+                binary=dict(
+                    optional=True,
+                    default="[model]",
                 ),
-                part = dict(
-                    optional = True,
-                    default  = 'all',
-                ),
-                binary = dict(
-                    optional = True,
-                    default  = '[model]',
-                ),
-                clscontents = dict(
-                    default = FormatAdapter,
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             ),
         )
@@ -102,11 +109,11 @@ class Listing(FlowResource):
 
     @property
     def realkind(self):
-        return 'listing'
+        return "listing"
 
     def olive_basename(self):
         """Fake basename for getting olive listings"""
-        if hasattr(self, '_listingpath'):
+        if hasattr(self, "_listingpath"):
             return self._listingpath
         else:
             return "NOT_IMPLEMENTED"
@@ -117,39 +124,40 @@ class Listing(FlowResource):
 
 class ParallelListing(Listing):
     """Multi output for parallel MPI and/or OpenMP processing."""
+
     _footprint = [
         dict(
-            attr = dict(
-                kind = dict(
-                    values = ['listing', 'plisting', 'mlisting'],
-                    remap  = dict(
-                        listing  = 'plisting',
-                        mlisting = 'plisting',
-                    )
+            attr=dict(
+                kind=dict(
+                    values=["listing", "plisting", "mlisting"],
+                    remap=dict(
+                        listing="plisting",
+                        mlisting="plisting",
+                    ),
                 ),
-                mpi = dict(
-                    optional = True,
-                    default  = None,
-                    type     = FmtInt,
-                    args     = dict(fmt = '03'),
+                mpi=dict(
+                    optional=True,
+                    default=None,
+                    type=FmtInt,
+                    args=dict(fmt="03"),
                 ),
-                openmp = dict(
-                    optional = True,
-                    default  = None,
-                    type     = FmtInt,
-                    args     = dict(fmt = '02'),
+                openmp=dict(
+                    optional=True,
+                    default=None,
+                    type=FmtInt,
+                    args=dict(fmt="02"),
                 ),
-                seta = dict(
-                    optional = True,
-                    default  = None,
-                    type     = FmtInt,
-                    args     = dict(fmt = '03'),
+                seta=dict(
+                    optional=True,
+                    default=None,
+                    type=FmtInt,
+                    args=dict(fmt="03"),
                 ),
-                setb = dict(
-                    optional = True,
-                    default  = None,
-                    type     = FmtInt,
-                    args     = dict(fmt = '02'),
+                setb=dict(
+                    optional=True,
+                    default=None,
+                    type=FmtInt,
+                    args=dict(fmt="02"),
                 ),
             )
         )
@@ -159,38 +167,34 @@ class ParallelListing(Listing):
         """From base information of ``listing`` add mpi and openmp values."""
         info = super().namebuilding_info()
         if self.mpi and self.openmp:
-            info['compute'] = [{'mpi': self.mpi}, {'openmp': self.openmp}]
+            info["compute"] = [{"mpi": self.mpi}, {"openmp": self.openmp}]
         if self.seta and self.setb:
-            info['compute'] = [{'seta': self.seta}, {'setb': self.setb}]
+            info["compute"] = [{"seta": self.seta}, {"setb": self.setb}]
         return info
 
 
-@namebuilding_insert('src', lambda s: [s.binary, s.task.split('/').pop()])
-@namebuilding_insert('compute', lambda s: s.part)
-@namebuilding_delete('fmt')
+@namebuilding_insert("src", lambda s: [s.binary, s.task.split("/").pop()])
+@namebuilding_insert("compute", lambda s: s.part)
+@namebuilding_delete("fmt")
 class StaticListing(Resource):
     """Miscelanous application output from a task processing, out-of-flow."""
+
     _footprint = [
         dict(
-            info = 'Listing',
-            attr = dict(
-                task = dict(
-                    optional = True,
-                    default  = 'anonymous'
+            info="Listing",
+            attr=dict(
+                task=dict(optional=True, default="anonymous"),
+                kind=dict(values=["staticlisting"]),
+                part=dict(
+                    optional=True,
+                    default="all",
                 ),
-                kind = dict(
-                    values   = ['staticlisting']
+                binary=dict(
+                    optional=True,
+                    default="[model]",
                 ),
-                part = dict(
-                    optional = True,
-                    default  = 'all',
-                ),
-                binary = dict(
-                    optional = True,
-                    default  = '[model]',
-                ),
-                clscontents = dict(
-                    default = FormatAdapter,
+                clscontents=dict(
+                    default=FormatAdapter,
                 ),
             ),
         )
@@ -198,23 +202,33 @@ class StaticListing(Resource):
 
     @property
     def realkind(self):
-        return 'staticlisting'
+        return "staticlisting"
 
 
-@namebuilding_insert('compute', lambda s: None if s.mpi is None else [{'mpi': s.mpi}, ],
-                     none_discard=True)
+@namebuilding_insert(
+    "compute",
+    lambda s: None
+    if s.mpi is None
+    else [
+        {"mpi": s.mpi},
+    ],
+    none_discard=True,
+)
 class DrHookListing(Listing):
     """Output produced by DrHook"""
+
     _footprint = [
         dict(
-            attr = dict(
-                kind = dict(
-                    values = ['drhook', ],
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "drhook",
+                    ],
                 ),
-                mpi = dict(
-                    optional = True,
-                    type     = FmtInt,
-                    args     = dict(fmt = '03'),
+                mpi=dict(
+                    optional=True,
+                    type=FmtInt,
+                    args=dict(fmt="03"),
                 ),
             )
         )
@@ -222,116 +236,107 @@ class DrHookListing(Listing):
 
     @property
     def realkind(self):
-        return 'drhookprof'
+        return "drhookprof"
 
 
 @use_flow_logs_stack
 class Beacon(FlowResource):
     """Output indicating the end of a model run."""
+
     _footprint = [
         dict(
-            info = 'Beacon',
-            attr = dict(
-                kind = dict(
-                    values   = ['beacon']
+            info="Beacon",
+            attr=dict(
+                kind=dict(values=["beacon"]),
+                clscontents=dict(
+                    default=JsonDictContent,
                 ),
-                clscontents = dict(
-                    default = JsonDictContent,
+                nativefmt=dict(
+                    default="json",
                 ),
-                nativefmt = dict(
-                    default = 'json',
-                ),
-            )
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'beacon'
+        return "beacon"
 
 
 @use_flow_logs_stack
-@namebuilding_insert('src', lambda s: s.task.split('/').pop())
-@namebuilding_insert('compute', lambda s: s.scope)
+@namebuilding_insert("src", lambda s: s.task.split("/").pop())
+@namebuilding_insert("compute", lambda s: s.scope)
 class TaskInfo(FlowResource):
     """Task informations."""
+
     _footprint = [
         dict(
-            info = 'Task informations',
-            attr = dict(
-                task = dict(
-                    optional = True,
-                    default  = 'anonymous'
+            info="Task informations",
+            attr=dict(
+                task=dict(optional=True, default="anonymous"),
+                kind=dict(values=["taskinfo"]),
+                scope=dict(
+                    optional=True,
+                    default="void",
                 ),
-                kind = dict(
-                    values   = ['taskinfo']
+                clscontents=dict(
+                    default=JsonDictContent,
                 ),
-                scope = dict(
-                    optional = True,
-                    default  = 'void',
+                nativefmt=dict(
+                    default="json",
                 ),
-                clscontents = dict(
-                    default = JsonDictContent,
-                ),
-                nativefmt = dict(
-                    default = 'json',
-                ),
-            )
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'taskinfo'
+        return "taskinfo"
 
 
-@namebuilding_insert('src', lambda s: s.task.split('/').pop())
-@namebuilding_insert('compute', lambda s: s.scope)
-@namebuilding_delete('fmt')
+@namebuilding_insert("src", lambda s: s.task.split("/").pop())
+@namebuilding_insert("compute", lambda s: s.scope)
+@namebuilding_delete("fmt")
 class StaticTaskInfo(Resource):
     """Task informations."""
+
     _footprint = [
         dict(
-            info = 'Task informations',
-            attr = dict(
-                task = dict(
-                    optional = True,
-                    default  = 'anonymous'
+            info="Task informations",
+            attr=dict(
+                task=dict(optional=True, default="anonymous"),
+                kind=dict(values=["statictaskinfo"]),
+                scope=dict(
+                    optional=True,
+                    default="void",
                 ),
-                kind = dict(
-                    values   = ['statictaskinfo']
+                clscontents=dict(
+                    default=JsonDictContent,
                 ),
-                scope = dict(
-                    optional = True,
-                    default  = 'void',
+                nativefmt=dict(
+                    default="json",
                 ),
-                clscontents = dict(
-                    default = JsonDictContent,
-                ),
-                nativefmt = dict(
-                    default = 'json',
-                ),
-            )
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'statictaskinfo'
+        return "statictaskinfo"
 
 
 class SectionsSlice(collections.abc.Sequence):
     """Hold a list of dictionaries representing Sections."""
 
-    _INDEX_PREFIX = 'sslice'
-    _INDEX_ATTR = 'sliceindex'
+    _INDEX_PREFIX = "sslice"
+    _INDEX_ATTR = "sliceindex"
 
     def __init__(self, sequence):
         self._data = sequence
 
     def __getitem__(self, i):
         if isinstance(i, str) and i.startswith(self._INDEX_PREFIX):
-            i = int(i[len(self._INDEX_PREFIX):])
+            i = int(i[len(self._INDEX_PREFIX) :])
         return self._data[i]
 
     def __eq__(self, other):
@@ -361,23 +366,26 @@ class SectionsSlice(collections.abc.Sequence):
         'resource', 'provider' and 'container' parts of the 'rh'sub-dictionary
         are also looked for.
         """
-        if k == 'role':
-            return item[k] or item['alternate']
-        elif k == 'kind' and k in item.get('rh', dict()).get('resource', dict()):
-            return item['rh']['resource'][k]
-        elif k == 'section_kind' and 'kind' in item:
-            return item['kind']
+        if k == "role":
+            return item[k] or item["alternate"]
+        elif k == "kind" and k in item.get("rh", dict()).get(
+            "resource", dict()
+        ):
+            return item["rh"]["resource"][k]
+        elif k == "section_kind" and "kind" in item:
+            return item["kind"]
         elif k in item:
             return item[k]
-        elif k in item.get('rh', dict()).get('resource', dict()):
-            return item['rh']['resource'][k]
-        elif k in item.get('rh', dict()).get('provider', dict()):
-            return item['rh']['provider'][k]
-        elif k in item.get('rh', dict()).get('container', dict()):
-            return item['rh']['container'][k]
+        elif k in item.get("rh", dict()).get("resource", dict()):
+            return item["rh"]["resource"][k]
+        elif k in item.get("rh", dict()).get("provider", dict()):
+            return item["rh"]["provider"][k]
+        elif k in item.get("rh", dict()).get("container", dict()):
+            return item["rh"]["container"][k]
         else:
-            raise KeyError("'{:s}' wasn't found in the designated dictionary"
-                           .format(k))
+            raise KeyError(
+                "'{:s}' wasn't found in the designated dictionary".format(k)
+            )
 
     @staticmethod
     def _sloppy_compare(json_v, v):
@@ -398,20 +406,22 @@ class SectionsSlice(collections.abc.Sequence):
 
     def _sloppy_ckeck(self, item, k, v, extras):
         """Perform a _sloppy_lookup and check the result against *v*."""
-        if k in ('role', 'alternate'):
+        if k in ("role", "alternate"):
             v = setrole(v)
         try:
-            if k == 'baseterm':
-                found = self._sloppy_lookup(item, 'term')
-                foundbis = self._sloppy_lookup(item, 'date')
+            if k == "baseterm":
+                found = self._sloppy_lookup(item, "term")
+                foundbis = self._sloppy_lookup(item, "date")
             else:
                 found = self._sloppy_lookup(item, k)
         except KeyError:
             return False
         if not isinstance(v, (list, tuple, set)):
-            v = [v, ]
-        if k == 'baseterm' and extras.get('basedate', None):
-            delta = (Date(extras['basedate']) - Date(foundbis))
+            v = [
+                v,
+            ]
+        if k == "baseterm" and extras.get("basedate", None):
+            delta = Date(extras["basedate"]) - Date(foundbis)
             found = Time(found) - delta
         return any([self._sloppy_compare(found, a_v) for a_v in v])
 
@@ -423,10 +433,17 @@ class SectionsSlice(collections.abc.Sequence):
             >>> self.filter(role='Guess', member=1)
         """
         extras = dict()
-        extras['basedate'] = kwargs.pop('basedate', None)
-        newslice = [s for s in self
-                    if all([self._sloppy_ckeck(s, k, v, extras)
-                            for k, v in kwargs.items()])]
+        extras["basedate"] = kwargs.pop("basedate", None)
+        newslice = [
+            s
+            for s in self
+            if all(
+                [
+                    self._sloppy_ckeck(s, k, v, extras)
+                    for k, v in kwargs.items()
+                ]
+            )
+        ]
         return self.__class__(newslice)
 
     def uniquefilter(self, **kwargs):
@@ -442,7 +459,9 @@ class SectionsSlice(collections.abc.Sequence):
     @property
     def indexes(self):
         """Returns an index list of all the element contained if the present object."""
-        return [self._INDEX_PREFIX + '{:d}'.format(i) for i in range(len(self))]
+        return [
+            self._INDEX_PREFIX + "{:d}".format(i) for i in range(len(self))
+        ]
 
     def __deepcopy__(self, memo):
         newslice = self.__class__(self._data)
@@ -465,27 +484,40 @@ class SectionsSlice(collections.abc.Sequence):
         be generated using the :meth:`indexes` property), the corresponding element
         will be searched using :meth:`_sloppy_lookup`.
         """.format(idx_attr=self._INDEX_ATTR)
-        if attr.startswith('__'):
+        if attr.startswith("__"):
             raise AttributeError(attr)
         if len(self) == 1:
             try:
                 return self._sloppy_lookup(self[0], attr)
             except KeyError:
-                raise AttributeError("'{:s}' wasn't found in the unique dictionary"
-                                     .format(attr))
+                raise AttributeError(
+                    "'{:s}' wasn't found in the unique dictionary".format(attr)
+                )
         elif len(self) == 0:
-            raise AttributeError("The current SectionsSlice is empty. No attribute lookup allowed !")
+            raise AttributeError(
+                "The current SectionsSlice is empty. No attribute lookup allowed !"
+            )
         else:
+
             def _attr_lookup(g, x):
-                if len(self) > 1 and (self._INDEX_ATTR in g or self._INDEX_ATTR in x):
+                if len(self) > 1 and (
+                    self._INDEX_ATTR in g or self._INDEX_ATTR in x
+                ):
                     idx = g.get(self._INDEX_ATTR, x.get(self._INDEX_ATTR))
                     try:
                         return self._sloppy_lookup(self[idx], attr)
                     except KeyError:
-                        raise AttributeError("'{:s}' wasn't found in the {!s}-th dictionary"
-                                             .format(attr, idx))
+                        raise AttributeError(
+                            "'{:s}' wasn't found in the {!s}-th dictionary".format(
+                                attr, idx
+                            )
+                        )
                 else:
-                    raise AttributeError("A '{:s}' attribute must be there !".format(self._INDEX_ATTR))
+                    raise AttributeError(
+                        "A '{:s}' attribute must be there !".format(
+                            self._INDEX_ATTR
+                        )
+                    )
 
             return _attr_lookup
 
@@ -518,7 +550,7 @@ class SectionsJsonListContent(DataContent):
 
 
 @use_flow_logs_stack
-@namebuilding_insert('src', lambda s: s.task.split('/').pop())
+@namebuilding_insert("src", lambda s: s.task.split("/").pop())
 class SectionsList(FlowResource):
     """Class to handle a resource that contains a list of Sections in JSON format.
 
@@ -527,23 +559,24 @@ class SectionsList(FlowResource):
     """
 
     _footprint = dict(
-        info = 'A Sections List',
-        attr = dict(
+        info="A Sections List",
+        attr=dict(
             kind=dict(
-                values=['sectionslist', ],
+                values=[
+                    "sectionslist",
+                ],
             ),
-            task = dict(
-                optional = True,
-                default  = 'anonymous'
+            task=dict(optional=True, default="anonymous"),
+            clscontents=dict(
+                default=SectionsJsonListContent,
             ),
-            clscontents = dict(
-                default = SectionsJsonListContent,
+            nativefmt=dict(
+                values=[
+                    "json",
+                ],
+                default="json",
             ),
-            nativefmt   = dict(
-                values  = ['json', ],
-                default = 'json',
-            )
-        )
+        ),
     )
 
     @property

--- a/src/vortex/nwp/data/modelstates.py
+++ b/src/vortex/nwp/data/modelstates.py
@@ -20,45 +20,51 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-@namebuilding_insert('src', lambda s: [s.filling, s.model])
+@namebuilding_insert("src", lambda s: [s.filling, s.model])
 class AbstractAnalysis(GeoFlowResource):
     """Analysis resource.
 
     It can be an atmospheric, surface or full analysis (full = atmospheric + surface).
     """
+
     _abstract = True
     _footprint = dict(
-        info = 'Analysis',
-        attr = dict(
-            kind = dict(
-                values   = ['analysis', 'analyse', 'atm_analysis']
+        info="Analysis",
+        attr=dict(
+            kind=dict(values=["analysis", "analyse", "atm_analysis"]),
+            nativefmt=dict(
+                values=["fa", "grib", "lfi", "netcdf", "txt", "unknown"],
+                default="fa",
             ),
-            nativefmt = dict(
-                values   = ['fa', 'grib', 'lfi', 'netcdf', 'txt', 'unknown'],
-                default  = 'fa',
+            filtering=dict(
+                info="The filtering that was applied during the generating process.",
+                optional=True,
+                values=["dfi"],
+                doc_zorder=-5,
             ),
-            filtering = dict(
-                info         = "The filtering that was applied during the generating process.",
-                optional    = True,
-                values      = ['dfi'],
-                doc_zorder  = -5,
-            ),
-            filling = dict(
-                info     = "The content/coverage of the analysis.",
-                optional = True,
-                default  = 'full',
-                values   = ['surface', 'surf', 'atmospheric', 'atm', 'full', 'soil'],
-                remap    = dict(
-                    surface     = 'surf',
-                    atmospheric = 'atm',
+            filling=dict(
+                info="The content/coverage of the analysis.",
+                optional=True,
+                default="full",
+                values=[
+                    "surface",
+                    "surf",
+                    "atmospheric",
+                    "atm",
+                    "full",
+                    "soil",
+                ],
+                remap=dict(
+                    surface="surf",
+                    atmospheric="atm",
                 ),
-            )
-        )
+            ),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'analysis'
+        return "analysis"
 
 
 class Analysis3D(AbstractAnalysis):
@@ -70,71 +76,79 @@ class Analysis3D(AbstractAnalysis):
     _footprint = [
         term,
         dict(
-            attr = dict(
-                term = dict(
-                    values = [Time(0), ],
-                    optional = True,
-                    default = Time(0)
+            attr=dict(
+                term=dict(
+                    values=[
+                        Time(0),
+                    ],
+                    optional=True,
+                    default=Time(0),
                 )
             )
-        )
+        ),
     ]
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        ananame = 'analyse'
-        if 'surf' in self.filling:
-            if re.match('aladin|arome', self.model):
-                ananame = 'analyse_surf'
-            elif self.model == 'surfex':
-                ananame = 'analyse'
-            elif self.model in ('hycom', 'mfwam'):
-                ananame = '(prefix:modelkey)(termfix:modelkey)(suffix:modelkey)'
+        ananame = "analyse"
+        if "surf" in self.filling:
+            if re.match("aladin|arome", self.model):
+                ananame = "analyse_surf"
+            elif self.model == "surfex":
+                ananame = "analyse"
+            elif self.model in ("hycom", "mfwam"):
+                ananame = (
+                    "(prefix:modelkey)(termfix:modelkey)(suffix:modelkey)"
+                )
             else:
-                ananame = 'analyse_surface1'
+                ananame = "analyse_surface1"
 
         if self.filtering is not None:
-            if 'aladin' in self.model:
-                ananame = 'ANALYSE_DFI'
+            if "aladin" in self.model:
+                ananame = "ANALYSE_DFI"
 
-        if self.model == 'surfex':
-            ananame += '.sfx'
+        if self.model == "surfex":
+            ananame += ".sfx"
 
         return ananame
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        olivename_map = {'atm': 'TRAJ' + self.model[:4].upper() + '+0000',
-                         'surf': 'surfanalyse',
-                         'full': 'analyse'}
-        if self.model != 'arpege':
-            olivename_map['surf'] = 'analyse'
-            if self.model == 'surfex':
-                olivename_map = {k: x + '.sfx' for k, x in olivename_map.items()}
+        olivename_map = {
+            "atm": "TRAJ" + self.model[:4].upper() + "+0000",
+            "surf": "surfanalyse",
+            "full": "analyse",
+        }
+        if self.model != "arpege":
+            olivename_map["surf"] = "analyse"
+            if self.model == "surfex":
+                olivename_map = {
+                    k: x + ".sfx" for k, x in olivename_map.items()
+                }
         return olivename_map[self.filling]
 
     def iga_pathinfo(self):
         """Standard path information for IGA inline cache."""
-        if self.model == 'arome':
-            if self.filling == 'surf':
-                directory = 'fic_day'
+        if self.model == "arome":
+            if self.filling == "surf":
+                directory = "fic_day"
             else:
-                directory = 'workdir/analyse'
-        elif self.model == 'arpege':
-            if self.filling == 'surf':
-                directory = 'workdir/analyse'
+                directory = "workdir/analyse"
+        elif self.model == "arpege":
+            if self.filling == "surf":
+                directory = "workdir/analyse"
             else:
-                directory = 'autres'
-        elif self.model in ('hycom', 'mfwam'):
-            if self.filling == 'surf':
-                directory = 'guess'
-        elif self.model == 'surfex':
-            directory = 'fic_day'
+                directory = "autres"
+        elif self.model in ("hycom", "mfwam"):
+            if self.filling == "surf":
+                directory = "guess"
+        elif self.model == "surfex":
+            directory = "fic_day"
         else:
-            if self.filling == 'surf':
-                directory = 'autres'
+            if self.filling == "surf":
+                directory = "autres"
             else:
-                directory = 'workdir/analyse'
+                directory = "workdir/analyse"
         return dict(
             fmt=directory,
             model=self.model,
@@ -148,12 +162,14 @@ class Analysis4D(AbstractAnalysis):
     _footprint = [
         term_deco,
         dict(
-            attr = dict(
-                term = dict(
-                    outcast = [Time(0), ]
+            attr=dict(
+                term=dict(
+                    outcast=[
+                        Time(0),
+                    ]
                 )
             )
-        )
+        ),
     ]
 
 
@@ -161,14 +177,15 @@ class InitialCondition(AbstractAnalysis):
     """
     Class for initial condition resources : anything from which a model run can be performed.
     """
+
     _footprint = dict(
-        info = 'Initial condition',
-        attr = dict(
-            kind = dict(
-                values   = ['initial_condition', 'ic', 'starting_point'],
-                remap    = dict(autoremap = 'first'),
+        info="Initial condition",
+        attr=dict(
+            kind=dict(
+                values=["initial_condition", "ic", "starting_point"],
+                remap=dict(autoremap="first"),
             ),
-        )
+        ),
     )
 
     @property
@@ -178,86 +195,98 @@ class InitialCondition(AbstractAnalysis):
 
     @property
     def realkind(self):
-        return 'ic'
+        return "ic"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        logger.warning("The member number is only known by the provider, so the generic historic name is returned.")
-        return 'ICMSH' + self.model[:4].upper() + '+' + self.term.fmthour
+        logger.warning(
+            "The member number is only known by the provider, so the generic historic name is returned."
+        )
+        return "ICMSH" + self.model[:4].upper() + "+" + self.term.fmthour
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'ICFC_(memberfix:member)'
+        return "ICFC_(memberfix:member)"
 
 
 class Historic(GeoFlowResource):
     """
     Class for historical state of a model (e.g. from a forecast).
     """
+
     _footprint = [
         term_deco,
         dict(
-            info = 'Historic forecast file',
-            attr = dict(
-                kind = dict(
-                    values = ['historic', 'modelstate'],
-                    remap = dict(
-                        modelstate = 'historic'
-                    )
+            info="Historic forecast file",
+            attr=dict(
+                kind=dict(
+                    values=["historic", "modelstate"],
+                    remap=dict(modelstate="historic"),
                 ),
-                subset = dict(
+                subset=dict(
                     # Dummy argument but avoid priority related messages with footprints
-                    info = 'With Historical files, leave subset empty...',
-                    optional = True,
-                    values = [None, ],
+                    info="With Historical files, leave subset empty...",
+                    optional=True,
+                    values=[
+                        None,
+                    ],
                 ),
-                nativefmt = dict(
-                    values = ['fa', 'grib', 'lfi', 'netcdf', 'unknown', 'nc'],
-                    remap = dict(nc='netcdf'),
-                    default = 'fa',
+                nativefmt=dict(
+                    values=["fa", "grib", "lfi", "netcdf", "unknown", "nc"],
+                    remap=dict(nc="netcdf"),
+                    default="fa",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'historic'
+        return "historic"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        if self.model in ('mfwam', 'hycom'):
-            prefix = '(prefix:modelkey)'
-            midfix = ''
+        if self.model in ("mfwam", "hycom"):
+            prefix = "(prefix:modelkey)"
+            midfix = ""
         else:
-            prefix = '(icmshfix:modelkey)'
-            midfix = '(histfix:igakey)'
-        termfix = '(termfix:modelkey)'
-        suffix = '(suffix:modelkey)'
+            prefix = "(icmshfix:modelkey)"
+            midfix = "(histfix:igakey)"
+        termfix = "(termfix:modelkey)"
+        suffix = "(suffix:modelkey)"
 
-        if self.geometry.lam and re.match('testms1|testmp1|testmp2', self.geometry.area):
-            suffix = '.r' + archive_suffix(self.model, self.cutoff, self.date)
+        if self.geometry.lam and re.match(
+            "testms1|testmp1|testmp2", self.geometry.area
+        ):
+            suffix = ".r" + archive_suffix(self.model, self.cutoff, self.date)
 
-        if self.model == 'mocage':
-            prefix = 'HM'
+        if self.model == "mocage":
+            prefix = "HM"
             midfix = self.geometry.area
-            if self.nativefmt == 'netcdf':
-                suffix = '.nc'
+            if self.nativefmt == "netcdf":
+                suffix = ".nc"
 
         return prefix + midfix + termfix + suffix
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        if self.model == 'mesonh':
-            return '.'.join(
-                (self.model.upper(), self.geometry.area[:4].upper() + '+' + self.term.fmthour, self.nativefmt)
+        if self.model == "mesonh":
+            return ".".join(
+                (
+                    self.model.upper(),
+                    self.geometry.area[:4].upper() + "+" + self.term.fmthour,
+                    self.nativefmt,
+                )
             )
         else:
-            return 'ICMSH' + self.model[:4].upper() + '+' + self.term.fmthour
+            return "ICMSH" + self.model[:4].upper() + "+" + self.term.fmthour
 
     def _geo2basename_info(self, add_stretching=True):
         """Return an array describing the geometry for the Vortex's name builder."""
-        if isinstance(self.geometry, CurvlinearGeometry) and self.model == 'hycom':
+        if (
+            isinstance(self.geometry, CurvlinearGeometry)
+            and self.model == "hycom"
+        ):
             # return the old naming convention for surges restart files
             lgeo = [self.geometry.area, self.geometry.rnice]
             return lgeo
@@ -265,70 +294,70 @@ class Historic(GeoFlowResource):
             return super()._geo2basename_info(add_stretching=add_stretching)
 
 
-@namebuilding_insert('filtername', lambda s: s.subset)
+@namebuilding_insert("filtername", lambda s: s.subset)
 class HistoricSubset(GeoFlowResource):
     """
     Class for a subset of the historical state of a model (e.g. from a forecast).
     """
+
     _footprint = [
         term_deco,
         dict(
-            info = 'Subset of an historic forecast file',
-            attr = dict(
-                kind = dict(
-                    values = ['historic', 'modelstate'],
-                    remap = dict(
-                        modelstate = 'historic'
-                    )
+            info="Subset of an historic forecast file",
+            attr=dict(
+                kind=dict(
+                    values=["historic", "modelstate"],
+                    remap=dict(modelstate="historic"),
                 ),
-                subset = dict(
-                    info = "The subset of fields contained in this data.",
+                subset=dict(
+                    info="The subset of fields contained in this data.",
                 ),
-                nativefmt = dict(
-                    values = ['fa', 'grib', 'lfi', 'netcdf', 'unknown', 'nc'],
-                    remap = dict(nc='netcdf'),
-                    default = 'fa',
+                nativefmt=dict(
+                    values=["fa", "grib", "lfi", "netcdf", "unknown", "nc"],
+                    remap=dict(nc="netcdf"),
+                    default="fa",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'historic'
+        return "historic"
 
 
 class BiasDFI(GeoFlowResource):
     """
     Class for some kind of DFI bias (please add proper documentation).
     """
+
     _footprint = [
         term_deco,
         dict(
-            info = 'DFI bias file',
-            attr = dict(
-                kind = dict(
-                    values = ['biasdfi', 'dfibias'],
-                    remap = dict(
-                        dfibias = 'biasdfi'
-                    )
+            info="DFI bias file",
+            attr=dict(
+                kind=dict(
+                    values=["biasdfi", "dfibias"],
+                    remap=dict(dfibias="biasdfi"),
                 ),
-                nativefmt = dict(
-                    values = ['fa'],
-                    default = 'fa',
+                nativefmt=dict(
+                    values=["fa"],
+                    default="fa",
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'biasdfi'
+        return "biasdfi"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'BIASDFI+{:04d}'.format(self.term.hour)
+        return "BIASDFI+{:04d}".format(self.term.hour)
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'BIASDFI{:s}+{:04d}'.format(self.model[:4].upper(), self.term.hour)
+        return "BIASDFI{:s}+{:04d}".format(
+            self.model[:4].upper(), self.term.hour
+        )

--- a/src/vortex/nwp/data/monitoring.py
+++ b/src/vortex/nwp/data/monitoring.py
@@ -14,36 +14,38 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
-@namebuilding_insert('src', lambda s: [s.stage, s.obs])
+@namebuilding_insert("src", lambda s: [s.stage, s.obs])
 class Monitoring(FlowResource):
     """Abstract monitoring resource."""
 
     _abstract = True
     _footprint = dict(
-        info = 'Observations monitoring file',
-        attr = dict(
-            kind = dict(
-                values = ['monitoring', ],
+        info="Observations monitoring file",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "monitoring",
+                ],
             ),
-            nativefmt = dict(
-                values =['ascii', 'binary', 'txt', 'bin'],
-                remap = dict(ascii='txt', binary='bin')
+            nativefmt=dict(
+                values=["ascii", "binary", "txt", "bin"],
+                remap=dict(ascii="txt", binary="bin"),
             ),
-            stage = dict(
-                values = ['can', 'surf', 'surface', 'atm', 'atmospheric'],
-                remap = dict(can='surf', surface='surf', atmospheric='atm'),
-                info = 'The processing stage of the ODB base.',
+            stage=dict(
+                values=["can", "surf", "surface", "atm", "atmospheric"],
+                remap=dict(can="surf", surface="surf", atmospheric="atm"),
+                info="The processing stage of the ODB base.",
             ),
-            obs = dict(
-                values = ['all', 'used'],
-                info = 'The processing part of the ODB base.',
+            obs=dict(
+                values=["all", "used"],
+                info="The processing part of the ODB base.",
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'monitoring'
+        return "monitoring"
 
 
 class MntObsThreshold(GenvModelResource):
@@ -53,168 +55,139 @@ class MntObsThreshold(GenvModelResource):
     """
 
     _footprint = dict(
-        info='Observations threshold',
+        info="Observations threshold",
         attr=dict(
-            kind=dict(
-                values=['obs_threshold']
-            ),
-            gvar=dict(
-                default='monitoring_seuils_obs'
-            ),
-            source=dict(
-            ),
-        )
+            kind=dict(values=["obs_threshold"]),
+            gvar=dict(default="monitoring_seuils_obs"),
+            source=dict(),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'obs_threshold'
+        return "obs_threshold"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self.source
+        return "extract=" + self.source
 
 
-@namebuilding_insert('period', lambda s: s.periodicity)
+@namebuilding_insert("period", lambda s: s.periodicity)
 class MntCumulStat(Monitoring):
     """Accumulated statistics file."""
 
     _footprint = dict(
-        info='Monthly accumulated statistics',
+        info="Monthly accumulated statistics",
         attr=dict(
-            kind=dict(
-                values=['accumulated_stats']
-            ),
+            kind=dict(values=["accumulated_stats"]),
             nativefmt=dict(
-                values=['binary', 'bin'],
-                default='bin',
-                optional = True
+                values=["binary", "bin"], default="bin", optional=True
             ),
-            periodicity = dict(
-                values = ['monthly',
-                          'weekly_on_mondays',
-                          'weekly_on_sundays'],
-                default = 'monthly',
-                optional =True
-            )
-        )
+            periodicity=dict(
+                values=["monthly", "weekly_on_mondays", "weekly_on_sundays"],
+                default="monthly",
+                optional=True,
+            ),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'accumulated_stats'
+        return "accumulated_stats"
 
 
-@namebuilding_append('src', lambda s: s.monitor)
+@namebuilding_append("src", lambda s: s.monitor)
 class MntStat(Monitoring):
     """Monitoring statistics file."""
 
     _footprint = dict(
-        info='Monitoring statistics',
+        info="Monitoring statistics",
         attr=dict(
-            kind=dict(
-                values=['monitoring_stats']
-            ),
+            kind=dict(values=["monitoring_stats"]),
             nativefmt=dict(
-                values=['ascii', 'txt'],
-                default='txt',
-                optional=True
+                values=["ascii", "txt"], default="txt", optional=True
             ),
             monitor=dict(
-                values=['bias', 'analysis'],
-                remap=dict(cy='analysis', deb='bias'),
-            )
-        )
+                values=["bias", "analysis"],
+                remap=dict(cy="analysis", deb="bias"),
+            ),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'monitoring_stats'
+        return "monitoring_stats"
 
 
 class MntGrossErrors(Monitoring):
     """Gross errors file."""
 
     _footprint = dict(
-        info='Gross errors',
+        info="Gross errors",
         attr=dict(
-            kind=dict(
-                values=['gross_errors']
+            kind=dict(values=["gross_errors"]),
+            nativefmt=dict(
+                values=["ascii", "txt"], default="txt", optional=True
             ),
-            nativefmt = dict(
-                values=['ascii', 'txt'],
-                default='txt',
-                optional=True
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'gross_errors'
+        return "gross_errors"
 
 
 class MntNbMessages(Monitoring):
     """Number of messages for each observations type"""
 
     _footprint = dict(
-        info='Obs messages',
+        info="Obs messages",
         attr=dict(
-            kind=dict(
-                values=['nbmessages']
+            kind=dict(values=["nbmessages"]),
+            nativefmt=dict(
+                values=["ascii", "txt"], default="txt", optional=True
             ),
-            nativefmt = dict(
-                values=['ascii', 'txt'],
-                default='txt',
-                optional=True
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'nbmessages'
+        return "nbmessages"
 
 
 class MntMissingObs(Monitoring):
     """Missing observations."""
 
     _footprint = dict(
-        info='Missing observations',
+        info="Missing observations",
         attr=dict(
-            kind=dict(
-                values=['missing_obs']
+            kind=dict(values=["missing_obs"]),
+            nativefmt=dict(
+                values=["ascii", "txt"], default="txt", optional=True
             ),
-            nativefmt = dict(
-                values=['ascii', 'txt'],
-                default='txt',
-                optional=True
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'missing_obs'
+        return "missing_obs"
 
 
 class MntObsLocation(Monitoring):
     """Observations location."""
 
     _footprint = dict(
-        info='Observations location',
+        info="Observations location",
         attr=dict(
-            kind=dict(
-                values=['obslocation']
+            kind=dict(values=["obslocation"]),
+            nativefmt=dict(
+                values=["obslocationpack"],
+                default="obslocationpack",
+                optional=True,
             ),
-            nativefmt = dict(
-                values=['obslocationpack'],
-                default='obslocationpack',
-                optional=True
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'obslocation'
+        return "obslocation"

--- a/src/vortex/nwp/data/namelists.py
+++ b/src/vortex/nwp/data/namelists.py
@@ -22,49 +22,71 @@ __all__ = []
 
 logger = loggers.getLogger(__name__)
 
-KNOWN_NAMELIST_MACROS = {'NPROC', 'NBPROC', 'NBPROC_IO', 'NCPROC', 'NDPROC',
-                         'NBPROCIN', 'NBPROCOUT', 'IDAT', 'CEXP',
-                         'TIMESTEP', 'FCSTOP', 'NMODVAL', 'NBE', 'SEED',
-                         'MEMBER', 'NUMOD', 'OUTPUTID', 'NRESX', 'PERTURB',
-                         'JOUR', 'RES', 'LLADAJ', 'LLADMON', 'LLFLAG',
-                         'LLARO', 'LLVRP', 'LLCAN'}
+KNOWN_NAMELIST_MACROS = {
+    "NPROC",
+    "NBPROC",
+    "NBPROC_IO",
+    "NCPROC",
+    "NDPROC",
+    "NBPROCIN",
+    "NBPROCOUT",
+    "IDAT",
+    "CEXP",
+    "TIMESTEP",
+    "FCSTOP",
+    "NMODVAL",
+    "NBE",
+    "SEED",
+    "MEMBER",
+    "NUMOD",
+    "OUTPUTID",
+    "NRESX",
+    "PERTURB",
+    "JOUR",
+    "RES",
+    "LLADAJ",
+    "LLADMON",
+    "LLFLAG",
+    "LLARO",
+    "LLVRP",
+    "LLCAN",
+}
 
 
 class NamelistPack(ModelResource):
     """
     Class for all kinds of namelists
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'A whole Namelist pack',
-            attr = dict(
-                kind = dict(
-                    values   = ['namelistpack']
+            info="A whole Namelist pack",
+            attr=dict(
+                kind=dict(values=["namelistpack"]),
+                gvar=dict(
+                    values=["NAMELIST_" + x.upper() for x in binaries],
+                    default="namelist_[binary]",
                 ),
-                gvar = dict(
-                    values   = ['NAMELIST_' + x.upper() for x in binaries],
-                    default  = 'namelist_[binary]'
+                model=dict(
+                    optional=True,
                 ),
-                model = dict(
-                    optional = True,
+                binary=dict(
+                    optional=True,
+                    values=binaries,
+                    default="[model]",
                 ),
-                binary = dict(
-                    optional = True,
-                    values   = binaries,
-                    default  = '[model]',
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'namelistpack'
+        return "namelistpack"
 
     def gget_urlquery(self):
         """GGET specific query : ``dir_extract``."""
-        return 'dir_extract=1'
+        return "dir_extract=1"
 
 
 class NamelistContentError(ValueError):
@@ -81,10 +103,10 @@ class NamelistContent(AlmostDictContent):
           * remove : elements to remove from the contents
           * parser : a namelist parser object (a default one will be built otherwise)
         """
-        kw.setdefault('macros', {k: None for k in KNOWN_NAMELIST_MACROS})
-        kw.setdefault('remove', set())
-        kw.setdefault('parser', None)
-        kw.setdefault('data', NamelistSet())
+        kw.setdefault("macros", {k: None for k in KNOWN_NAMELIST_MACROS})
+        kw.setdefault("remove", set())
+        kw.setdefault("parser", None)
+        kw.setdefault("data", NamelistSet())
         super().__init__(**kw)
         self._declaredmacros = set(self._macros.keys())
 
@@ -125,13 +147,14 @@ class NamelistContent(AlmostDictContent):
     def merge(self, delta, rmkeys=None, rmblocks=None, clblocks=None):
         """Merge of the current namelist content with the set of namelist blocks provided."""
         if isinstance(delta, NamelistContent):
-            if rmblocks is None and hasattr(delta, 'rmblocks'):
+            if rmblocks is None and hasattr(delta, "rmblocks"):
                 rmblocks = delta.rmblocks()
             actualdelta = delta.data
         else:
             actualdelta = delta
-        self._data.merge(actualdelta,
-                         rmkeys=rmkeys, rmblocks=rmblocks, clblocks=clblocks)
+        self._data.merge(
+            actualdelta, rmkeys=rmkeys, rmblocks=rmblocks, clblocks=clblocks
+        )
 
     def slurp(self, container):
         """Get data from the ``container`` namelist."""
@@ -142,7 +165,9 @@ class NamelistContent(AlmostDictContent):
             try:
                 namset = self._parser.parse(container.read())
             except (ValueError, OSError) as e:
-                raise NamelistContentError('Could not parse container contents: {!s}'.format(e))
+                raise NamelistContentError(
+                    "Could not parse container contents: {!s}".format(e)
+                )
         self._data = namset
         for macro, value in self._macros.items():
             self._data.setmacro(macro, value)
@@ -167,59 +192,58 @@ class Namelist(ModelResource):
     """
     Class for all kinds of namelists
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Namelist from binary pack',
-            attr = dict(
-                kind = dict(
-                    values   = ['namelist']
+            info="Namelist from binary pack",
+            attr=dict(
+                kind=dict(values=["namelist"]),
+                clscontents=dict(default=NamelistContent),
+                gvar=dict(
+                    values=["NAMELIST_" + x.upper() for x in binaries],
+                    default="namelist_[binary]",
                 ),
-                clscontents = dict(
-                    default  = NamelistContent
+                source=dict(
+                    info="The namelist name within the namelist pack.",
+                    optional=True,
+                    default="namel_[binary]",
+                    doc_zorder=50,
                 ),
-                gvar = dict(
-                    values   = ['NAMELIST_' + x.upper() for x in binaries],
-                    default  = 'namelist_[binary]'
+                model=dict(
+                    optional=True,
                 ),
-                source = dict(
-                    info        = 'The namelist name within the namelist pack.',
-                    optional    = True,
-                    default     = 'namel_[binary]',
-                    doc_zorder  = 50
+                binary=dict(
+                    optional=True,
+                    values=binaries,
+                    default="[model]",
                 ),
-                model = dict(
-                    optional = True,
+                date=dict(
+                    type=Date,
+                    optional=True,
                 ),
-                binary = dict(
-                    optional = True,
-                    values   = binaries,
-                    default  = '[model]',
-                ),
-                date = dict(
-                    type     = Date,
-                    optional = True,
-                )
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'namelist'
+        return "namelist"
 
     def _find_source(self):
-        sources = self.source.split('|')
+        sources = self.source.split("|")
         if len(sources) == 1:
-            source = sources[0].split(':')[0]
+            source = sources[0].split(":")[0]
         else:
             # Check that the date argument was provided.:
             if self.date is None:
-                raise AttributeError('The date argument should be provided when dealing ' +
-                                     'with time based namelist sources.')
+                raise AttributeError(
+                    "The date argument should be provided when dealing "
+                    + "with time based namelist sources."
+                )
             datedSource = {}
             for s in sources:
-                dateNsource = s.split(':')
+                dateNsource = s.split(":")
                 if dateNsource[0]:
                     if len(dateNsource) == 2:
                         date = Date(dateNsource[1], year=self.date.year)
@@ -228,22 +252,25 @@ class Namelist(ModelResource):
                     if date not in datedSource.keys():
                         datedSource[date] = dateNsource[0]
                     else:
-                        logger.warning('%s already begins the %s, %s is ignored.',
-                                       datedSource[date],
-                                       date.strftime('%d of %b.'), dateNsource[0])
+                        logger.warning(
+                            "%s already begins the %s, %s is ignored.",
+                            datedSource[date],
+                            date.strftime("%d of %b."),
+                            dateNsource[0],
+                        )
             datedSource = sorted(datedSource.items(), reverse=True)
             source = datedSource[0][1]
             for dateNsource in datedSource:
                 if self.date >= dateNsource[0]:
                     source = dateNsource[1]
                     break
-            logger.info('The consistent source is %s', source)
+            logger.info("The consistent source is %s", source)
 
         return source
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self._find_source()
+        return "extract=" + self._find_source()
 
 
 class NamelistDelta(Namelist):
@@ -252,42 +279,45 @@ class NamelistDelta(Namelist):
     """
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                values   = ['namdelta', 'deltanam', ]
+        attr=dict(
+            kind=dict(
+                values=[
+                    "namdelta",
+                    "deltanam",
+                ]
             ),
-            source = dict(
-                default     = 'deltanam.[binary]',
+            source=dict(
+                default="deltanam.[binary]",
             ),
         )
     )
 
     @property
     def realkind(self):
-        return 'namdelta'
+        return "namdelta"
 
 
 class NamelistUtil(Namelist):
     """
     Class for namelists utilities
     """
+
     _footprint = dict(
-        info = 'Namelist from utilities pack',
-        attr = dict(
-            kind = dict(
-                values   = ['namelist_util', 'namutil'],
-                remap    = dict(autoremap = 'first'),
+        info="Namelist from utilities pack",
+        attr=dict(
+            kind=dict(
+                values=["namelist_util", "namutil"],
+                remap=dict(autoremap="first"),
             ),
-            gvar = dict(
-                values   = ['NAMELIST_UTILITIES'],
-                default  = 'namelist_utilities'
+            gvar=dict(
+                values=["NAMELIST_UTILITIES"], default="namelist_utilities"
             ),
-            binary = dict(
-                values   = ['batodb', 'utilities', 'odbtools'],
-                default  = 'utilities',
-                optional = True,
+            binary=dict(
+                values=["batodb", "utilities", "odbtools"],
+                default="utilities",
+                optional=True,
             ),
-        )
+        ),
     )
 
 
@@ -295,22 +325,19 @@ class NamelistTerm(Namelist):
     """
     Class for all the terms dependent namelists
     """
+
     _footprint = [
         term,
         dict(
-            info = 'Terms dependent namelist',
-            attr = dict(
-                kind = dict(
-                    values = ['namterm']
-                )
-            )
-        )
+            info="Terms dependent namelist",
+            attr=dict(kind=dict(values=["namterm"])),
+        ),
     ]
 
     def incoming_xxt_fixup(self, attr, key=None, prefix=None):
         """Fix as best as possible the ``xxt.def`` file."""
 
-        regex = re.compile(r',(.*)$')
+        regex = re.compile(r",(.*)$")
         myenv = env.current()
         suffix = regex.search(myenv.VORTEX_XXT_DEF)
         if suffix:
@@ -319,35 +346,37 @@ class NamelistTerm(Namelist):
             fp = None
 
         try:
-            with open('xxt.def') as f:
+            with open("xxt.def") as f:
                 lines = f.readlines()
         except OSError:
-            logger.error('Could not open file xxt.def')
+            logger.error("Could not open file xxt.def")
             raise
 
         select = lines[self.term.hour].split()[2]
 
-        if not re.match(r'undef', select):
+        if not re.match(r"undef", select):
             if fp:
-                rgx = re.compile(key + r'(.*)$')
+                rgx = re.compile(key + r"(.*)$")
                 sfx = rgx.search(select)
                 if sfx:
                     s = sfx.group(1)
                 else:
-                    s = ''
-                return ''.join((key, '_', fp, s))
+                    s = ""
+                return "".join((key, "_", fp, s))
             else:
                 return select
         else:
-            logger.error('Fullpos namelist id not defined for term %s', self.term)
+            logger.error(
+                "Fullpos namelist id not defined for term %s", self.term
+            )
 
     def incoming_namelist_fixup(self, attr, key=None):
         """Fix as best as possible the namelist term extensions."""
 
         val = getattr(self, attr)
-        r1 = re.compile(r'^(.*\/)?(' + key + r'.*_fp|cpl)$')
-        r2 = re.compile(r'^(.*\/)?(' + key + r'.*_fp)(\..*)$')
-        r3 = re.compile(r'^(.*\/)?(' + key + r'.*_p)$')
+        r1 = re.compile(r"^(.*\/)?(" + key + r".*_fp|cpl)$")
+        r2 = re.compile(r"^(.*\/)?(" + key + r".*_fp)(\..*)$")
+        r3 = re.compile(r"^(.*\/)?(" + key + r".*_p)$")
 
         fixed = 0
 
@@ -357,26 +386,26 @@ class NamelistTerm(Namelist):
                 fixed = 1
                 (dirpath, base) = (s.group(1), s.group(2))
                 if dirpath is None:
-                    dirpath = ''
-                ext = ''
+                    dirpath = ""
+                ext = ""
                 if r == r3:
                     if self.term.hour == 0:
-                        p = '0'
+                        p = "0"
                     elif self.term.hour % 6 == 0:
-                        p = '6'
+                        p = "6"
                     elif self.term.hour % 3 == 0:
-                        p = '3'
+                        p = "3"
                     else:
-                        p = '1'
+                        p = "1"
                 else:
                     if self.term.hour == 0:
-                        p = '0'
+                        p = "0"
                     else:
-                        p = ''
+                        p = ""
                     if r == r2:
                         ext = s.group(3)
                         if ext is None:
-                            ext = ''
+                            ext = ""
 
         if fixed:
             return dirpath + base + p + ext
@@ -388,89 +417,99 @@ class NamelistSelect(NamelistTerm):
     """
     Class for the select namelists
     """
+
     _footprint = [
         dict(
-            info = 'Select namelist for fullpos ',
-            attr = dict(
-                kind = dict(
-                    values = ['namselect', ]
+            info="Select namelist for fullpos ",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "namselect",
+                    ]
                 )
-            )
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'namselect'
+        return "namselect"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
         myenv = env.current()
-        if myenv.true('VORTEX_XXT_DEF'):
-            return 'extract=' + self.incoming_xxt_fixup('source', 'select')
+        if myenv.true("VORTEX_XXT_DEF"):
+            return "extract=" + self.incoming_xxt_fixup("source", "select")
         else:
-            return 'extract={:s}'.format(self.source)
+            return "extract={:s}".format(self.source)
 
 
 class NamelistFullPos(NamelistTerm):
     """
     Class for the fullpos term dependent namelists
     """
+
     _footprint = [
         dict(
-            info = 'Namelist for offline fullpos ',
-            attr = dict(
-                kind = dict(
-                    values = ['namelistfp', ]
+            info="Namelist for offline fullpos ",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "namelistfp",
+                    ]
                 )
-            )
+            ),
         )
     ]
 
     @property
     def realkind(self):
-        return 'namelistfp'
+        return "namelistfp"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self.incoming_namelist_fixup('source', 'namel')
+        return "extract=" + self.incoming_namelist_fixup("source", "namel")
 
 
 class NamelistFpServerObject(Namelist):
     """Class for a fullpos server object's namelists."""
 
     _footprint = dict(
-        info = 'Namelist for a fullpos server object',
-        attr = dict(
-            kind = dict(
-                values   = ['namelist_fpobject', ]
+        info="Namelist for a fullpos server object",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "namelist_fpobject",
+                ]
             ),
-            fp_conf = dict(
-                info     = 'The FPCONF setting associated with this object.',
-                type     = int,
-                optional = True,
+            fp_conf=dict(
+                info="The FPCONF setting associated with this object.",
+                type=int,
+                optional=True,
             ),
-            fp_cmodel = dict(
-                info     = 'The CMODEL setting associated with this object.',
-                optional = True,
+            fp_cmodel=dict(
+                info="The CMODEL setting associated with this object.",
+                optional=True,
             ),
-            fp_lextern = dict(
-                info     = 'The LEXTERN setting associated with this object.',
-                type     = bool,
-                optional = True,
+            fp_lextern=dict(
+                info="The LEXTERN setting associated with this object.",
+                type=bool,
+                optional=True,
             ),
-            fp_terms = dict(
-                info     = ('Apply this object only on a subset of the input '
-                            'data (based on term)'),
-                type     = FPList,
-                optional = True,
-            )
-        )
+            fp_terms=dict(
+                info=(
+                    "Apply this object only on a subset of the input "
+                    "data (based on term)"
+                ),
+                type=FPList,
+                optional=True,
+            ),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'namelist_fpobject'
+        return "namelist_fpobject"
 
 
 class XXTContent(IndexedTable):
@@ -494,7 +533,7 @@ class XXTContent(IndexedTable):
 
         These naming convention refer to the footprints resolve mechanism.
         """
-        t = g.get('term', x.get('term', None))
+        t = g.get("term", x.get("term", None))
         if t is None:
             return None
         else:
@@ -505,7 +544,9 @@ class XXTContent(IndexedTable):
                 return None
             tkey = self.get(t.fmthm, self.get(str(t.hour), None))
             if tkey is None:
-                logger.warning('No entry found in the XXT file for term = %s.', t.fmthm)
+                logger.warning(
+                    "No entry found in the XXT file for term = %s.", t.fmthm
+                )
             else:
                 try:
                     value = tkey[n]
@@ -532,17 +573,24 @@ class XXTContent(IndexedTable):
                 maxterm = -1
         maxterm = Time(maxterm)
 
-        if (self._cachedomains is None) or (self._cachedomains_term != maxterm):
-
+        if (self._cachedomains is None) or (
+            self._cachedomains_term != maxterm
+        ):
             select_seen = dict()
             for a_term in [x for x in allterms if x <= maxterm]:
-                tvalue = self.get(a_term.fmthm, self.get(str(a_term.hour), None))
+                tvalue = self.get(
+                    a_term.fmthm, self.get(str(a_term.hour), None)
+                )
                 sh = sessions.system()
                 if tvalue[0] is not None:
-                    local_guesses = [tvalue[0], 'fpselect_' + a_term.fmthm]
+                    local_guesses = [tvalue[0], "fpselect_" + a_term.fmthm]
                     if where:
-                        local_guesses = [sh.path.join(where, g) for g in local_guesses]
-                    local_guesses = [g for g in local_guesses if sh.path.exists(g)]
+                        local_guesses = [
+                            sh.path.join(where, g) for g in local_guesses
+                        ]
+                    local_guesses = [
+                        g for g in local_guesses if sh.path.exists(g)
+                    ]
                     if local_guesses:
                         # Do not waste time on duplicated selects...
                         if tvalue[1] not in select_seen:
@@ -551,8 +599,14 @@ class XXTContent(IndexedTable):
                                 xx = fortp.parse(fd.read())
                             domains = set()
                             for nb in xx.values():
-                                for domlist in [y for x, y in nb.items() if x.startswith('CLD')]:
-                                    domains = domains | set(domlist.pop().split(':'))
+                                for domlist in [
+                                    y
+                                    for x, y in nb.items()
+                                    if x.startswith("CLD")
+                                ]:
+                                    domains = domains | set(
+                                        domlist.pop().split(":")
+                                    )
                             select_seen[tvalue[1]] = domains
                         else:
                             domains = select_seen[tvalue[1]]
@@ -571,74 +625,72 @@ class XXTContent(IndexedTable):
 
 class NamelistSelectDef(StaticResource):
     """Utility, so-called xxt file."""
+
     _footprint = [
         cutoff,
         gvar,
         dict(
-            info = 'xxt.def file from namelist pack',
-            attr = dict(
-                gvar = dict(
-                    values = ['NAMELIST_' + x.upper() for x in binaries],
-                    default = 'namelist_[binary]'
+            info="xxt.def file from namelist pack",
+            attr=dict(
+                gvar=dict(
+                    values=["NAMELIST_" + x.upper() for x in binaries],
+                    default="namelist_[binary]",
                 ),
-                source = dict(
-                    optional = True,
+                source=dict(
+                    optional=True,
                 ),
-                binary = dict(
-                    optional = True,
-                    values = binaries,
-                    default = '[model]',
+                binary=dict(
+                    optional=True,
+                    values=binaries,
+                    default="[model]",
                 ),
-                kind = dict(
-                    values = ['xxtdef', 'namselectdef']
-                ),
-                clscontents = dict(
-                    default = XXTContent
-                )
+                kind=dict(values=["xxtdef", "namselectdef"]),
+                clscontents=dict(default=XXTContent),
             ),
-            bind = ['gvar', 'source']
-        )
+            bind=["gvar", "source"],
+        ),
     ]
 
-    _source_map = dict(assim='xxt.def.assim', )
+    _source_map = dict(
+        assim="xxt.def.assim",
+    )
 
     @property
     def realkind(self):
-        return 'namselectdef'
+        return "namselectdef"
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
         if self.source is None:
-            thesource = self._source_map.get(self.cutoff, 'xxt.def')
+            thesource = self._source_map.get(self.cutoff, "xxt.def")
         else:
             thesource = self.source
-        return 'extract=' + thesource
+        return "extract=" + thesource
 
 
-@namebuilding_insert('src', lambda s: s.target)
+@namebuilding_insert("src", lambda s: s.target)
 class GeoBlocks(ModelGeoResource):
     """Extract of a namelist containing Geometry blocks."""
 
     _footprint = dict(
-        attr = dict(
-            kind = dict(
-                info = "Geometry blocks of namelist.",
-                values = ['geoblocks']
+        attr=dict(
+            kind=dict(
+                info="Geometry blocks of namelist.", values=["geoblocks"]
             ),
-            clscontents = dict(
-                default = NamelistContent,
+            clscontents=dict(
+                default=NamelistContent,
             ),
-            target = dict(
-                info = "Scope that should use these blocks.",
+            target=dict(
+                info="Scope that should use these blocks.",
             ),
-            nativefmt = dict(
-                optional = True,
-                values = ['nam'],
-                default = 'nam',
+            nativefmt=dict(
+                optional=True,
+                values=["nam"],
+                default="nam",
             ),
         )
     )
 
     @property
     def realkind(self):
-        return 'geoblocks'
+        return "geoblocks"

--- a/src/vortex/nwp/data/obs.py
+++ b/src/vortex/nwp/data/obs.py
@@ -18,14 +18,16 @@ from vortex.syntax import stdattrs, stddeco
 from ..syntax.stdattrs import gvar, GenvKey
 
 #: Automatic export of Observations class
-__all__ = ['Observations', ]
+__all__ = [
+    "Observations",
+]
 
 logger = loggers.getLogger(__name__)
 
 
-@stddeco.namebuilding_insert('style', lambda s: 'obs')
-@stddeco.namebuilding_insert('stage', lambda s: s.stage)
-@stddeco.namebuilding_insert('part', lambda s: s.part)
+@stddeco.namebuilding_insert("style", lambda s: "obs")
+@stddeco.namebuilding_insert("stage", lambda s: s.stage)
+@stddeco.namebuilding_insert("part", lambda s: s.part)
 class Observations(GeoFlowResource):
     """
     Abstract observation resource.
@@ -33,135 +35,176 @@ class Observations(GeoFlowResource):
 
     _abstract = True
     _footprint = dict(
-        info = 'Observations file',
-        attr = dict(
-            kind = dict(
-                values   = ['observations', 'obs'],
-                remap    = dict(obs = 'observations'),
+        info="Observations file",
+        attr=dict(
+            kind=dict(
+                values=["observations", "obs"],
+                remap=dict(obs="observations"),
             ),
-            part = dict(
-                info     = 'The name of this subset of observations.'
+            part=dict(info="The name of this subset of observations."),
+            nativefmt=dict(
+                alias=("format",),
             ),
-            nativefmt = dict(
-                alias    = ('format',),
+            stage=dict(
+                info="The processing stage for this subset of observations."
             ),
-            stage = dict(
-                info     = 'The processing stage for this subset of observations.'
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'observations'
+        return "observations"
 
 
 class ObsProcessed(Observations):
     """Pre-Processed or Processed observations."""
 
     _footprint = dict(
-        info = 'Pre-Processed observations.',
-        attr = dict(
-            nativefmt = dict(
-                values  = ['ascii', 'netcdf', 'hdf5'],
+        info="Pre-Processed observations.",
+        attr=dict(
+            nativefmt=dict(
+                values=["ascii", "netcdf", "hdf5"],
             ),
-            stage = dict(
-                values   = ['preprocessing', ],
+            stage=dict(
+                values=[
+                    "preprocessing",
+                ],
             ),
-        )
+        ),
     )
 
 
-@stddeco.namebuilding_insert('layout', lambda s: s.layout)
+@stddeco.namebuilding_insert("layout", lambda s: s.layout)
 class ObsODB(Observations):
     """Observations in ODB format associated to a given stage."""
 
     _footprint = dict(
-        info = 'Packed observations (ODB, CCMA, etc.)',
-        attr = dict(
-            nativefmt = dict(
-                values   = ['odb', 'odb/split', 'odb/compressed'],
-                remap    = {
-                    'odb/split': 'odb',
-                    'odb/compressed': 'odb'
-                },
+        info="Packed observations (ODB, CCMA, etc.)",
+        attr=dict(
+            nativefmt=dict(
+                values=["odb", "odb/split", "odb/compressed"],
+                remap={"odb/split": "odb", "odb/compressed": "odb"},
             ),
-            layout = dict(
-                info     = 'The layout of the ODB database.',
-                optional = True,
-                default  = 'ecma',
-                values   = [
-                    'ccma', 'ecma', 'ecmascr',
-                    'CCMA', 'ECMA', 'ECMASCR',
-                    'rstbias', 'countryrstrhbias', 'sondetyperstrhbias',
-                    'RSTBIAS', 'COUNTRYRSTRHBIAS', 'SONDETYPERSTRHBIAS',
+            layout=dict(
+                info="The layout of the ODB database.",
+                optional=True,
+                default="ecma",
+                values=[
+                    "ccma",
+                    "ecma",
+                    "ecmascr",
+                    "CCMA",
+                    "ECMA",
+                    "ECMASCR",
+                    "rstbias",
+                    "countryrstrhbias",
+                    "sondetyperstrhbias",
+                    "RSTBIAS",
+                    "COUNTRYRSTRHBIAS",
+                    "SONDETYPERSTRHBIAS",
                 ],
-                remap    = dict(
-                    CCMA = 'ccma', ECMA = 'ecma', ECMASCR = 'ecmascr',
-                    RSTBIAS = 'rstbias',
-                    COUNTRYRSTRHBIAS = 'countryrstrhbias',
-                    SONDETYPERSTRHBIAS = 'sondetyperstrhbias',
-                )
-            ),
-            stage = dict(
-                values   = [
-                    'void', 'avg', 'average', 'screen', 'screening', 'split', 'build',
-                    'traj', 'min', 'minim', 'complete', 'matchup',
-                    'canari', 'cans'
-                ],
-                remap    = dict(
-                    avg    = 'average',
-                    min    = 'minim',
-                    cans   = 'canari',
-                    split  = 'build',
-                    screen = 'screening',
+                remap=dict(
+                    CCMA="ccma",
+                    ECMA="ecma",
+                    ECMASCR="ecmascr",
+                    RSTBIAS="rstbias",
+                    COUNTRYRSTRHBIAS="countryrstrhbias",
+                    SONDETYPERSTRHBIAS="sondetyperstrhbias",
                 ),
             ),
-        )
+            stage=dict(
+                values=[
+                    "void",
+                    "avg",
+                    "average",
+                    "screen",
+                    "screening",
+                    "split",
+                    "build",
+                    "traj",
+                    "min",
+                    "minim",
+                    "complete",
+                    "matchup",
+                    "canari",
+                    "cans",
+                ],
+                remap=dict(
+                    avg="average",
+                    min="minim",
+                    cans="canari",
+                    split="build",
+                    screen="screening",
+                ),
+            ),
+        ),
     )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        stage_map = dict(screening='screen', build='split', minim='min', canari='cans')
+        stage_map = dict(
+            screening="screen", build="split", minim="min", canari="cans"
+        )
         mystage = stage_map.get(self.stage, self.stage)
-        return '_'.join((self.layout, mystage, self.part)) + '.tar'
+        return "_".join((self.layout, mystage, self.part)) + ".tar"
 
     @property
     def _archive_mapping(self):
-        re_fullmix = re.compile(r'^(?:altitude|mix|full)$')
-        ecma_map = dict(void='ecmascr.tar',
-                        screening='odb_screen.tar',
-                        matchup='odb_cpl.tar', complete='odb_cpl.tar')
-        ecma_prefix = {('matchup', 'arpege'): 'BASE/',
-                       ('complete', 'arpege'): 'BASE/',
-                       ('matchup', 'arome'): 'BASE/',
-                       ('complete', 'arome'): 'BASE/',
-                       ('screening', 'arome'): './'}
-        if self.stage in ecma_map and self.layout == 'ecma':
+        re_fullmix = re.compile(r"^(?:altitude|mix|full)$")
+        ecma_map = dict(
+            void="ecmascr.tar",
+            screening="odb_screen.tar",
+            matchup="odb_cpl.tar",
+            complete="odb_cpl.tar",
+        )
+        ecma_prefix = {
+            ("matchup", "arpege"): "BASE/",
+            ("complete", "arpege"): "BASE/",
+            ("matchup", "arome"): "BASE/",
+            ("complete", "arome"): "BASE/",
+            ("screening", "arome"): "./",
+        }
+        if self.stage in ecma_map and self.layout == "ecma":
             if re_fullmix.match(self.part):
-                return (ecma_map[self.stage], 'extract=all&format=unknown')
-            elif self.part == 'virtual':
-                return (ecma_map[self.stage],
-                        'extract={:s}ECMA&format=unknown'
-                        .format(ecma_prefix.get((self.stage, self.model), '')))
+                return (ecma_map[self.stage], "extract=all&format=unknown")
+            elif self.part == "virtual":
+                return (
+                    ecma_map[self.stage],
+                    "extract={:s}ECMA&format=unknown".format(
+                        ecma_prefix.get((self.stage, self.model), "")
+                    ),
+                )
             else:
-                return (ecma_map[self.stage],
-                        'extract={:s}ECMA.{:s}&format=unknown'
-                        .format(ecma_prefix.get((self.stage, self.model), ''), self.part))
-        elif self.stage == 'screening' and self.layout == 'ccma':
-            return ('odb_ccma_screen.tar', '')
-        elif re_fullmix.match(self.part) and self.stage == 'traj':
-            return ('odb_traj.tar', '')
-        elif re_fullmix.match(self.part) and self.stage == 'minim' and self.model == 'aladin':
-            return ('odb_cpl.tar', '')
-        elif re_fullmix.match(self.part) and self.stage == 'minim':
-            return ('odb_min.tar', '')
-        elif self.part in ('ground', 'surf') and self.stage in ('canari', 'surfan'):
-            return ('odb_canari.tar', '')
+                return (
+                    ecma_map[self.stage],
+                    "extract={:s}ECMA.{:s}&format=unknown".format(
+                        ecma_prefix.get((self.stage, self.model), ""),
+                        self.part,
+                    ),
+                )
+        elif self.stage == "screening" and self.layout == "ccma":
+            return ("odb_ccma_screen.tar", "")
+        elif re_fullmix.match(self.part) and self.stage == "traj":
+            return ("odb_traj.tar", "")
+        elif (
+            re_fullmix.match(self.part)
+            and self.stage == "minim"
+            and self.model == "aladin"
+        ):
+            return ("odb_cpl.tar", "")
+        elif re_fullmix.match(self.part) and self.stage == "minim":
+            return ("odb_min.tar", "")
+        elif self.part in ("ground", "surf") and self.stage in (
+            "canari",
+            "surfan",
+        ):
+            return ("odb_canari.tar", "")
         else:
             logger.error(
-                'No archive basename defined for such observations (format=%s, part=%s, stage=%s)',
-                self.nativefmt, self.part, self.stage
+                "No archive basename defined for such observations (format=%s, part=%s, stage=%s)",
+                self.nativefmt,
+                self.part,
+                self.stage,
             )
             return (None, None)
 
@@ -180,88 +223,102 @@ class ObsRaw(Observations):
     """
 
     _footprint = dict(
-        info = 'Raw observations set',
-        attr = dict(
-            nativefmt = dict(
-                values  = ['obsoul', 'grib', 'bufr', 'ascii', 'netcdf', 'hdf5'],
-                remap   = dict(
-                    OBSOUL = 'obsoul',
-                    GRIB   = 'grib',
-                    BUFR   = 'bufr',
-                    ASCII  = 'ascii',
-                    NETCDF = 'netcdf',
-                    HDF5   = 'hdf5'
-                )
-            ),
-            stage = dict(
-                values  = ['void', 'extract', 'raw', 'std']
-            ),
-            olivefmt = dict(
-                info     = 'The mapping between Vortex and Olive formats names.',
-                type     = footprints.FPDict,
-                optional = True,
-                default  = footprints.FPDict(
-                    ascii  = 'ascii',
-                    obsoul = 'obsoul',
-                    grib   = 'obsgrib',
-                    bufr   = 'obsbufr',
-                    netcdf = 'netcdf',
-                    hdf5 = 'hdf5',
+        info="Raw observations set",
+        attr=dict(
+            nativefmt=dict(
+                values=["obsoul", "grib", "bufr", "ascii", "netcdf", "hdf5"],
+                remap=dict(
+                    OBSOUL="obsoul",
+                    GRIB="grib",
+                    BUFR="bufr",
+                    ASCII="ascii",
+                    NETCDF="netcdf",
+                    HDF5="hdf5",
                 ),
-                doc_visibility  = footprints.doc.visibility.GURU,
-            )
-        )
+            ),
+            stage=dict(values=["void", "extract", "raw", "std"]),
+            olivefmt=dict(
+                info="The mapping between Vortex and Olive formats names.",
+                type=footprints.FPDict,
+                optional=True,
+                default=footprints.FPDict(
+                    ascii="ascii",
+                    obsoul="obsoul",
+                    grib="obsgrib",
+                    bufr="obsbufr",
+                    netcdf="netcdf",
+                    hdf5="hdf5",
+                ),
+                doc_visibility=footprints.doc.visibility.GURU,
+            ),
+        ),
     )
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return '_'.join((
-            self.olivefmt.get(self.nativefmt, 'obsfoo'),
-            self.stage,
-            self.part
-        ))
+        return "_".join(
+            (
+                self.olivefmt.get(self.nativefmt, "obsfoo"),
+                self.stage,
+                self.part,
+            )
+        )
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        if (re.match(r'^(?:bufr|obsoul|grib|netcdf|hdf5)$', self.nativefmt) and
-                self.part != 'full' and self.stage == 'void'):
-            return '.'.join((self.nativefmt, self.part))
-        elif re.match(r'^obsoul$', self.nativefmt) and self.part == 'full' and self.stage == 'void':
-            return 'obsoul'
+        if (
+            re.match(r"^(?:bufr|obsoul|grib|netcdf|hdf5)$", self.nativefmt)
+            and self.part != "full"
+            and self.stage == "void"
+        ):
+            return ".".join((self.nativefmt, self.part))
+        elif (
+            re.match(r"^obsoul$", self.nativefmt)
+            and self.part == "full"
+            and self.stage == "void"
+        ):
+            return "obsoul"
         else:
             logger.error(
-                'No archive basename defined for such observations (format=%s, part=%s, stage=%s)',
-                self.nativefmt, self.part, self.stage
+                "No archive basename defined for such observations (format=%s, part=%s, stage=%s)",
+                self.nativefmt,
+                self.part,
+                self.stage,
             )
 
 
-@stddeco.namebuilding_insert('radical', lambda s: s.kind)
-@stddeco.namebuilding_insert('src', lambda s: [s.part, ])
+@stddeco.namebuilding_insert("radical", lambda s: s.kind)
+@stddeco.namebuilding_insert(
+    "src",
+    lambda s: [
+        s.part,
+    ],
+)
 class ObsFlags(FlowResource):
     """Class for observations flags."""
 
     _footprint = dict(
-        info = 'Observations flags',
-        attr = dict(
-            kind = dict(
-                values = ['obsflag'],
+        info="Observations flags",
+        attr=dict(
+            kind=dict(
+                values=["obsflag"],
             ),
             nativefmt=dict(
-                values=['ascii', 'txt'],
-                default='txt',
-                remap=dict(ascii='txt'),
+                values=["ascii", "txt"],
+                default="txt",
+                remap=dict(ascii="txt"),
             ),
-            part = dict(),
+            part=dict(),
         ),
     )
 
     @property
     def realkind(self):
-        return 'obsflags'
+        return "obsflags"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'BDM_CQ'
+        return "BDM_CQ"
 
 
 @nicedeco
@@ -278,7 +335,6 @@ def needs_slurp(mtd):
 
 
 class VarBCContent(AlmostListContent):
-
     # The VarBC file is too big: revert to the good old diff
     _diffable = False
 
@@ -305,6 +361,7 @@ class VarBCContent(AlmostListContent):
         if self._parsed_data is None:
             # May fail if Numpy is not installed...
             from bronx.datagrip.varbc import VarbcFile
+
             self._parsed_data = VarbcFile(self.data)
         return self._parsed_data
 
@@ -319,68 +376,86 @@ class VarBCContent(AlmostListContent):
         self._do_delayed_slurp = container
         with container.preferred_decoding(byte=False):
             container.rewind()
-            self._metadata = VarbcHeadersFile([container.readline() for _ in range(3)])
+            self._metadata = VarbcHeadersFile(
+                [container.readline() for _ in range(3)]
+            )
 
 
-@stddeco.namebuilding_append('src', lambda s: [s.stage, ])
+@stddeco.namebuilding_append(
+    "src",
+    lambda s: [
+        s.stage,
+    ],
+)
 class VarBC(FlowResource):
     """
     VarBC file resource. Contains all the coefficients for the VarBC bias correction scheme.
     """
 
     _footprint = dict(
-        info = 'Varbc file (coefficients for the bias correction of observations).',
-        attr = dict(
-            kind = dict(
-                values   = ['varbc']
+        info="Varbc file (coefficients for the bias correction of observations).",
+        attr=dict(
+            kind=dict(values=["varbc"]),
+            clscontents=dict(
+                default=VarBCContent,
             ),
-            clscontents = dict(
-                default  = VarBCContent,
+            nativefmt=dict(
+                values=["ascii", "txt"],
+                default="txt",
+                remap=dict(ascii="txt"),
             ),
-            nativefmt = dict(
-                values   = ['ascii', 'txt'],
-                default  = 'txt',
-                remap    = dict(ascii = 'txt'),
+            stage=dict(
+                optional=True,
+                values=[
+                    "void",
+                    "merge",
+                    "screen",
+                    "screening",
+                    "minim",
+                    "traj",
+                ],
+                remap=dict(screen="screening"),
+                default="void",
             ),
-            stage = dict(
-                optional = True,
-                values   = ['void', 'merge', 'screen', 'screening', 'minim', 'traj'],
-                remap    = dict(screen = 'screening'),
-                default  = 'void'
+            mixmodel=dict(
+                optional=True,
+                default=None,
+                values=stdattrs.models,
             ),
-            mixmodel = dict(
-                optional = True,
-                default  = None,
-                values   = stdattrs.models,
-            ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'varbc'
+        return "varbc"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        olivestage_map = {'screening': 'screen', }
-        return self.realkind.upper() + "." + olivestage_map.get(self.stage, self.stage)
+        olivestage_map = {
+            "screening": "screen",
+        }
+        return (
+            self.realkind.upper()
+            + "."
+            + olivestage_map.get(self.stage, self.stage)
+        )
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        if self.stage in ('void', 'traj'):
-            bname = 'VARBC.cycle'
+        if self.stage in ("void", "traj"):
+            bname = "VARBC.cycle"
             if self.mixmodel is not None:
-                bname += '_'
-                if self.mixmodel.startswith('alad'):
+                bname += "_"
+                if self.mixmodel.startswith("alad"):
                     bname = bname + self.mixmodel[:4]
                 else:
                     bname = bname + self.mixmodel[:3]
         else:
-            bname = 'VARBC.' + self.stage
+            bname = "VARBC." + self.stage
         return bname
 
 
-@stddeco.namebuilding_insert('src', lambda s: s.scope)
+@stddeco.namebuilding_insert("src", lambda s: s.scope)
 class BlackList(FlowResource):
     """
     TODO.
@@ -389,66 +464,73 @@ class BlackList(FlowResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Blacklist file for observations',
-            attr = dict(
-                kind = dict(
-                    values  = ['blacklist'],
+            info="Blacklist file for observations",
+            attr=dict(
+                kind=dict(
+                    values=["blacklist"],
                 ),
-                gvar = dict(
-                    default  = 'blacklist_[scope]',
-                    values   = ['BLACKLIST_LOC', 'BLACKLIST_DIAP', 'BLACKLIST_LOCAL', 'BLACKLIST_GLOBAL'],
-                    remap    = dict(
-                        BLACKLIST_LOCAL  = 'BLACKLIST_LOC',
-                        BLACKLIST_GLOBAL = 'BLACKLIST_DIAP',
-                        blacklist_local  = 'BLACKLIST_LOC',
-                        blacklist_global = 'BLACKLIST_DIAP',
-                    )
+                gvar=dict(
+                    default="blacklist_[scope]",
+                    values=[
+                        "BLACKLIST_LOC",
+                        "BLACKLIST_DIAP",
+                        "BLACKLIST_LOCAL",
+                        "BLACKLIST_GLOBAL",
+                    ],
+                    remap=dict(
+                        BLACKLIST_LOCAL="BLACKLIST_LOC",
+                        BLACKLIST_GLOBAL="BLACKLIST_DIAP",
+                        blacklist_local="BLACKLIST_LOC",
+                        blacklist_global="BLACKLIST_DIAP",
+                    ),
                 ),
-                clscontents = dict(
-                    default  = TextContent,
+                clscontents=dict(
+                    default=TextContent,
                 ),
-                nativefmt = dict(
-                    values  = ['txt'],
-                    default = 'txt'
+                nativefmt=dict(values=["txt"], default="txt"),
+                scope=dict(
+                    values=[
+                        "loc",
+                        "local",
+                        "site",
+                        "global",
+                        "diap",
+                        "diapason",
+                    ],
+                    remap=dict(
+                        loc="local",
+                        site="local",
+                        diap="global",
+                        diapason="global",
+                    ),
                 ),
-                scope = dict(
-                    values  = ['loc', 'local', 'site', 'global', 'diap', 'diapason'],
-                    remap   = dict(
-                        loc      = 'local',
-                        site     = 'local',
-                        diap     = 'global',
-                        diapason = 'global',
-                    )
-                ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'blacklist'
+        return "blacklist"
 
     def iga_pathinfo(self):
         """Standard path information for IGA inline cache."""
-        return dict(
-            model=self.model
-        )
+        return dict(model=self.model)
 
     def archive_map(self):
         """OP ARCHIVE specific naming convention."""
         return {
-            'local': 'LISTE_LOC',
-            'global': 'LISTE_NOIRE_DIAP',
+            "local": "LISTE_LOC",
+            "global": "LISTE_NOIRE_DIAP",
         }
 
     def archive_basename(self):
         """OP ARCHIVE local basename."""
         mapd = self.archive_map()
-        return mapd.get(self.scope, 'LISTE_NOIRE_X')
+        return mapd.get(self.scope, "LISTE_NOIRE_X")
 
 
 #: A namedtuple of the internal fields of an ObsRef file
-ObsRefItem = namedtuple('ObsRefItem', ('data', 'fmt', 'instr', 'date', 'time'))
+ObsRefItem = namedtuple("ObsRefItem", ("data", "fmt", "instr", "date", "time"))
 
 
 class ObsRefContent(TextContent):
@@ -460,51 +542,55 @@ class ObsRefContent(TextContent):
 
     def slurp(self, container):
         with container.preferred_decoding(byte=False):
-            self._data.extend([ObsRefItem(*x.split()[:5]) for x in container if not x.startswith('#')])
+            self._data.extend(
+                [
+                    ObsRefItem(*x.split()[:5])
+                    for x in container
+                    if not x.startswith("#")
+                ]
+            )
             self._size = container.totalsize
 
     @classmethod
     def formatted_data(self, item):
         """Return a formatted string."""
-        return '{:8s} {:8s} {:16s} {:s} {!s}'.format(
+        return "{:8s} {:8s} {:16s} {:s} {!s}".format(
             item.data, item.fmt, item.instr, str(item.date), item.time
         )
 
 
-@stddeco.namebuilding_append('src', lambda s: [s.part, ])
+@stddeco.namebuilding_append(
+    "src",
+    lambda s: [
+        s.part,
+    ],
+)
 class Refdata(FlowResource):
     """
     TODO.
     """
 
     _footprint = dict(
-        info = 'Refdata file',
-        attr = dict(
-            kind = dict(
-                values   = ['refdata']
+        info="Refdata file",
+        attr=dict(
+            kind=dict(values=["refdata"]),
+            clscontents=dict(
+                default=ObsRefContent,
             ),
-            clscontents = dict(
-                default  = ObsRefContent,
+            nativefmt=dict(
+                values=["ascii", "txt"], default="txt", remap=dict(ascii="txt")
             ),
-            nativefmt = dict(
-                values   = ['ascii', 'txt'],
-                default  = 'txt',
-                remap    = dict(ascii = 'txt')
-            ),
-            part = dict(
-                optional = True,
-                default  = 'all'
-            ),
-        )
+            part=dict(optional=True, default="all"),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'refdata'
+        return "refdata"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return self.realkind + '.' + self.part
+        return self.realkind + "." + self.part
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
@@ -512,7 +598,7 @@ class Refdata(FlowResource):
 
 
 #: A namedtuple of the internal fields of an ObsMap file
-ObsMapItem = namedtuple('ObsMapItem', ('odb', 'data', 'fmt', 'instr'))
+ObsMapItem = namedtuple("ObsMapItem", ("odb", "data", "fmt", "instr"))
 
 
 class ObsMapContent(TextContent):
@@ -545,8 +631,8 @@ class ObsMapContent(TextContent):
     """
 
     def __init__(self, **kw):
-        kw.setdefault('discarded', set())
-        kw.setdefault('only', None)
+        kw.setdefault("discarded", set())
+        kw.setdefault("only", None)
         super().__init__(**kw)
 
     @property
@@ -566,30 +652,41 @@ class ObsMapContent(TextContent):
     def slurp(self, container):
         """Get data from the ``container``."""
         if self.only is not None:
-            ofilters = [re.compile(d if ':' in d else d + ':')
-                        for d in self.only]
+            ofilters = [
+                re.compile(d if ":" in d else d + ":") for d in self.only
+            ]
         else:
             ofilters = None
-        dfilters = [re.compile(d if ':' in d else d + ':') for d in self.discarded]
+        dfilters = [
+            re.compile(d if ":" in d else d + ":") for d in self.discarded
+        ]
 
         def item_filter(omline):
-            om = ':'.join([omline.odb, omline.data])
-            return ((ofilters is None or
-                     any([f.match(om) for f in ofilters])) and
-                    not any([f.match(om) for f in dfilters]))
+            om = ":".join([omline.odb, omline.data])
+            return (
+                ofilters is None or any([f.match(om) for f in ofilters])
+            ) and not any([f.match(om) for f in dfilters])
 
         with container.preferred_decoding(byte=False):
             container.rewind()
-            self.extend(filter(item_filter,
-                               [ObsMapItem(* x.split())
-                                for x in [line.strip() for line in container]
-                                if x and not x.startswith('#')]))
+            self.extend(
+                filter(
+                    item_filter,
+                    [
+                        ObsMapItem(*x.split())
+                        for x in [line.strip() for line in container]
+                        if x and not x.startswith("#")
+                    ],
+                )
+            )
             self._size = container.totalsize
 
     @classmethod
     def formatted_data(self, item):
         """Return a formatted string."""
-        return '{:12s} {:12s} {:12s} {:s}'.format(item.odb, item.data, item.fmt, item.instr)
+        return "{:12s} {:12s} {:12s} {:s}".format(
+            item.odb, item.data, item.fmt, item.instr
+        )
 
     def odbset(self):
         """Return set of odb values."""
@@ -623,15 +720,15 @@ class ObsMapContent(TextContent):
 
         These naming convention refer to the footprints resolve mechanism.
         """
-        part = g.get('part', x.get('part', None))
+        part = g.get("part", x.get("part", None))
         if part is None:
             return None
         else:
             return self.datafmt(part)
 
 
-@stddeco.namebuilding_insert('style', lambda s: 'obsmap')
-@stddeco.namebuilding_insert('stage', lambda s: [s.scope, s.stage])
+@stddeco.namebuilding_insert("style", lambda s: "obsmap")
+@stddeco.namebuilding_insert("stage", lambda s: [s.scope, s.stage])
 class ObsMap(FlowResource):
     """Observation mapping.
 
@@ -648,46 +745,43 @@ class ObsMap(FlowResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Bator mapping file',
-            attr = dict(
-                kind = dict(
-                    values   = ['obsmap'],
+            info="Bator mapping file",
+            attr=dict(
+                kind=dict(
+                    values=["obsmap"],
                 ),
-                clscontents = dict(
-                    default  = ObsMapContent,
+                clscontents=dict(
+                    default=ObsMapContent,
                 ),
-                nativefmt = dict(
-                    values   = ['ascii', 'txt'],
-                    default  = 'txt',
-                    remap    = dict(ascii = 'txt')
+                nativefmt=dict(
+                    values=["ascii", "txt"],
+                    default="txt",
+                    remap=dict(ascii="txt"),
                 ),
-                stage = dict(
-                    optional = True,
-                    default  = 'void'
+                stage=dict(optional=True, default="void"),
+                scope=dict(
+                    optional=True,
+                    default="full",
+                    remap=dict(surf="surface"),
                 ),
-                scope = dict(
-                    optional = True,
-                    default  = 'full',
-                    remap = dict(surf = 'surface'),
+                discard=dict(
+                    info="Discard some lines of the mapping (see the class documentation).",
+                    type=footprints.FPSet,
+                    optional=True,
+                    default=footprints.FPSet(),
                 ),
-                discard = dict(
-                    info     = "Discard some lines of the mapping (see the class documentation).",
-                    type     = footprints.FPSet,
-                    optional = True,
-                    default  = footprints.FPSet(),
+                only=dict(
+                    info="Only retain some lines of the mapping (see the class documentation).",
+                    type=footprints.FPSet,
+                    optional=True,
                 ),
-                only = dict(
-                    info     = "Only retain some lines of the mapping (see the class documentation).",
-                    type     = footprints.FPSet,
-                    optional = True,
-                )
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'obsmap'
+        return "obsmap"
 
     def contents_args(self):
         """Returns default arguments value to class content constructor."""
@@ -695,54 +789,52 @@ class ObsMap(FlowResource):
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'OBSMAP_' + self.stage
+        return "OBSMAP_" + self.stage
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        if self.scope.startswith('surf'):
-            return 'BATOR_MAP_' + self.scope[:4].lower()
+        if self.scope.startswith("surf"):
+            return "BATOR_MAP_" + self.scope[:4].lower()
         else:
-            return 'BATOR_MAP'
+            return "BATOR_MAP"
 
     def genv_basename(self):
         """Genv key naming convention."""
-        cutoff_map = {'production': 'prod'}
+        cutoff_map = {"production": "prod"}
         if self.gvar is None:
-            if self.scope == 'surface':
-                gkey = 'bator_map_surf'
+            if self.scope == "surface":
+                gkey = "bator_map_surf"
             else:
-                gkey = 'bator_map_' + cutoff_map.get(self.cutoff, self.cutoff)
+                gkey = "bator_map_" + cutoff_map.get(self.cutoff, self.cutoff)
             return GenvKey(gkey)
         else:
             return self.gvar
 
 
-@stddeco.namebuilding_insert('src', lambda s: s.satbias)
+@stddeco.namebuilding_insert("src", lambda s: s.satbias)
 class Bcor(FlowResource):
     """Bias correction parameters."""
 
     _footprint = dict(
-        info = 'Bias correction parameters',
-        attr = dict(
-            kind = dict(
-                values  = ['bcor'],
+        info="Bias correction parameters",
+        attr=dict(
+            kind=dict(
+                values=["bcor"],
             ),
-            nativefmt = dict(
-                values  = ['ascii', 'txt'],
-                default = 'txt',
-                remap   = dict(ascii = 'txt')
+            nativefmt=dict(
+                values=["ascii", "txt"], default="txt", remap=dict(ascii="txt")
             ),
-            satbias = dict(
-                values  = ['mtop', 'metop', 'noaa', 'ssmi'],
-                remap   = dict(metop = 'mtop'),
+            satbias=dict(
+                values=["mtop", "metop", "noaa", "ssmi"],
+                remap=dict(metop="mtop"),
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bcor'
+        return "bcor"
 
     def archive_basename(self):
         """OP ARCHIVE specific naming convention."""
-        return 'bcor_' + self.satbias + '.dat'
+        return "bcor_" + self.satbias + ".dat"

--- a/src/vortex/nwp/data/oopsexec.py
+++ b/src/vortex/nwp/data/oopsexec.py
@@ -11,7 +11,7 @@ from vortex.syntax.stddeco import namebuilding_append
 __all__ = []
 
 
-@namebuilding_append('src', lambda self: self.run)
+@namebuilding_append("src", lambda self: self.run)
 class OOPSBinary(NWPModel):
     """Yet an other OOPS Binary."""
 
@@ -21,30 +21,32 @@ class OOPSBinary(NWPModel):
         oops_run,
         executable_flavour_deco,
         dict(
-            info = 'OOPS Binary: an OOPS binary, dedicated to a task (a run in OOPS namespace).',
-            attr = dict(
-                kind = dict(
-                    values = ['oopsbinary', ],
+            info="OOPS Binary: an OOPS binary, dedicated to a task (a run in OOPS namespace).",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "oopsbinary",
+                    ],
                 ),
-                gvar = dict(
-                    default = 'master_[run]',
+                gvar=dict(
+                    default="master_[run]",
                 ),
-                run = dict(
-                    outcast = known_oops_testcomponent_runs,
+                run=dict(
+                    outcast=known_oops_testcomponent_runs,
                 ),
-            )
-        )
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'oopsbinary'
+        return "oopsbinary"
 
     def command_line(self, configfile):
         """
         Build command line for execution as a single string.
         """
-        cmdline = '{}'.format(configfile)
+        cmdline = "{}".format(configfile)
         return cmdline
 
 
@@ -52,11 +54,11 @@ class OOPSTestComponent(OOPSBinary):
     """Binary for OOPS Tests of components."""
 
     _footprint = dict(
-        info = 'OOPS Component Test: can run a sub-test or a family of sub-tests',
-        attr = dict(
-            run = dict(
-                values   = known_oops_testcomponent_runs,
-                outcast  = [],
+        info="OOPS Component Test: can run a sub-test or a family of sub-tests",
+        attr=dict(
+            run=dict(
+                values=known_oops_testcomponent_runs,
+                outcast=[],
             ),
         ),
     )
@@ -65,8 +67,8 @@ class OOPSTestComponent(OOPSBinary):
         """
         Build command line for execution as a single string.
         """
-        cmdline = ''
+        cmdline = ""
         if test_type is not None:
-            cmdline += '-t {} '.format(test_type)
+            cmdline += "-t {} ".format(test_type)
         cmdline += super().command_line(configfile)
         return cmdline

--- a/src/vortex/nwp/data/query.py
+++ b/src/vortex/nwp/data/query.py
@@ -23,84 +23,66 @@ class Query(StaticResource):
     _footprint = [
         gvar,
         dict(
-            info = 'Abstract class for queries.',
-            attr = dict(
-                gvar = dict(
-                    values  = ['extract_stuff'],
-                    default = 'extract_stuff'
-                ),
-                source = dict(),
-                origin = dict(),
+            info="Abstract class for queries.",
+            attr=dict(
+                gvar=dict(values=["extract_stuff"], default="extract_stuff"),
+                source=dict(),
+                origin=dict(),
             ),
-        )
+        ),
     ]
 
     def gget_urlquery(self):
         """GGET specific query : ``extract``."""
-        return 'extract=' + self.source
+        return "extract=" + self.source
 
 
 class BDAPQuery(Query):
     """Class to deal with BDAP queries."""
+
     _footprint = dict(
-        info = 'BDAP query',
-        attr = dict(
-            kind = dict(
-                values = ['bdap_query']
-            ),
-            origin = dict(
-                default = 'bdap',
-                values = ['bdap'],
-                optional = True
-            )
-        )
+        info="BDAP query",
+        attr=dict(
+            kind=dict(values=["bdap_query"]),
+            origin=dict(default="bdap", values=["bdap"], optional=True),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bdap_query'
+        return "bdap_query"
 
 
 class BDMPQuery(Query):
     """Class to deal with BDMP queries."""
+
     _footprint = dict(
-        info = 'BDMP query',
-        attr = dict(
-            kind = dict(
-                values = ['bdmp_query']
-            ),
-            origin = dict(
-                default = 'bdmp',
-                values = ['bdmp'],
-                optional = True
-            )
-        )
+        info="BDMP query",
+        attr=dict(
+            kind=dict(values=["bdmp_query"]),
+            origin=dict(default="bdmp", values=["bdmp"], optional=True),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bdmp_query'
+        return "bdmp_query"
 
 
 class BDCPQuery(Query):
     """Class to deal with BDCP queries."""
+
     _footprint = dict(
-        info = 'BDCP query',
-        attr = dict(
-            kind = dict(
-                values = ['bdcp_query']
-            ),
-            origin = dict(
-                default = 'bdcp',
-                values = ['bdcp'],
-                optional = True
-            ),
-        )
+        info="BDCP query",
+        attr=dict(
+            kind=dict(values=["bdcp_query"]),
+            origin=dict(default="bdcp", values=["bdcp"], optional=True),
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bdcp_query'
+        return "bdcp_query"
 
 
 class StaticCutoffDispenser:
@@ -116,8 +98,9 @@ class StaticCutoffDispenser:
     def __init__(self, default_cutoff, obstype_cutoffs=None):
         self._default_cutoff = default_cutoff
         if obstype_cutoffs:
-            self._cutoffs = {k: {o.lower() for o in v}
-                             for k, v in obstype_cutoffs.items()}
+            self._cutoffs = {
+                k: {o.lower() for o in v} for k, v in obstype_cutoffs.items()
+            }
         else:
             self._cutoffs = {}
 
@@ -150,66 +133,72 @@ class BDMQueryContent(AlmostListContent):
         information in the BDM query.
         """
         if cutoffs_dispenser.max_cutoff is None:
-            logger.warning("The cutoffs_dispenser is empty. No cutoff data can be retrieved")
+            logger.warning(
+                "The cutoffs_dispenser is empty. No cutoff data can be retrieved"
+            )
         else:
             xdata = list()
             for line in self:
                 xdata.append(line)
                 l_match = self._RE_OBSTYPE.match(line)
                 if l_match:
-                    cutoff_fmt = '{0:s}{1:<' + str(len(l_match.group(2))) + 's}:{2:s}{3.ymdhms:s}\n'
+                    cutoff_fmt = (
+                        "{0:s}{1:<"
+                        + str(len(l_match.group(2)))
+                        + "s}:{2:s}{3.ymdhms:s}\n"
+                    )
                     cutoff_date = cutoffs_dispenser(l_match.group(4))
-                    xdata.append(cutoff_fmt.format(l_match.group(1),
-                                                   'CUTOFF',
-                                                   l_match.group(3),
-                                                   cutoff_date))
-                    logger.info('CUTOFF=%s added for obstype < %s >.',
-                                cutoff_date.ymdhms, l_match.group(4))
+                    xdata.append(
+                        cutoff_fmt.format(
+                            l_match.group(1),
+                            "CUTOFF",
+                            l_match.group(3),
+                            cutoff_date,
+                        )
+                    )
+                    logger.info(
+                        "CUTOFF=%s added for obstype < %s >.",
+                        cutoff_date.ymdhms,
+                        l_match.group(4),
+                    )
             self._data = xdata
 
 
 class BDMQuery(Query):
     """Class to deal with BDM queries."""
+
     _footprint = dict(
-        info = 'BDM query',
-        attr = dict(
-            kind = dict(
-                values = ['bdm_query']
-            ),
-            origin = dict(
-                default = 'bdm',
-                values = ['bdm'],
-                optional = True
-            ),
+        info="BDM query",
+        attr=dict(
+            kind=dict(values=["bdm_query"]),
+            origin=dict(default="bdm", values=["bdm"], optional=True),
             clscontents=dict(
-                default = BDMQueryContent,
+                default=BDMQueryContent,
             ),
-        )
+        ),
     )
 
     @property
     def realkind(self):
-        return 'bdm_query'
+        return "bdm_query"
 
 
 class MarsQuery(Query):
     """Class to deal with Mars queries"""
 
     _footprint = dict(
-        info = 'Mars query',
-        attr = dict(
-            kind = dict(
-                values = ['mars_query']
+        info="Mars query",
+        attr=dict(
+            kind=dict(values=["mars_query"]),
+            origin=dict(
+                default="mars",
+                values=[
+                    "mars",
+                ],
+                optional=True,
             ),
-            origin = dict(
-                default = "mars",
-                values = ["mars", ],
-                optional = True
-            ),
-            clscontents=dict(
-                default = DataTemplate
-            ),
-        )
+            clscontents=dict(default=DataTemplate),
+        ),
     )
 
     @property

--- a/src/vortex/nwp/data/surfex.py
+++ b/src/vortex/nwp/data/surfex.py
@@ -10,7 +10,7 @@ from ..syntax.stdattrs import gvar
 __all__ = []
 
 
-@namebuilding_delete('src')
+@namebuilding_delete("src")
 class PGDRaw(ModelGeoResource):
     """
     SURFEX climatological resource.
@@ -18,34 +18,39 @@ class PGDRaw(ModelGeoResource):
 
     :note: OBSOLETE classes do not use.
     """
+
     _abstract = True
     _footprint = [
         gvar,
         dict(
-            info = 'Surfex climatological file',
-            attr = dict(
-                gvar = dict(
-                    default  = 'pgd_[nativefmt]',
+            info="Surfex climatological file",
+            attr=dict(
+                gvar=dict(
+                    default="pgd_[nativefmt]",
                 ),
-            )
-        )
+            ),
+        ),
     ]
-    _extension_remap = dict(netcdf='nc')
+    _extension_remap = dict(netcdf="nc")
 
     @property
     def realkind(self):
-        return 'pgd'
+        return "pgd"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'PGDFILE-' + self.geometry.area + '.' + self.nativefmt
+        return "PGDFILE-" + self.geometry.area + "." + self.nativefmt
 
     def namebuilding_info(self):
         nbi = super().namebuilding_info()
         nbi.update(
             # will work only with the @cen namebuilder:
-            cen_rawbasename=('PGD_' + self.geometry.area + '.' +
-                             self._extension_remap.get(self.nativefmt, self.nativefmt))
+            cen_rawbasename=(
+                "PGD_"
+                + self.geometry.area
+                + "."
+                + self._extension_remap.get(self.nativefmt, self.nativefmt)
+            )
             # With the standard provider, the usual keys will be used...
         )
         return nbi
@@ -58,16 +63,17 @@ class PGDLFI(PGDRaw):
 
     :note: OBSOLETE classes do not use.
     """
+
     _footprint = dict(
-        info = 'Grid-point data consts',
-        attr = dict(
-            kind = dict(
-                values  = ['pgdlfi'],
+        info="Grid-point data consts",
+        attr=dict(
+            kind=dict(
+                values=["pgdlfi"],
             ),
-            nativefmt = dict(
-                default = 'lfi',
-            )
-        )
+            nativefmt=dict(
+                default="lfi",
+            ),
+        ),
     )
 
 
@@ -78,16 +84,17 @@ class PGDFA(PGDRaw):
 
     :note: OBSOLETE classes do not use.
     """
+
     _footprint = dict(
-        info = 'Grid-point data consts',
-        attr = dict(
-            kind = dict(
-                values  = ['pgdfa'],
+        info="Grid-point data consts",
+        attr=dict(
+            kind=dict(
+                values=["pgdfa"],
             ),
-            nativefmt = dict(
-                default = 'fa',
-            )
-        )
+            nativefmt=dict(
+                default="fa",
+            ),
+        ),
     )
 
 
@@ -98,52 +105,56 @@ class PGDNC(PGDRaw):
 
     :note: OBSOLETE classes do not use.
     """
+
     _footprint = dict(
-        info = 'Grid-point data consts',
-        attr = dict(
-            kind = dict(
-                values  = ['pgdnc'],
+        info="Grid-point data consts",
+        attr=dict(
+            kind=dict(
+                values=["pgdnc"],
             ),
-            nativefmt = dict(
-                default = 'netcdf',
-            )
-        )
+            nativefmt=dict(
+                default="netcdf",
+            ),
+        ),
     )
 
 
-@namebuilding_delete('src')
+@namebuilding_delete("src")
 class PGDWithGeo(ModelGeoResource):
     """
     SURFEX climatological resource.
     A Genvkey can be provided.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Surfex climatological file',
-            attr = dict(
-                kind = dict(
-                    values  = ['pgd', ],
+            info="Surfex climatological file",
+            attr=dict(
+                kind=dict(
+                    values=[
+                        "pgd",
+                    ],
                 ),
-                nativefmt = dict(
-                    values  = ['fa', 'lfi', 'netcdf', 'txt'],
-                    default = 'fa',
+                nativefmt=dict(
+                    values=["fa", "lfi", "netcdf", "txt"],
+                    default="fa",
                 ),
-                gvar = dict(
-                    default = 'pgd_[geometry::gco_grid_def]_[nativefmt]',
+                gvar=dict(
+                    default="pgd_[geometry::gco_grid_def]_[nativefmt]",
                 ),
-            )
-        )
+            ),
+        ),
     ]
-    _extension_remap = dict(netcdf='nc')
+    _extension_remap = dict(netcdf="nc")
 
     @property
     def realkind(self):
-        return 'pgd'
+        return "pgd"
 
     def olive_basename(self):
         """OLIVE specific naming convention."""
-        return 'PGDFILE-' + self.geometry.area + '.' + self.nativefmt
+        return "PGDFILE-" + self.geometry.area + "." + self.nativefmt
 
 
 class CoverParams(ModelGeoResource):
@@ -151,30 +162,29 @@ class CoverParams(ModelGeoResource):
     Class of a tar-zip set of coefficients for radiative transfers computations.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Coefficients of RRTM scheme',
-            attr = dict(
-                kind = dict(
-                    values   = ['coverparams', 'surfexcover'],
-                    remap    = dict(surfexcover = 'coverparams'),
+            info="Coefficients of RRTM scheme",
+            attr=dict(
+                kind=dict(
+                    values=["coverparams", "surfexcover"],
+                    remap=dict(surfexcover="coverparams"),
                 ),
-                source = dict(
-                    optional = True,
-                    default  = 'ecoclimap',
-                    values   = ['ecoclimap', 'ecoclimap1', 'ecoclimap2'],
+                source=dict(
+                    optional=True,
+                    default="ecoclimap",
+                    values=["ecoclimap", "ecoclimap1", "ecoclimap2"],
                 ),
-                gvar = dict(
-                    default  = '[source]_covers_param'
-                ),
-            )
-        )
+                gvar=dict(default="[source]_covers_param"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'coverparams'
+        return "coverparams"
 
 
 class IsbaParams(ModelGeoResource):
@@ -182,25 +192,24 @@ class IsbaParams(ModelGeoResource):
     Class of surface (vegetations, etc.) coefficients.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'ISBA parameters',
-            attr = dict(
-                kind = dict(
-                    values   = ['isba', 'isbaan'],
-                    remap    = dict(isbaan = 'isba'),
+            info="ISBA parameters",
+            attr=dict(
+                kind=dict(
+                    values=["isba", "isbaan"],
+                    remap=dict(isbaan="isba"),
                 ),
-                gvar = dict(
-                    default  = 'analyse_isba'
-                ),
-            )
-        )
+                gvar=dict(default="analyse_isba"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'isba'
+        return "isba"
 
 
 class SandDB(ModelGeoResource):
@@ -208,26 +217,24 @@ class SandDB(ModelGeoResource):
     Class of a tar-zip (.dir/.hdr) file containing surface sand database.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for quantity of sand in soil',
-            attr = dict(
-                kind = dict(
-                    values   = ['sand'],
+            info="Database for quantity of sand in soil",
+            attr=dict(
+                kind=dict(
+                    values=["sand"],
                 ),
-                source = dict(
-                ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                source=dict(),
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'sand'
+        return "sand"
 
 
 class ClayDB(ModelGeoResource):
@@ -235,26 +242,24 @@ class ClayDB(ModelGeoResource):
     Class of a tar-zip (.dir/.hdr) file containing surface clay database.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for quantity of clay in soil',
-            attr = dict(
-                kind = dict(
-                    values   = ['clay'],
+            info="Database for quantity of clay in soil",
+            attr=dict(
+                kind=dict(
+                    values=["clay"],
                 ),
-                source = dict(
-                ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                source=dict(),
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'clay'
+        return "clay"
 
 
 class OrographyDB(ModelGeoResource):
@@ -262,26 +267,24 @@ class OrographyDB(ModelGeoResource):
     Class of a tar-zip (.dir/.hdr) file containing orography database.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for orography',
-            attr = dict(
-                kind = dict(
-                    values   = ['orography'],
+            info="Database for orography",
+            attr=dict(
+                kind=dict(
+                    values=["orography"],
                 ),
-                source = dict(
-                ),
-                gvar = dict(
-                    default  = '[source]_[kind]_[geometry::rnice_u]'
-                ),
-            )
-        )
+                source=dict(),
+                gvar=dict(default="[source]_[kind]_[geometry::rnice_u]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'orography'
+        return "orography"
 
 
 class SurfaceTypeDB(ModelGeoResource):
@@ -289,26 +292,24 @@ class SurfaceTypeDB(ModelGeoResource):
     Class of a tar-zip (.dir/.hdr) file containing surface type database.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for surface type',
-            attr = dict(
-                kind = dict(
-                    values   = ['surface_type'],
+            info="Database for surface type",
+            attr=dict(
+                kind=dict(
+                    values=["surface_type"],
                 ),
-                source = dict(
-                ),
-                gvar = dict(
-                    default  = '[source]_[kind]'
-                ),
-            )
-        )
+                source=dict(),
+                gvar=dict(default="[source]_[kind]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'surface_type'
+        return "surface_type"
 
 
 class BathymetryDB(ModelGeoResource):
@@ -316,23 +317,21 @@ class BathymetryDB(ModelGeoResource):
     Class of file containing bathymetry database.
     A Genvkey can be given.
     """
+
     _footprint = [
         gvar,
         dict(
-            info = 'Database for bathymetry',
-            attr = dict(
-                kind = dict(
-                    values   = ['bathymetry'],
+            info="Database for bathymetry",
+            attr=dict(
+                kind=dict(
+                    values=["bathymetry"],
                 ),
-                source = dict(
-                ),
-                gvar = dict(
-                    default  = '[source]_[kind]_[geometry::rnice_u]'
-                ),
-            )
-        )
+                source=dict(),
+                gvar=dict(default="[source]_[kind]_[geometry::rnice_u]"),
+            ),
+        ),
     ]
 
     @property
     def realkind(self):
-        return 'bathymetry'
+        return "bathymetry"

--- a/src/vortex/nwp/syntax/__init__.py
+++ b/src/vortex/nwp/syntax/__init__.py
@@ -6,4 +6,4 @@ The most important usage is done by :class:`FootprintBase` derivated objects.
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'nwp module where standard attributes are defined.'
+__tocinfoline__ = "nwp module where standard attributes are defined."

--- a/src/vortex/nwp/syntax/stdattrs.py
+++ b/src/vortex/nwp/syntax/stdattrs.py
@@ -12,17 +12,19 @@ __all__ = []
 
 #: Usual Footprint for a single member (in an algo Component)
 a_algo_member = dict(
-    info=("The current member's number " +
-          "(may be omitted in deterministic configurations)."),
+    info=(
+        "The current member's number "
+        + "(may be omitted in deterministic configurations)."
+    ),
     optional=True,
-    type=int
+    type=int,
 )
 
 #: Usual Footprint of the ``outputid`` attribute.
 algo_member = footprints.Footprint(attr=dict(member=a_algo_member))
 
 #: Known OOPS testcomponent ``run``
-known_oops_testcomponent_runs = ['ootestcomponent', 'testcomponent', 'testvar']
+known_oops_testcomponent_runs = ["ootestcomponent", "testcomponent", "testvar"]
 
 #: Usual definition of the ``run`` attribute for OOPS binaries.
 a_oops_run = dict(
@@ -30,41 +32,51 @@ a_oops_run = dict(
     optional=False,
 )
 #: Usual Footprint of the ``run`` attribute for OOPS binaries.
-oops_run = footprints.Footprint(info='OOPS kind of run', attr=dict(run=a_oops_run))
+oops_run = footprints.Footprint(
+    info="OOPS kind of run", attr=dict(run=a_oops_run)
+)
 
 #: Usual definition of the ``test_type`` attribute.
 a_oops_test_type = dict(
-    info='Sub-test or family of sub-tests to be ran.',
+    info="Sub-test or family of sub-tests to be ran.",
     optional=False,
 )
 #: Usual Footprint of the ``test_type`` attribute.
-oops_test_type = footprints.Footprint(info='OOPS type of test', attr=dict(test_type=a_oops_test_type))
+oops_test_type = footprints.Footprint(
+    info="OOPS type of test", attr=dict(test_type=a_oops_test_type)
+)
 
 #: Usual definition of the ``expected_target`` attribute.
 an_oops_expected_target = dict(
-    info=('Expected target for the test success'),
+    info=("Expected target for the test success"),
     type=footprints.FPDict,
     optional=True,
-    default=None
+    default=None,
 )
 #: Usual Footprint of the ``expected_target`` attribute.
-oops_expected_target = footprints.Footprint(attr=dict(expected_target=an_oops_expected_target))
+oops_expected_target = footprints.Footprint(
+    attr=dict(expected_target=an_oops_expected_target)
+)
 
 #: Usual Footprint of a combined lists of members and terms
 oops_members_terms_lists = footprints.Footprint(
     info="Abstract footprint for a members/terms list.",
     attr=dict(
         members=dict(
-            info='A list of members.',
+            info="A list of members.",
             type=footprints.FPList,
         ),
         terms=dict(
-            info='A list of effective terms.',
+            info="A list of effective terms.",
             type=footprints.FPList,
             optional=True,
-            default=footprints.FPList([Time(0), ])
+            default=footprints.FPList(
+                [
+                    Time(0),
+                ]
+            ),
         ),
-    )
+    ),
 )
 
 #: Usual definition of the ``outputid`` attribute
@@ -79,15 +91,20 @@ outputid = footprints.Footprint(attr=dict(outputid=a_outputid))
 
 def _apply_outputid(cls):
     """Decorator that tweak the class in order to add OUTPUTID on the namelist"""
-    orig_pnd = getattr(cls, 'prepare_namelist_delta', None)
+    orig_pnd = getattr(cls, "prepare_namelist_delta", None)
     if orig_pnd is None:
-        raise ImportError('_apply_outputid can not be applied on {!s}'.format(cls))
+        raise ImportError(
+            "_apply_outputid can not be applied on {!s}".format(cls)
+        )
 
     def prepare_namelist_delta(self, rh, namcontents, namlocal):
         namw = orig_pnd(self, rh, namcontents, namlocal)
-        if self.outputid is not None and any(['OUTPUTID' in nam_b.macros()
-                                              for nam_b in namcontents.values()]):
-            self._set_nam_macro(namcontents, namlocal, 'OUTPUTID', self.outputid)
+        if self.outputid is not None and any(
+            ["OUTPUTID" in nam_b.macros() for nam_b in namcontents.values()]
+        ):
+            self._set_nam_macro(
+                namcontents, namlocal, "OUTPUTID", self.outputid
+            )
             namw = True
         return namw
 
@@ -96,16 +113,29 @@ def _apply_outputid(cls):
 
 
 #: Decorated footprint for the ``outputid`` attribute
-outputid_deco = footprints.DecorativeFootprint(outputid,
-                                               decorator=[_apply_outputid, ])
+outputid_deco = footprints.DecorativeFootprint(
+    outputid,
+    decorator=[
+        _apply_outputid,
+    ],
+)
 
 
 def show():
     """Returns available items and their type."""
     dmod = globals()
-    for stda in sorted(filter(lambda x: x.startswith('a_') or isinstance(dmod[x], footprints.Footprint),
-                              dmod.keys())):
-        print('{} ( {} ) :\n  {}\n'.format(stda, type(dmod[stda]).__name__, dmod[stda]))
+    for stda in sorted(
+        filter(
+            lambda x: x.startswith("a_")
+            or isinstance(dmod[x], footprints.Footprint),
+            dmod.keys(),
+        )
+    ):
+        print(
+            "{} ( {} ) :\n  {}\n".format(
+                stda, type(dmod[stda]).__name__, dmod[stda]
+            )
+        )
 
 
 """
@@ -122,7 +152,7 @@ import footprints
 from vortex.syntax.stddeco import namebuilding_append
 
 #: Export some new class for attributes in footprint objects, eg : GenvKey
-__all__ = ['GenvKey', 'GenvDomain']
+__all__ = ["GenvKey", "GenvDomain"]
 
 domain_remap = dict()
 
@@ -141,18 +171,18 @@ class GenvKey(str):
 
     def __new__(cls, value):
         """Proxy to ``str.__new___`` with attributes inside brackets translated to lower case."""
-        return str.__new__(cls, re.sub(r'\[\w+\]', _lowerattr, value.upper()))
+        return str.__new__(cls, re.sub(r"\[\w+\]", _lowerattr, value.upper()))
 
 
-a_gvar = dict(info='The key that identifies the resource in the Genv database.',
-              type=GenvKey,
-              optional=True,
-              doc_visibility=footprints.doc.visibility.ADVANCED,
-              )
+a_gvar = dict(
+    info="The key that identifies the resource in the Genv database.",
+    type=GenvKey,
+    optional=True,
+    doc_visibility=footprints.doc.visibility.ADVANCED,
+)
 
 #: Usual definition of the ``genv`` attribute.
-gvar = footprints.Footprint(info='A GENV access key',
-                            attr=dict(gvar=a_gvar))
+gvar = footprints.Footprint(info="A GENV access key", attr=dict(gvar=a_gvar))
 
 
 class GenvDomain(str):
@@ -166,15 +196,18 @@ class GenvDomain(str):
         return str.__new__(cls, domain_remap.get(value, value))
 
 
-a_gdomain = dict(info="The resource's geographical domain name in the Genv database.",
-                 type=GenvDomain,
-                 optional=True,
-                 default='[geometry::area]',
-                 doc_visibility=footprints.doc.visibility.ADVANCED,)
+a_gdomain = dict(
+    info="The resource's geographical domain name in the Genv database.",
+    type=GenvDomain,
+    optional=True,
+    default="[geometry::area]",
+    doc_visibility=footprints.doc.visibility.ADVANCED,
+)
 
 #: Usual definition of the ``gdomain`` attribute.
-gdomain = footprints.Footprint(info='A domain name in GCO convention',
-                               attr=dict(gdomain=a_gdomain))
+gdomain = footprints.Footprint(
+    info="A domain name in GCO convention", attr=dict(gdomain=a_gdomain)
+)
 
 
 @total_ordering
@@ -187,22 +220,33 @@ class ArpIfsSimplifiedCycle:
 
     It can be used in a footprint specification.
     """
-    _cy_re = re.compile(r'(?:u(?:env|get):)?(?:cy|al)(\d+)(?:t(\d{1,3}))?(?=_|@|\.|$)(?:.*?(?:[_-]op(\d{1,3})))?')
+
+    _cy_re = re.compile(
+        r"(?:u(?:env|get):)?(?:cy|al)(\d+)(?:t(\d{1,3}))?(?=_|@|\.|$)(?:.*?(?:[_-]op(\d{1,3})))?"
+    )
     _hash_shift = 10000
 
     def __init__(self, cyclestr):
         cy_match = self._cy_re.match(cyclestr)
         if cy_match:
             self._number = int(cy_match.group(1))
-            self._toulouse = (int(cy_match.group(2)) + 1
-                              if cy_match.group(2) is not None else 0)
-            self._op = (int(cy_match.group(3)) + 1
-                        if cy_match.group(3) is not None else 0)
+            self._toulouse = (
+                int(cy_match.group(2)) + 1
+                if cy_match.group(2) is not None
+                else 0
+            )
+            self._op = (
+                int(cy_match.group(3)) + 1
+                if cy_match.group(3) is not None
+                else 0
+            )
         else:
-            raise ValueError('Malformed cycle: {}'.format(cyclestr))
+            raise ValueError("Malformed cycle: {}".format(cyclestr))
 
     def __hash__(self):
-        return (self._number * self._hash_shift + self._toulouse) * self._hash_shift + self._op
+        return (
+            self._number * self._hash_shift + self._toulouse
+        ) * self._hash_shift + self._op
 
     def __eq__(self, other):
         if not isinstance(other, ArpIfsSimplifiedCycle):
@@ -218,39 +262,51 @@ class ArpIfsSimplifiedCycle:
         return hash(self) > hash(other)
 
     def __str__(self):
-        return ('cy{:d}'.format(self._number) +
-                ('t{:d}'.format(self._toulouse - 1) if self._toulouse else '') +
-                ('_op{:d}'.format(self._op - 1) if self._op else ''))
+        return (
+            "cy{:d}".format(self._number)
+            + ("t{:d}".format(self._toulouse - 1) if self._toulouse else "")
+            + ("_op{:d}".format(self._op - 1) if self._op else "")
+        )
 
     def __repr__(self):
-        return '<{} | {!s}>'.format(object.__repr__(self).lstrip('<').rstrip('>'), self)
+        return "<{} | {!s}>".format(
+            object.__repr__(self).lstrip("<").rstrip(">"), self
+        )
 
     def export_dict(self):
         """The pure dict/json output is the raw integer"""
         return str(self)
 
 
-a_arpifs_cycle = dict(info="An Arpege/IFS cycle name",
-                      type=ArpIfsSimplifiedCycle,
-                      optional=True,
-                      default='cy40',  # For "old" Olive configurations to keep working
-                      )
+a_arpifs_cycle = dict(
+    info="An Arpege/IFS cycle name",
+    type=ArpIfsSimplifiedCycle,
+    optional=True,
+    default="cy40",  # For "old" Olive configurations to keep working
+)
 
 #: Usual definition of the ``cycle`` attribute.
-arpifs_cycle = footprints.Footprint(info='An abstract arpifs_cycle in GCO convention',
-                                    attr=dict(cycle=a_arpifs_cycle))
+arpifs_cycle = footprints.Footprint(
+    info="An abstract arpifs_cycle in GCO convention",
+    attr=dict(cycle=a_arpifs_cycle),
+)
 
-uget_sloppy_id_regex = re.compile(r'(?P<shortuget>(?P<id>\S+)@(?P<location>[-\w]+))')
-uget_id_regex = r'(?P<fulluget>u(?:get|env):' + uget_sloppy_id_regex.pattern + ')'
-uget_id_regex_only = re.compile('^' + uget_id_regex + '$')
-uget_id_regex = re.compile(r'\b' + uget_id_regex + r'\b')
+uget_sloppy_id_regex = re.compile(
+    r"(?P<shortuget>(?P<id>\S+)@(?P<location>[-\w]+))"
+)
+uget_id_regex = (
+    r"(?P<fulluget>u(?:get|env):" + uget_sloppy_id_regex.pattern + ")"
+)
+uget_id_regex_only = re.compile("^" + uget_id_regex + "$")
+uget_id_regex = re.compile(r"\b" + uget_id_regex + r"\b")
 
 
 class GgetId(str):
     """Basestring wrapper for Gget Ids."""
+
     def __new__(cls, value):
         if uget_id_regex_only.match(value):
-            raise ValueError('A GgetId cannot look like a UgetId !')
+            raise ValueError("A GgetId cannot look like a UgetId !")
         return str.__new__(cls, value)
 
 
@@ -265,12 +321,20 @@ class AbstractUgetId(str):
         if not vmatch:
             raise ValueError('Invalid UgetId (got "{:s}")'.format(value))
         me = str.__new__(cls, value)
-        me._id = vmatch.group('id')
-        me._location = vmatch.group('location')
+        me._id = vmatch.group("id")
+        me._location = vmatch.group("location")
         if me._location in set(cls._OUTCAST_LOCATIONS):
-            raise ValueError('Invalid UgetId (got "{:s}"). Outcast Location.'.format(value))
-        if cls._ALLOWED_LOCATIONS and me._location not in set(cls._ALLOWED_LOCATIONS):
-            raise ValueError('Invalid UgetId (got "{:s}"). Disallowed location'.format(value))
+            raise ValueError(
+                'Invalid UgetId (got "{:s}"). Outcast Location.'.format(value)
+            )
+        if cls._ALLOWED_LOCATIONS and me._location not in set(
+            cls._ALLOWED_LOCATIONS
+        ):
+            raise ValueError(
+                'Invalid UgetId (got "{:s}"). Disallowed location'.format(
+                    value
+                )
+            )
         return me
 
     @property
@@ -283,31 +347,30 @@ class AbstractUgetId(str):
 
     @property
     def short(self):
-        return self._id + '@' + self._location
+        return self._id + "@" + self._location
 
     def monthlyshort(self, month):
-        return self._id + '.m{:02d}'.format(month) + '@' + self._location
+        return self._id + ".m{:02d}".format(month) + "@" + self._location
 
 
 class UgetId(AbstractUgetId):
-
-    _OUTCAST_LOCATIONS = ('demo', )
+    _OUTCAST_LOCATIONS = ("demo",)
 
 
 def genv_ifs_compiler_convention(cls):
     """Add the necessary method to handle compiler version/option in Genv."""
-    original_gget_basename = getattr(cls, 'gget_basename', None)
+    original_gget_basename = getattr(cls, "gget_basename", None)
     if original_gget_basename is not None:
 
         def gget_basename(self):
             """GGET specific naming convention."""
             b_dict = original_gget_basename(self)
-            if getattr(self, 'compiler_version', None):
-                b_dict['compiler_version'] = self.compiler_version
-            if getattr(self, 'compiler_option', None):
-                b_dict['compiler_option'] = self.compiler_option
-            if getattr(self, 'cycle', None):
-                b_dict['cycle'] = self.cycle
+            if getattr(self, "compiler_version", None):
+                b_dict["compiler_version"] = self.compiler_version
+            if getattr(self, "compiler_option", None):
+                b_dict["compiler_option"] = self.compiler_option
+            if getattr(self, "cycle", None):
+                b_dict["cycle"] = self.cycle
             return b_dict
 
         cls.gget_basename = gget_basename
@@ -316,15 +379,13 @@ def genv_ifs_compiler_convention(cls):
 
 #: Usual definition of the ``compiler_version`` and ``compiler_option`` attributes.
 gmkpack_compiler_identification = footprints.Footprint(
-    info='Add the compiler version/option in the footprint',
+    info="Add the compiler version/option in the footprint",
     attr=dict(
         compiler_version=dict(
-            info="The compiler version in gmkpack convention.",
-            optional=True
+            info="The compiler version in gmkpack convention.", optional=True
         ),
         compiler_option=dict(
-            info="The compiler option in gmkpack convention.",
-            optional=True
+            info="The compiler option in gmkpack convention.", optional=True
         ),
     ),
 )
@@ -333,21 +394,27 @@ gmkpack_compiler_identification = footprints.Footprint(
 #: Usual definition of the ``compiler_version`` and ``compiler_option`` attributes + genv integration.
 gmkpack_compiler_identification_deco = footprints.DecorativeFootprint(
     gmkpack_compiler_identification,
-    decorator=[genv_ifs_compiler_convention, ]
+    decorator=[
+        genv_ifs_compiler_convention,
+    ],
 )
 
 
 def genv_executable_flavour(cls):
     """Add the necessary method to the "flavour" in Genv."""
-    original_genv_basename = getattr(cls, 'genv_basename', None)
+    original_genv_basename = getattr(cls, "genv_basename", None)
     if original_genv_basename is not None:
 
         def genv_basename(self):
             """Just retrieve a potential gvar attribute."""
             gvar = original_genv_basename(self)
-            if getattr(self, 'flavour', None):
-                gvar += '_' + {'singleprecision': 'SP'
-                               }.get(self.flavour, self.flavour).upper()
+            if getattr(self, "flavour", None):
+                gvar += (
+                    "_"
+                    + {"singleprecision": "SP"}.get(
+                        self.flavour, self.flavour
+                    ).upper()
+                )
             return gvar
 
         cls.genv_basename = genv_basename
@@ -356,11 +423,13 @@ def genv_executable_flavour(cls):
 
 #: Usual definition of the ``flavour`` attribute.
 executable_flavour = footprints.Footprint(
-    info='Add the executable flavour attribute to the resource',
+    info="Add the executable flavour attribute to the resource",
     attr=dict(
         flavour=dict(
             info="The executable flavour (This may influence the Genv's key choice).",
-            values=['singleprecision', ],
+            values=[
+                "singleprecision",
+            ],
             optional=True,
         ),
     ),
@@ -370,6 +439,10 @@ executable_flavour = footprints.Footprint(
 #: Usual definition of the ``flavour``.
 executable_flavour_deco = footprints.DecorativeFootprint(
     executable_flavour,
-    decorator=[genv_executable_flavour,
-               namebuilding_append('src', lambda self: [self.flavour], none_discard=True)]
+    decorator=[
+        genv_executable_flavour,
+        namebuilding_append(
+            "src", lambda self: [self.flavour], none_discard=True
+        ),
+    ],
 )

--- a/src/vortex/nwp/syntax/stdattrs.py
+++ b/src/vortex/nwp/syntax/stdattrs.py
@@ -4,11 +4,16 @@ of attributes description that could be used in the footprint definition of any
 class which follow the :class:`footprints.Footprint` syntax.
 """
 
-from bronx.stdtypes.date import Time
-import footprints
+import re
+from functools import total_ordering
 
-#: Export a set of attributes :data:`a_run`, etc..
-__all__ = []
+import footprints
+from bronx.stdtypes.date import Time
+
+from vortex.syntax.stddeco import namebuilding_append
+
+#: Export some new class for attributes in footprint objects, eg : GenvKey
+__all__ = ["GenvKey", "GenvDomain"]
 
 #: Usual Footprint for a single member (in an algo Component)
 a_algo_member = dict(
@@ -137,22 +142,6 @@ def show():
             )
         )
 
-
-"""
-This module provides some pre-defined attributes descriptions or combined sets
-of attributes description that could be used in the footprint definition of any
-class which follow the :class:`footprints.Footprint` syntax.
-"""
-
-import re
-from functools import total_ordering
-
-import footprints
-
-from vortex.syntax.stddeco import namebuilding_append
-
-#: Export some new class for attributes in footprint objects, eg : GenvKey
-__all__ = ["GenvKey", "GenvDomain"]
 
 domain_remap = dict()
 

--- a/src/vortex/nwp/tools/__init__.py
+++ b/src/vortex/nwp/tools/__init__.py
@@ -3,8 +3,8 @@ Standalone tools for NWP
 """
 
 # Recursive inclusion of packages with potential FootprintBase classes
-from . import conftools
-from . import ifstools
+from . import conftools as conftools
+from . import ifstools as ifstools
 
 #: Automatic export of data subpackage
 __all__ = []

--- a/src/vortex/nwp/tools/addons.py
+++ b/src/vortex/nwp/tools/addons.py
@@ -19,17 +19,22 @@ class NWPAddonsGroup(AddonGroup):
     """A set of usual NWP Addons."""
 
     _footprint = dict(
-        info = 'Default NWP Addons',
-        attr = dict(
-            kind = dict(
-                values = ['nwp', ],
+        info="Default NWP Addons",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "nwp",
+                ],
             ),
-        )
+        ),
     )
 
-    _addonslist = ('allfolders',  # Folder like...
-                   'lfi', 'iopoll',  # Wonderful FA/LFI world...
-                   'grib', 'gribapi',  # GRIB stuff...
-                   'arpifs_listings',  # Obscure IFS/Arpege listings...
-                   'sfx',  # Surfex...
-                   )
+    _addonslist = (
+        "allfolders",  # Folder like...
+        "lfi",
+        "iopoll",  # Wonderful FA/LFI world...
+        "grib",
+        "gribapi",  # GRIB stuff...
+        "arpifs_listings",  # Obscure IFS/Arpege listings...
+        "sfx",  # Surfex...
+    )

--- a/src/vortex/nwp/tools/addons.py
+++ b/src/vortex/nwp/tools/addons.py
@@ -4,12 +4,12 @@ Various System needed for NWP applications.
 
 from vortex.tools.addons import AddonGroup
 
-# Load the proper Addon modules...
-import vortex.tools.folder  # @UnusedImport
-import vortex.tools.lfi  # @UnusedImport
-import vortex.tools.grib  # @UnusedImport
-import vortex.tools.listings  # @UnusedImport
-import vortex.tools.surfex  # @UnusedImport
+# Import the proper Addon modules for footprints
+from vortex.tools import folder as folder
+from vortex.tools import lfi as lfi
+from vortex.tools import grib as grib
+from vortex.tools import listings as listings
+from vortex.tools import surfex as surfex
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/nwp/tools/agt.py
+++ b/src/vortex/nwp/tools/agt.py
@@ -7,6 +7,7 @@ import collections
 
 class AgtConfigurationError(Exception):
     """Specific Transfer Agent configuration error."""
+
     pass
 
 
@@ -15,10 +16,10 @@ def agt_volatile_path(sh):
     and hard-linking to it instead of expecting it to be present "later".
     """
     config = sh.default_target.config
-    if not config.has_section('agt'):
+    if not config.has_section("agt"):
         fmt = 'Missing section "agt" in configuration file\n"{}"'
         raise AgtConfigurationError(fmt.format(config.file))
-    return config.get('agt', 'agt_volatile')
+    return config.get("agt", "agt_volatile")
 
 
 def agt_actual_command(sh, binary_name, args, extraenv=None):
@@ -35,21 +36,32 @@ def agt_actual_command(sh, binary_name, args, extraenv=None):
     :param extraenv: Additional environment variables to export (dictionary)
     """
     config = sh.default_target.config
-    if not config.has_section('agt'):
+    if not config.has_section("agt"):
         fmt = 'Missing section "agt" in configuration file\n"{}"'
         raise AgtConfigurationError(fmt.format(config.file))
 
-    agt_path = sh.default_target.get('agt_path', default=None)
+    agt_path = sh.default_target.get("agt_path", default=None)
     agt_bin = sh.default_target.get(binary_name, default=None)
     if not all([agt_path, agt_bin]):
         fmt = 'Missing key "agt_path" or "{}" in configuration file\n"{}"'
         raise AgtConfigurationError(fmt.format(binary_name, config.file))
-    cfgkeys = ['HOME_SOPRA', 'LD_LIBRARY_PATH',
-               'base_transfert_agent', 'DIAP_AGENT_NUMPROG_AGENT']
-    context = ' ; '.join(["export {}={}".format(key, config.get('agt', key))
-                          for key in cfgkeys])
+    cfgkeys = [
+        "HOME_SOPRA",
+        "LD_LIBRARY_PATH",
+        "base_transfert_agent",
+        "DIAP_AGENT_NUMPROG_AGENT",
+    ]
+    context = " ; ".join(
+        ["export {}={}".format(key, config.get("agt", key)) for key in cfgkeys]
+    )
     if extraenv is not None and isinstance(extraenv, collections.abc.Mapping):
-        context = ' ; '.join([context, ] +
-                             ["export {}={}".format(key.upper(), value)
-                              for (key, value) in extraenv.items()])
-    return '{} ; {} {}'.format(context, sh.path.join(agt_path, agt_bin), args)
+        context = " ; ".join(
+            [
+                context,
+            ]
+            + [
+                "export {}={}".format(key.upper(), value)
+                for (key, value) in extraenv.items()
+            ]
+        )
+    return "{} ; {} {}".format(context, sh.path.join(agt_path, agt_bin), args)

--- a/src/vortex/nwp/tools/bdap.py
+++ b/src/vortex/nwp/tools/bdap.py
@@ -8,16 +8,19 @@ __all__ = []
 
 class BDAPError(Exception):
     """General BDAP error."""
+
     pass
 
 
 class BDAPRequestConfigurationError(BDAPError):
     """Specific Transfer Agent configuration error."""
+
     pass
 
 
 class BDAPGetError(BDAPError):
     """Generic BDAP get error."""
+
     pass
 
 
@@ -38,11 +41,19 @@ def BDAPrequest_actual_command(command, date, term, query, int_extraenv=False):
     """
 
     # Environment variable to specify the date of the file
-    context = ' ; '.join(["export {}={}".format('dmt_date_pivot'.upper(), date.ymdhms)])
+    context = " ; ".join(
+        ["export {}={}".format("dmt_date_pivot".upper(), date.ymdhms)]
+    )
     # Extra environment variables (integration BDAP)
     if int_extraenv:
-        context = ' ; '.join([context] +
-                             ["export {}={}".format('db_file_bdap'.upper(),
-                                                    '/usr/local/sopra/neons_db_bdap.intgr')])
+        context = " ; ".join(
+            [context]
+            + [
+                "export {}={}".format(
+                    "db_file_bdap".upper(),
+                    "/usr/local/sopra/neons_db_bdap.intgr",
+                )
+            ]
+        )
     # Return the command to be launched
-    return '{} ; {} {:d} {}'.format(context, command, term.hour, query)
+    return "{} ; {} {:d} {}".format(context, command, term.hour, query)

--- a/src/vortex/nwp/tools/bdcp.py
+++ b/src/vortex/nwp/tools/bdcp.py
@@ -8,16 +8,19 @@ __all__ = []
 
 class BDCPError(Exception):
     """General BDMP error."""
+
     pass
 
 
 class BDCPRequestConfigurationError(BDCPError):
     """Specific Transfer Agent configuration error."""
+
     pass
 
 
 class BDCPGetError(BDCPError):
     """Generic BDCP get error."""
+
     pass
 
 
@@ -35,4 +38,4 @@ def BDCPrequest_actual_command(command, query_file, output_file):
     """
 
     # Return the command to be launched
-    return '{} -D {} -f {}'.format(command, query_file, output_file)
+    return "{} -D {} -f {}".format(command, query_file, output_file)

--- a/src/vortex/nwp/tools/bdm.py
+++ b/src/vortex/nwp/tools/bdm.py
@@ -8,14 +8,17 @@ __all__ = []
 
 class BDMError(Exception):
     """General BDM error."""
+
     pass
 
 
 class BDMRequestConfigurationError(BDMError):
     """Specific Transfer Agent configuration error."""
+
     pass
 
 
 class BDMGetError(BDMError):
     """Generic BDM get error."""
+
     pass

--- a/src/vortex/nwp/tools/bdmp.py
+++ b/src/vortex/nwp/tools/bdmp.py
@@ -8,16 +8,19 @@ __all__ = []
 
 class BDMPError(Exception):
     """General BDMP error."""
+
     pass
 
 
 class BDMPRequestConfigurationError(BDMPError):
     """Specific Transfer Agent configuration error."""
+
     pass
 
 
 class BDMPGetError(BDMPError):
     """Generic BDMP get error."""
+
     pass
 
 
@@ -34,16 +37,18 @@ def BDMPrequest_actual_command(command, query, target_bdmp):
     :param target_bdmp: string to determine the BDMP used
     """
     # Environment variable used for the request
-    extraenv_pwd = "export {} {}".format('pwd_file'.upper(), '/usr/local/sopra/neons_pwd')
-    if target_bdmp == 'OPER':
-        extraenv_db = '/usr/local/sopra/neons_db_bdm'
-    elif target_bdmp == 'INTE':
-        extraenv_db = '/usr/local/sopra/neons_db_bdm.archi'
-    elif target_bdmp == 'ARCH':
-        extraenv_db = '/usr/local/sopra/neons_db_bdm.intgr'
+    extraenv_pwd = "export {} {}".format(
+        "pwd_file".upper(), "/usr/local/sopra/neons_pwd"
+    )
+    if target_bdmp == "OPER":
+        extraenv_db = "/usr/local/sopra/neons_db_bdm"
+    elif target_bdmp == "INTE":
+        extraenv_db = "/usr/local/sopra/neons_db_bdm.archi"
+    elif target_bdmp == "ARCH":
+        extraenv_db = "/usr/local/sopra/neons_db_bdm.intgr"
     else:
         raise BDMPError
-    extraenv_db = 'export {} {}'.format('db_file_bdm'.upper(), extraenv_db)
+    extraenv_db = "export {} {}".format("db_file_bdm".upper(), extraenv_db)
 
     # Return the command to be launched
-    return '{} ; {} ; {} {}'.format(extraenv_pwd, extraenv_db, command, query)
+    return "{} ; {} ; {} {}".format(extraenv_pwd, extraenv_db, command, query)

--- a/src/vortex/nwp/tools/conftools.py
+++ b/src/vortex/nwp/tools/conftools.py
@@ -31,12 +31,12 @@ class ConfTool(footprints.FootprintBase):
     """Abstract class for conftools objects."""
 
     _abstract = True
-    _collector = ('conftool',)
+    _collector = ("conftool",)
     _footprint = dict(
-        info = 'Abstract Conf/Weird Tool',
-        attr = dict(
-            kind = dict(),
-        )
+        info="Abstract Conf/Weird Tool",
+        attr=dict(
+            kind=dict(),
+        ),
     )
 
 
@@ -45,12 +45,14 @@ class AbstractObjectProxyConfTool(ConfTool):
 
     _abstract = True
     _footprint = dict(
-        info = 'Conf tool that find the appropriate begin/end date for an input resource.',
-        attr = dict(
-            kind = dict(
-                values      = ['objproxy', ],
+        info="Conf tool that find the appropriate begin/end date for an input resource.",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "objproxy",
+                ],
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -72,13 +74,15 @@ class AbstractObjectProxyConfTool(ConfTool):
 
 
 #: Holds coupling's data for a particular cutoff/hour
-CouplingInfos = collections.namedtuple('CouplingInfos',
-                                       ('base', 'dayoff', 'cutoff', 'vapp', 'vconf', 'xpid', 'model', 'steps')
-                                       )
+CouplingInfos = collections.namedtuple(
+    "CouplingInfos",
+    ("base", "dayoff", "cutoff", "vapp", "vconf", "xpid", "model", "steps"),
+)
 
 
 class CouplingOffsetConfError(Exception):
     """Abstract exception raise by :class:`CouplingOffsetConfTool` objects."""
+
     pass
 
 
@@ -86,7 +90,7 @@ class CouplingOffsetConfPrepareError(CouplingOffsetConfError):
     """Exception raised when an error occurs during coupling data calculations."""
 
     def __init__(self, fmtk):
-        msg = 'It is useless to compute coupling for: {}.'.format(fmtk)
+        msg = "It is useless to compute coupling for: {}.".format(fmtk)
         super().__init__(msg)
 
 
@@ -94,11 +98,11 @@ class CouplingOffsetConfRefillError(CouplingOffsetConfError):
     """Exception raised when an orror occurs during refill."""
 
     def __init__(self, fmtk, hh=None):
-        msg = 'It is useless to compute a refill for: {}'.format(fmtk)
+        msg = "It is useless to compute a refill for: {}".format(fmtk)
         if hh is None:
-            msg += '.'
+            msg += "."
         else:
-            msg += ' at HH={!s}.'.format(hh)
+            msg += " at HH={!s}.".format(hh)
         super().__init__(msg)
 
 
@@ -106,88 +110,96 @@ class CouplingOffsetConfTool(ConfTool):
     """Conf tool that do all sorts of computations for coupling."""
 
     _footprint = dict(
-        info = 'Conf tool that do all sorts of computations for coupling',
-        attr = dict(
-            kind = dict(
-                values= ['couplingoffset', ],
+        info="Conf tool that do all sorts of computations for coupling",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "couplingoffset",
+                ],
             ),
-            cplhhlist = dict(
-                info = ('The list of cutoff and hours for this application. '
-                        'If omitted, all entries of the **cplhhbase** attribute are used. ' +
-                        "(e.g ``{'assim':[0, 6, 12, 18], 'production':[0, ]}``)"),
-                type = FPDict,
-                optional = True,
+            cplhhlist=dict(
+                info=(
+                    "The list of cutoff and hours for this application. "
+                    "If omitted, all entries of the **cplhhbase** attribute are used. "
+                    + "(e.g ``{'assim':[0, 6, 12, 18], 'production':[0, ]}``)"
+                ),
+                type=FPDict,
+                optional=True,
             ),
-            cplhhbase = dict(
-                info = ('For a given cutoff and hour, gives the base hour to couple to. ' +
-                        "(e.g ``{'assim':{0:0, 6:6, 12:12, 18:18}, 'production':{0:18}}``)."),
-                type = FPDict,
+            cplhhbase=dict(
+                info=(
+                    "For a given cutoff and hour, gives the base hour to couple to. "
+                    + "(e.g ``{'assim':{0:0, 6:6, 12:12, 18:18}, 'production':{0:18}}``)."
+                ),
+                type=FPDict,
             ),
-            cpldayoff = dict(
-                info = ('For a given cutoff and hour, gives an offset in days. 0 by default. ' +
-                        "(e.g ``{'assim':{'default':0}, 'production':{'default':1}}``)."),
-                type = FPDict,
-                optional = True,
+            cpldayoff=dict(
+                info=(
+                    "For a given cutoff and hour, gives an offset in days. 0 by default. "
+                    + "(e.g ``{'assim':{'default':0}, 'production':{'default':1}}``)."
+                ),
+                type=FPDict,
+                optional=True,
             ),
-            cplcutoff = dict(
-                info = 'For a given cutoff and hour, gives the base cutoff to couple to.',
-                type = FPDict,
+            cplcutoff=dict(
+                info="For a given cutoff and hour, gives the base cutoff to couple to.",
+                type=FPDict,
             ),
-            cplvapp = dict(
-                info = 'For a given cutoff and hour, gives the base vapp to couple to.',
-                type = FPDict,
+            cplvapp=dict(
+                info="For a given cutoff and hour, gives the base vapp to couple to.",
+                type=FPDict,
             ),
-            cplvconf = dict(
-                info = 'For a given cutoff and hour, gives the base vconf to couple to.',
-                type = FPDict,
+            cplvconf=dict(
+                info="For a given cutoff and hour, gives the base vconf to couple to.",
+                type=FPDict,
             ),
-            cplxpid = dict(
-                info = 'For a given cutoff and hour, gives the experiment ID to couple to.',
-                type = FPDict,
-                optional = True,
+            cplxpid=dict(
+                info="For a given cutoff and hour, gives the experiment ID to couple to.",
+                type=FPDict,
+                optional=True,
             ),
-            cplmodel = dict(
-                info = 'For a given cutoff and hour, gives the base model to couple to.',
-                type = FPDict,
-                optional = True,
+            cplmodel=dict(
+                info="For a given cutoff and hour, gives the base model to couple to.",
+                type=FPDict,
+                optional=True,
             ),
-            cplsteps = dict(
-                info = 'For a given cutoff and hour, gives then list of requested terms.',
-                type = FPDict,
+            cplsteps=dict(
+                info="For a given cutoff and hour, gives then list of requested terms.",
+                type=FPDict,
             ),
-            finalterm = dict(
-                info = 'For a given cutoff and hour, the final term (for "finalterm" token substitution)',
-                type = FPDict,
-                optional = True
+            finalterm=dict(
+                info='For a given cutoff and hour, the final term (for "finalterm" token substitution)',
+                type=FPDict,
+                optional=True,
             ),
-            refill_cutoff = dict(
-                values = ['assim', 'production', 'all'],
-                info = 'By default, what is the cutoff name of the refill task.',
-                optional = True,
-                default = 'assim',
+            refill_cutoff=dict(
+                values=["assim", "production", "all"],
+                info="By default, what is the cutoff name of the refill task.",
+                optional=True,
+                default="assim",
             ),
-            compute_on_refill = dict(
-                info = 'Is it necessary to compute coupling files for the refilling cutoff ?',
-                optional = True,
-                default = True,
-                type = bool,
+            compute_on_refill=dict(
+                info="Is it necessary to compute coupling files for the refilling cutoff ?",
+                optional=True,
+                default=True,
+                type=bool,
             ),
-            isolated_refill = dict(
-                info = 'Are the refill tasks exclusive with prepare tasks ?',
-                optional = True,
-                default = True,
-                type = bool,
+            isolated_refill=dict(
+                info="Are the refill tasks exclusive with prepare tasks ?",
+                optional=True,
+                default=True,
+                type=bool,
             ),
-            verbose = dict(
-                info = 'When the object is created, print a summary.',
-                type = bool,
-                optional = True,
-                default = True,
+            verbose=dict(
+                info="When the object is created, print a summary.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-        )
+        ),
     )
 
-    _DFLT_KEY = 'default'
+    _DFLT_KEY = "default"
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
@@ -204,7 +216,9 @@ class CouplingOffsetConfTool(ConfTool):
         else:
             for c, clist in self.cplhhlist.items():
                 if not isinstance(clist, (tuple, list)):
-                    clist = [clist, ]
+                    clist = [
+                        clist,
+                    ]
                 self._target_hhs[c].update([Time(h) for h in clist])
             t_hhbase = self._reshape_inputs(self.cplhhbase, value_reclass=Time)
 
@@ -218,63 +232,101 @@ class CouplingOffsetConfTool(ConfTool):
             t_model = t_vapp
         else:
             t_model = self._reshape_inputs(self.cplmodel)
-        t_xpid = self._reshape_inputs(self.cplxpid, class_default='')
+        t_xpid = self._reshape_inputs(self.cplxpid, class_default="")
 
         # If relevent, do "finalterm" token substitution
         if self.finalterm is not None:
-            t_finalterm = self._reshape_inputs(self.finalterm, value_reclass=str)
+            t_finalterm = self._reshape_inputs(
+                self.finalterm, value_reclass=str
+            )
             for c, cv in t_hhbase.items():
                 for hh in cv.keys():
                     if isinstance(t_steps[c][hh], str):
-                        t_steps[c][hh] = t_steps[c][hh].replace('finalterm',
-                                                                t_finalterm[c][hh])
+                        t_steps[c][hh] = t_steps[c][hh].replace(
+                            "finalterm", t_finalterm[c][hh]
+                        )
 
         # Build the dictionary of CouplingInfos objects
         self._cpl_data = collections.defaultdict(dict)
         for c, cv in t_hhbase.items():
-            self._cpl_data[c] = {hh: CouplingInfos(cv[hh], int(t_dayoff[c][hh]),
-                                                   t_cutoff[c][hh], t_vapp[c][hh],
-                                                   t_vconf[c][hh], t_xpid[c][hh],
-                                                   t_model[c][hh],
-                                                   rangex(t_steps[c][hh]))
-                                 for hh in cv.keys()}
+            self._cpl_data[c] = {
+                hh: CouplingInfos(
+                    cv[hh],
+                    int(t_dayoff[c][hh]),
+                    t_cutoff[c][hh],
+                    t_vapp[c][hh],
+                    t_vconf[c][hh],
+                    t_xpid[c][hh],
+                    t_model[c][hh],
+                    rangex(t_steps[c][hh]),
+                )
+                for hh in cv.keys()
+            }
 
         # Pre-compute the prepare terms
         self._prepare_terms_map = self._compute_prepare_terms()
         if self.verbose:
             print()
-            print('#### Coupling configuration tool initialised ####')
-            print('**** Coupling tasks terms map:')
-            print('{:s}  :  {:s}'.format(self._cpl_fmtkey(('HH', 'VAPP', 'VCONF', 'XPID', 'MODEL', 'CUTOFF')),
-                                         'Computed Terms'))
+            print("#### Coupling configuration tool initialised ####")
+            print("**** Coupling tasks terms map:")
+            print(
+                "{:s}  :  {:s}".format(
+                    self._cpl_fmtkey(
+                        ("HH", "VAPP", "VCONF", "XPID", "MODEL", "CUTOFF")
+                    ),
+                    "Computed Terms",
+                )
+            )
             for k in sorted(self._prepare_terms_map.keys()):
-                print('{:s}  :  {:s}'.format(self._cpl_fmtkey(k),
-                                             ' '.join([str(t.hour)
-                                                       for t in self._prepare_terms_map[k]
-                                                       ])
-                                             )
-                      )
+                print(
+                    "{:s}  :  {:s}".format(
+                        self._cpl_fmtkey(k),
+                        " ".join(
+                            [str(t.hour) for t in self._prepare_terms_map[k]]
+                        ),
+                    )
+                )
 
         # Pre-compute the default refill_map
         self._refill_terms_map = dict()
-        self._refill_terms_map[self.refill_cutoff] = self._compute_refill_terms(self.refill_cutoff,
-                                                                                self.compute_on_refill,
-                                                                                self.isolated_refill)
+        self._refill_terms_map[self.refill_cutoff] = (
+            self._compute_refill_terms(
+                self.refill_cutoff,
+                self.compute_on_refill,
+                self.isolated_refill,
+            )
+        )
         if self.verbose:
-            print('**** Refill tasks activation map (default refill_cutoff is: {:s}):'.format(self.refill_cutoff))
-            print('{:s}  :  {:s}'.format(self._rtask_fmtkey(('VAPP', 'VCONF', 'XPID', 'MODEL', 'CUTOFF')),
-                                         'Active hours'))
+            print(
+                "**** Refill tasks activation map (default refill_cutoff is: {:s}):".format(
+                    self.refill_cutoff
+                )
+            )
+            print(
+                "{:s}  :  {:s}".format(
+                    self._rtask_fmtkey(
+                        ("VAPP", "VCONF", "XPID", "MODEL", "CUTOFF")
+                    ),
+                    "Active hours",
+                )
+            )
             for k in sorted(self._refill_terms_map[self.refill_cutoff].keys()):
                 vdict = self._refill_terms_map[self.refill_cutoff][k]
-                print('{:s}  :  {:s}'.format(self._rtask_fmtkey(k),
-                                             ' '.join([str(t.hour) for t in sorted(vdict.keys())])))
+                print(
+                    "{:s}  :  {:s}".format(
+                        self._rtask_fmtkey(k),
+                        " ".join([str(t.hour) for t in sorted(vdict.keys())]),
+                    )
+                )
             print()
 
     @property
     def target_hhs(self):
         return self._target_hhs
 
-    def _reshape_inputs(self, input_dict, class_default=None, value_reclass=lambda x: x):
+    def _reshape_inputs(
+        self, input_dict, class_default=None, value_reclass=lambda x: x
+    ):
         """Deal with default values, check dictionaries and convert keys to Time objects."""
         # Convert keys to time objects
         r_dict = dict()
@@ -307,10 +359,15 @@ class CouplingOffsetConfTool(ConfTool):
                     myv[h] = last_default
             else:
                 if not my_c_hhs >= self.target_hhs[c]:
-                    logger.error("Inconsistent input arrays while processing: \n%s",
-                                 str(input_dict))
-                    logger.error("Cutoff %s, expecting the following HH: \n%s",
-                                 c, str(self.target_hhs[c]))
+                    logger.error(
+                        "Inconsistent input arrays while processing: \n%s",
+                        str(input_dict),
+                    )
+                    logger.error(
+                        "Cutoff %s, expecting the following HH: \n%s",
+                        c,
+                        str(self.target_hhs[c]),
+                    )
                     raise ValueError("Inconsistent input array.")
 
         # Filter values according to _target_hhs
@@ -331,13 +388,9 @@ class CouplingOffsetConfTool(ConfTool):
 
     @staticmethod
     def _cpl_fmtkey(k):
-        cutoff_map = dict(production='prod')
-        return '{:5s} {:6s}  {:24s} {:s} ({:s})'.format(
-            k[0],
-            cutoff_map.get(k[5], k[5]),
-            k[1] + '/' + k[2],
-            k[3],
-            k[4]
+        cutoff_map = dict(production="prod")
+        return "{:5s} {:6s}  {:24s} {:s} ({:s})".format(
+            k[0], cutoff_map.get(k[5], k[5]), k[1] + "/" + k[2], k[3], k[4]
         )
 
     @staticmethod
@@ -346,13 +399,15 @@ class CouplingOffsetConfTool(ConfTool):
 
     @staticmethod
     def _rtask_fmtkey(k):
-        cutoff_map = dict(production='prod')
-        return '{:6s}  {:24s} {:s} ({:s})'.format(cutoff_map.get(k[4], k[4]), k[0] + '/' + k[1], k[2], k[3])
+        cutoff_map = dict(production="prod")
+        return "{:6s}  {:24s} {:s} ({:s})".format(
+            cutoff_map.get(k[4], k[4]), k[0] + "/" + k[1], k[2], k[3]
+        )
 
     @staticmethod
     def _process_date(date):
         mydate = Date(date)
-        myhh = Time('{0.hour:d}:{0.minute:02d}'.format(mydate))
+        myhh = Time("{0.hour:d}:{0.minute:02d}".format(mydate))
         return mydate, myhh
 
     @staticmethod
@@ -366,47 +421,85 @@ class CouplingOffsetConfTool(ConfTool):
         terms_map = collections.defaultdict(set)
         for _, cv in self._cpl_data.items():
             for h, infos in cv.items():
-                key = self._cpl_key(infos.base, infos.cutoff, infos.vapp, infos.vconf, infos.xpid, infos.model)
+                key = self._cpl_key(
+                    infos.base,
+                    infos.cutoff,
+                    infos.vapp,
+                    infos.vconf,
+                    infos.xpid,
+                    infos.model,
+                )
                 targetoffset = self._hh_offset(h, infos.base, infos.dayoff)
                 terms_map[key].update([s + targetoffset for s in infos.steps])
         terms_map = {k: sorted(terms) for k, terms in terms_map.items()}
         return terms_map
 
-    def _compute_refill_terms(self, refill_cutoff, compute_on_refill, isolated_refill):
-        finaldates = collections.defaultdict(functools.partial(collections.defaultdict,
-                                                               functools.partial(collections.defaultdict, set)))
-        if refill_cutoff == 'all':
-            possiblehours = sorted(functools.reduce(lambda x, y: x | y,
-                                                    [set(l) for l in self.target_hhs.values()]))
+    def _compute_refill_terms(
+        self, refill_cutoff, compute_on_refill, isolated_refill
+    ):
+        finaldates = collections.defaultdict(
+            functools.partial(
+                collections.defaultdict,
+                functools.partial(collections.defaultdict, set),
+            )
+        )
+        if refill_cutoff == "all":
+            possiblehours = sorted(
+                functools.reduce(
+                    lambda x, y: x | y,
+                    [set(l) for l in self.target_hhs.values()],
+                )
+            )
         else:
             possiblehours = self.target_hhs[refill_cutoff]
 
         # Look 24hr ahead
         for c, cv in self._cpl_data.items():
             for h, infos in cv.items():
-                key = self._rtask_key(infos.cutoff, infos.vapp, infos.vconf, infos.xpid, infos.model)
+                key = self._rtask_key(
+                    infos.cutoff,
+                    infos.vapp,
+                    infos.vconf,
+                    infos.xpid,
+                    infos.model,
+                )
                 offset = self._hh_offset(h, infos.base, infos.dayoff)
                 for possibleh in possiblehours:
                     roffset = self._hh_offset(h, possibleh, 0)
-                    if ((roffset > 0 or
-                            (compute_on_refill and roffset == 0 and (refill_cutoff == 'all' or refill_cutoff == c))) and
-                            (roffset < offset or (isolated_refill and roffset == offset))):
-                        finaldates[key][possibleh][offset - roffset].update([s + offset for s in infos.steps])
+                    if (
+                        roffset > 0
+                        or (
+                            compute_on_refill
+                            and roffset == 0
+                            and (refill_cutoff == "all" or refill_cutoff == c)
+                        )
+                    ) and (
+                        roffset < offset
+                        or (isolated_refill and roffset == offset)
+                    ):
+                        finaldates[key][possibleh][offset - roffset].update(
+                            [s + offset for s in infos.steps]
+                        )
 
         for key, vdict in finaldates.items():
             for possibleh in vdict.keys():
-                vdict[possibleh] = {off: sorted(terms) for off, terms in vdict[possibleh].items()}
+                vdict[possibleh] = {
+                    off: sorted(terms)
+                    for off, terms in vdict[possibleh].items()
+                }
 
         return finaldates
 
     def compatible_with(self, other):
         if isinstance(other, self.__class__):
-            return (self.target_hhs == other.target_hhs and
-                    self.refill_cutoff == other.refill_cutoff)
+            return (
+                self.target_hhs == other.target_hhs
+                and self.refill_cutoff == other.refill_cutoff
+            )
         else:
             return False
 
-    def prepare_terms(self, date, cutoff, vapp, vconf, model=None, xpid=''):
+    def prepare_terms(self, date, cutoff, vapp, vconf, model=None, xpid=""):
         """
         For a task computing coupling files (at **date** and **cutoff**,
         for a specific **vapp** and **vconf**), lists the terms that should be
@@ -427,8 +520,11 @@ class CouplingOffsetConfTool(ConfTool):
         time delta with the coupling model/file base date.
         """
         _, myhh = self._process_date(date)
-        return self._hh_offset(myhh, self._cpl_data[cutoff][myhh].base,
-                               self._cpl_data[cutoff][myhh].dayoff)
+        return self._hh_offset(
+            myhh,
+            self._cpl_data[cutoff][myhh].base,
+            self._cpl_data[cutoff][myhh].dayoff,
+        )
 
     def coupling_date(self, date, cutoff):
         """
@@ -436,8 +532,11 @@ class CouplingOffsetConfTool(ConfTool):
         base date of the coupling model/file.
         """
         mydate, myhh = self._process_date(date)
-        return mydate - self._hh_offset(myhh, self._cpl_data[cutoff][myhh].base,
-                                        self._cpl_data[cutoff][myhh].dayoff)
+        return mydate - self._hh_offset(
+            myhh,
+            self._cpl_data[cutoff][myhh].base,
+            self._cpl_data[cutoff][myhh].dayoff,
+        )
 
     def coupling_terms(self, date, cutoff):
         """
@@ -445,8 +544,11 @@ class CouplingOffsetConfTool(ConfTool):
         list of terms that should be fetched from the coupling model/file.
         """
         _, myhh = self._process_date(date)
-        offset = self._hh_offset(myhh, self._cpl_data[cutoff][myhh].base,
-                                 self._cpl_data[cutoff][myhh].dayoff)
+        offset = self._hh_offset(
+            myhh,
+            self._cpl_data[cutoff][myhh].base,
+            self._cpl_data[cutoff][myhh].dayoff,
+        )
         return [s + offset for s in self._cpl_data[cutoff][myhh].steps]
 
     def _coupling_stuff(self, date, cutoff, stuff):
@@ -458,105 +560,157 @@ class CouplingOffsetConfTool(ConfTool):
         For a task needing coupling (at **date** and **cutoff**), return the
         prescribed steps.
         """
-        return self._coupling_stuff(date, cutoff, 'steps')
+        return self._coupling_stuff(date, cutoff, "steps")
 
     def coupling_cutoff(self, date, cutoff):
         """
         For a task needing coupling (at **date** and **cutoff**), return the
         cutoff of the coupling model/file.
         """
-        return self._coupling_stuff(date, cutoff, 'cutoff')
+        return self._coupling_stuff(date, cutoff, "cutoff")
 
     def coupling_vapp(self, date, cutoff):
         """
         For a task needing coupling (at **date** and **cutoff**), return the
         vapp of the coupling model/file.
         """
-        return self._coupling_stuff(date, cutoff, 'vapp')
+        return self._coupling_stuff(date, cutoff, "vapp")
 
     def coupling_vconf(self, date, cutoff):
         """
         For a task needing coupling (at **date** and **cutoff**), return the
         vconf of the coupling model/file.
         """
-        return self._coupling_stuff(date, cutoff, 'vconf')
+        return self._coupling_stuff(date, cutoff, "vconf")
 
     def coupling_xpid(self, date, cutoff):
         """
         For a task needing coupling (at **date** and **cutoff**), return the
         experiment ID of the coupling model/file.
         """
-        return self._coupling_stuff(date, cutoff, 'xpid')
+        return self._coupling_stuff(date, cutoff, "xpid")
 
     def coupling_model(self, date, cutoff):
         """
         For a task needing coupling (at **date** and **cutoff**), return the
         vconf of the coupling model/file.
         """
-        return self._coupling_stuff(date, cutoff, 'model')
+        return self._coupling_stuff(date, cutoff, "model")
 
-    def refill_terms(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_terms(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The terms that should be computed for a given refill task."""
-        refill_cutoff = self.refill_cutoff if refill_cutoff is None else refill_cutoff
+        refill_cutoff = (
+            self.refill_cutoff if refill_cutoff is None else refill_cutoff
+        )
         if refill_cutoff not in self._refill_terms_map:
-            self._refill_terms_map[refill_cutoff] = self._compute_refill_terms(refill_cutoff,
-                                                                               self.compute_on_refill,
-                                                                               self.isolated_refill)
+            self._refill_terms_map[refill_cutoff] = self._compute_refill_terms(
+                refill_cutoff, self.compute_on_refill, self.isolated_refill
+            )
         if model is None:
             model = vapp
         mydate, myhh = self._process_date(date)
         key = self._rtask_key(cutoff, vapp, vconf, xpid, model)
         finaldates = dict()
-        if (key not in self._refill_terms_map[refill_cutoff] or
-                myhh not in self._refill_terms_map[refill_cutoff][key]):
+        if (
+            key not in self._refill_terms_map[refill_cutoff]
+            or myhh not in self._refill_terms_map[refill_cutoff][key]
+        ):
             raise CouplingOffsetConfRefillError(self._rtask_fmtkey(key))
-        for off, terms in self._refill_terms_map[refill_cutoff][key][myhh].items():
+        for off, terms in self._refill_terms_map[refill_cutoff][key][
+            myhh
+        ].items():
             finaldates[str(mydate - off)] = terms
-        return {'date': finaldates}
+        return {"date": finaldates}
 
-    def refill_dates(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_dates(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The dates that should be processed in a given refill task."""
-        return list(self.refill_terms(date, cutoff, vapp, vconf, model=model,
-                                      refill_cutoff=refill_cutoff, xpid=xpid)['date'].keys())
+        return list(
+            self.refill_terms(
+                date,
+                cutoff,
+                vapp,
+                vconf,
+                model=model,
+                refill_cutoff=refill_cutoff,
+                xpid=xpid,
+            )["date"].keys()
+        )
 
-    def refill_months(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_months(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The months that should be processed in a given refill task."""
-        mindate = min(self.refill_dates(date, cutoff, vapp, vconf, model=model,
-                                        refill_cutoff=refill_cutoff, xpid=xpid))
+        mindate = min(
+            self.refill_dates(
+                date,
+                cutoff,
+                vapp,
+                vconf,
+                model=model,
+                refill_cutoff=refill_cutoff,
+                xpid=xpid,
+            )
+        )
         minmonth = Month(mindate)
         return [minmonth, minmonth + 1]
 
 
 class AggregatedCouplingOffsetConfTool(ConfTool):
-
     _footprint = dict(
-        info = 'Aggregate several CouplingOffsetConfTool objects into one',
-        attr = dict(
-            kind = dict(
-                values= ['aggcouplingoffset', ],
+        info="Aggregate several CouplingOffsetConfTool objects into one",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "aggcouplingoffset",
+                ],
             ),
-            nominal = dict(
-                info = "A list of couplingoffset objects used in nominal cases",
-                type = FPList,
+            nominal=dict(
+                info="A list of couplingoffset objects used in nominal cases",
+                type=FPList,
             ),
-            alternate = dict(
-                info = "A list of couplingoffset objects used in rescue modes",
-                type = FPList,
-                optional = True,
+            alternate=dict(
+                info="A list of couplingoffset objects used in rescue modes",
+                type=FPList,
+                optional=True,
             ),
-            use_alternates = dict(
-                info = 'Actually use rescue mode ?',
-                optional = True,
-                default = True,
-                type = bool,
+            use_alternates=dict(
+                info="Actually use rescue mode ?",
+                optional=True,
+                default=True,
+                type=bool,
             ),
-            verbose = dict(
-                info = 'When the object is created, print a summary.',
-                type = bool,
-                optional = True,
-                default = True,
+            verbose=dict(
+                info="When the object is created, print a summary.",
+                type=bool,
+                optional=True,
+                default=True,
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -570,26 +724,52 @@ class AggregatedCouplingOffsetConfTool(ConfTool):
         # Check consistency
         for num, toolobj in enumerate(self._toolslist[1:]):
             if not self._toolslist[0].compatible_with(toolobj):
-                print('\n', '*' * 50)
-                print('self._toolslist[0] =', self._toolslist[0], '\n',
-                      ' target_hhs    =', self._toolslist[0].target_hhs,
-                      ' refill_cutoff =', self._toolslist[0].refill_cutoff)
-                print('is not consistent with object num', num, ':', toolobj, '\n',
-                      ' target_hhs    =', toolobj.target_hhs,
-                      ' refill_cutoff =', toolobj.refill_cutoff)
+                print("\n", "*" * 50)
+                print(
+                    "self._toolslist[0] =",
+                    self._toolslist[0],
+                    "\n",
+                    " target_hhs    =",
+                    self._toolslist[0].target_hhs,
+                    " refill_cutoff =",
+                    self._toolslist[0].refill_cutoff,
+                )
+                print(
+                    "is not consistent with object num",
+                    num,
+                    ":",
+                    toolobj,
+                    "\n",
+                    " target_hhs    =",
+                    toolobj.target_hhs,
+                    " refill_cutoff =",
+                    toolobj.refill_cutoff,
+                )
                 raise CouplingOffsetConfError("Inconsistent sub-objects")
 
         if self.verbose:
             print()
-            print('#### Aggregated Coupling configuration tool initialised ####')
-            print('It is made of {:d} nominal configuration tool(s)'.format(len(self.nominal)))
+            print(
+                "#### Aggregated Coupling configuration tool initialised ####"
+            )
+            print(
+                "It is made of {:d} nominal configuration tool(s)".format(
+                    len(self.nominal)
+                )
+            )
             if self.alternate and self.use_alternates:
-                print('+ {:d} rescue-mode configuration tool(s)'.format(len(self.alternate)))
+                print(
+                    "+ {:d} rescue-mode configuration tool(s)".format(
+                        len(self.alternate)
+                    )
+                )
             else:
-                print('No rescue-mode configuration tool is considered (deactivated)')
+                print(
+                    "No rescue-mode configuration tool is considered (deactivated)"
+                )
             print()
 
-    def prepare_terms(self, date, cutoff, vapp, vconf, model=None, xpid=''):
+    def prepare_terms(self, date, cutoff, vapp, vconf, model=None, xpid=""):
         """
         For a task computing coupling files (at **date** and **cutoff**,
         for a specific **vapp** and **vconf**), lists the terms that should be
@@ -598,7 +778,11 @@ class AggregatedCouplingOffsetConfTool(ConfTool):
         terms = set()
         for toolobj in self._toolslist:
             try:
-                terms.update(toolobj.prepare_terms(date, cutoff, vapp, vconf, model=model, xpid=xpid))
+                terms.update(
+                    toolobj.prepare_terms(
+                        date, cutoff, vapp, vconf, model=model, xpid=xpid
+                    )
+                )
             except CouplingOffsetConfPrepareError as e:
                 lateste = e
         if not terms:
@@ -606,14 +790,30 @@ class AggregatedCouplingOffsetConfTool(ConfTool):
         else:
             return sorted(terms)
 
-    def refill_terms(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_terms(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The terms that should be computed for a given refill task."""
         finaldates = collections.defaultdict(set)
         for toolobj in self._toolslist:
             try:
-                rt = toolobj.refill_terms(date, cutoff, vapp, vconf, model=model,
-                                          refill_cutoff=refill_cutoff, xpid=xpid)
-                for k, v in rt['date'].items():
+                rt = toolobj.refill_terms(
+                    date,
+                    cutoff,
+                    vapp,
+                    vconf,
+                    model=model,
+                    refill_cutoff=refill_cutoff,
+                    xpid=xpid,
+                )
+                for k, v in rt["date"].items():
                     finaldates[k].update(v)
             except CouplingOffsetConfRefillError as e:
                 lateste = e
@@ -622,23 +822,60 @@ class AggregatedCouplingOffsetConfTool(ConfTool):
         else:
             for k, v in finaldates.items():
                 finaldates[k] = sorted(v)
-            return {'date': finaldates}
+            return {"date": finaldates}
 
-    def refill_dates(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_dates(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The dates that should be processed in a given refill task."""
-        return list(self.refill_terms(date, cutoff, vapp, vconf, model=model,
-                                      refill_cutoff=refill_cutoff, xpid=xpid)['date'].keys())
+        return list(
+            self.refill_terms(
+                date,
+                cutoff,
+                vapp,
+                vconf,
+                model=model,
+                refill_cutoff=refill_cutoff,
+                xpid=xpid,
+            )["date"].keys()
+        )
 
-    def refill_months(self, date, cutoff, vapp, vconf, model=None, refill_cutoff=None, xpid=''):
+    def refill_months(
+        self,
+        date,
+        cutoff,
+        vapp,
+        vconf,
+        model=None,
+        refill_cutoff=None,
+        xpid="",
+    ):
         """The months that should be processed in a given refill task."""
-        mindate = min(self.refill_dates(date, cutoff, vapp, vconf, model=model,
-                                        refill_cutoff=refill_cutoff, xpid=xpid))
+        mindate = min(
+            self.refill_dates(
+                date,
+                cutoff,
+                vapp,
+                vconf,
+                model=model,
+                refill_cutoff=refill_cutoff,
+                xpid=xpid,
+            )
+        )
         minmonth = Month(mindate)
         return [minmonth, minmonth + 1]
 
 
 class TimeSerieInputFinderError(Exception):
     """Any exception raise by :class:`TimeSerieInputFinderConfTool` objects."""
+
     pass
 
 
@@ -669,31 +906,27 @@ class TimeSerieInputFinderConfTool(ConfTool):
     """
 
     _footprint = dict(
-        info = 'Conf tool that find the appropriate begin/end date for an input resource.',
-        attr = dict(
-            kind = dict(
-                values      = ['timeserie', ],
+        info="Conf tool that find the appropriate begin/end date for an input resource.",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "timeserie",
+                ],
             ),
-            timeserie_begin = dict(
-                info        = "The date when the time serie starts",
-                type        = Date
+            timeserie_begin=dict(
+                info="The date when the time serie starts", type=Date
             ),
-            timeserie_step = dict(
-                info        = "The step between files of the time serie.",
-                type        = Period
+            timeserie_step=dict(
+                info="The step between files of the time serie.", type=Period
             ),
-            upperbound_included = dict(
-                type        = bool,
-                optional    = True,
-                default     = True
+            upperbound_included=dict(type=bool, optional=True, default=True),
+            singlefile=dict(
+                info="The period requested by a user should be contained in a single file.",
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            singlefile = dict(
-                info        = "The period requested by a user should be contained in a single file.",
-                type        = bool,
-                optional    = True,
-                default     = False
-            )
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -705,10 +938,14 @@ class TimeSerieInputFinderConfTool(ConfTool):
         """Find the appropriate tiem serie's file date just before **begindate**."""
         if begindate not in self._begincache:
             if begindate < self.timeserie_begin:
-                raise TimeSerieInputFinderError("Request begin date is too soon !")
+                raise TimeSerieInputFinderError(
+                    "Request begin date is too soon !"
+                )
             dt = begindate - self.timeserie_begin
             nsteps = int(math.floor(dt.length / self._steplength))
-            self._begincache[begindate] = self.timeserie_begin + nsteps * self.timeserie_step
+            self._begincache[begindate] = (
+                self.timeserie_begin + nsteps * self.timeserie_step
+            )
         return self._begincache[begindate]
 
     def _begindates_expansion(self, tdate, tlength):
@@ -719,7 +956,9 @@ class TimeSerieInputFinderConfTool(ConfTool):
             nfiles += 1
         if nfiles > 1:
             if self.singlefile:
-                raise TimeSerieInputFinderError("Multiple files requested but singlefile=.T.")
+                raise TimeSerieInputFinderError(
+                    "Multiple files requested but singlefile=.T."
+                )
             return [tdate + i * self.timeserie_step for i in range(0, nfiles)]
         else:
             return tdate
@@ -767,7 +1006,9 @@ class TimeSerieInputFinderConfTool(ConfTool):
     def begindate(self, begindate, term):
         """Find the file dates encompassing [**begindate**, **begindate** + **term**]."""
         begindate, term = self._date_term_normalise(begindate, term)
-        return self._begindates_expansion(self._begin_lookup(begindate), int(term) * 60)
+        return self._begindates_expansion(
+            self._begin_lookup(begindate), int(term) * 60
+        )
 
     def enddate(self, begindate, term):
         """Find the file enddates encompassing [**begindate**, **begindate** + **term**]."""
@@ -933,33 +1174,41 @@ class ArpIfsForecastTermConfTool(ConfTool):
     """
 
     _footprint = dict(
-        info = "Conf tool that helps setting up Arpege's forecast term and outputs",
-        attr = dict(
-            kind = dict(
-                values= ['arpifs_fcterms', ],
+        info="Conf tool that helps setting up Arpege's forecast term and outputs",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "arpifs_fcterms",
+                ],
             ),
-            fcterm_def = dict(
-                info = ("The forecast's term for each cutoff and base time " +
-                        "(e.g ``{'assim':{0:6, 12:6}, 'production':{0:102}}``)"),
-                type = dict,
+            fcterm_def=dict(
+                info=(
+                    "The forecast's term for each cutoff and base time "
+                    + "(e.g ``{'assim':{0:6, 12:6}, 'production':{0:102}}``)"
+                ),
+                type=dict,
             ),
             fcterm_unit=dict(
                 info="The forecast's term unit (hour or timestep)",
-                values=['hour', 'timestep'],
+                values=["hour", "timestep"],
                 optional=True,
-                default='hour',
+                default="hour",
             ),
             hist_terms_def=dict(
-                info=("The forecast's terms when historical files are needed " +
-                      "(for permanant storage) " +
-                      "(e.g ``{'assim':{default: '0-finalterm-3'}, " +
-                      "'production':{0:'0-23-1,24-finalterm-6}}``)"),
+                info=(
+                    "The forecast's terms when historical files are needed "
+                    + "(for permanant storage) "
+                    + "(e.g ``{'assim':{default: '0-finalterm-3'}, "
+                    + "'production':{0:'0-23-1,24-finalterm-6}}``)"
+                ),
                 type=dict,
                 optional=True,
             ),
             surf_terms_def=dict(
-                info=("The forecast's terms when surface files are needed " +
-                      "(for permanant storage) "),
+                info=(
+                    "The forecast's terms when surface files are needed "
+                    + "(for permanant storage) "
+                ),
                 type=dict,
                 optional=True,
             ),
@@ -974,63 +1223,93 @@ class ArpIfsForecastTermConfTool(ConfTool):
                 optional=True,
             ),
             extra_fp_terms_def=dict(
-                info=("The forecast's terms when extra fullpos diagnostics are computed. " +
-                      "They are always computed by some offline tasks. " +
-                      "The dictionary has an additional level (describing the 'name' of the " +
-                      "extra fullpos processing"),
+                info=(
+                    "The forecast's terms when extra fullpos diagnostics are computed. "
+                    + "They are always computed by some offline tasks. "
+                    + "The dictionary has an additional level (describing the 'name' of the "
+                    + "extra fullpos processing"
+                ),
                 type=dict,
                 optional=True,
             ),
             secondary_diag_terms_def=dict(
-                info=("The forecast's terms when secondary diagnostics are computed. " +
-                      "Secondary dignostics are based on diagnostics previously created by " +
-                      "the inline/offline diag fullpos (see diag_fp_terms_def)." +
-                      "The dictionary has an additional level (describing the 'name' of the " +
-                      "secondary diags"),
+                info=(
+                    "The forecast's terms when secondary diagnostics are computed. "
+                    + "Secondary dignostics are based on diagnostics previously created by "
+                    + "the inline/offline diag fullpos (see diag_fp_terms_def)."
+                    + "The dictionary has an additional level (describing the 'name' of the "
+                    + "secondary diags"
+                ),
                 type=dict,
                 optional=True,
             ),
-            use_inline_fp = dict(
-                info = 'Use inline Fullpos to compute "core_fp_terms"',
-                type = bool,
-                optional = True,
-                default = True,
+            use_inline_fp=dict(
+                info='Use inline Fullpos to compute "core_fp_terms"',
+                type=bool,
+                optional=True,
+                default=True,
             ),
-        )
+        ),
     )
 
-    _ACTUAL_T_RE = re.compile(r'(\w+)_terms$')
-    _ACTUAL_FPLIST_T_RE = re.compile(r'(\w+)_terms_fplist$')
+    _ACTUAL_T_RE = re.compile(r"(\w+)_terms$")
+    _ACTUAL_FPLIST_T_RE = re.compile(r"(\w+)_terms_fplist$")
     _UNDEFINED = object()
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
-        self._x_fcterm = self._check_data_keys_and_times(self.fcterm_def, 'fcterm_def',
-                                                         cast=self._cast_unique_value)
-        self._x_hist_terms = self._check_data_keys_and_times(self.hist_terms_def, 'hist_terms_def',
-                                                             cast=self._cast_timerangex)
-        self._x_surf_terms = self._check_data_keys_and_times(self.surf_terms_def, 'surf_terms_def',
-                                                             cast=self._cast_timerangex)
-        self._x_norm_terms = self._check_data_keys_and_times(self.norm_terms_def, 'norm_terms_def',
-                                                             cast=self._cast_timerangex)
-        self._x_diag_fp_terms = self._check_data_keys_and_times(self.diag_fp_terms_def, 'diag_fp_terms_def',
-                                                                cast=self._cast_timerangex)
-        self._x_extra_fp_terms = dict() if self.extra_fp_terms_def is None else self.extra_fp_terms_def
-        if not all([isinstance(v, dict) for v in self._x_extra_fp_terms.values()]):
+        self._x_fcterm = self._check_data_keys_and_times(
+            self.fcterm_def, "fcterm_def", cast=self._cast_unique_value
+        )
+        self._x_hist_terms = self._check_data_keys_and_times(
+            self.hist_terms_def, "hist_terms_def", cast=self._cast_timerangex
+        )
+        self._x_surf_terms = self._check_data_keys_and_times(
+            self.surf_terms_def, "surf_terms_def", cast=self._cast_timerangex
+        )
+        self._x_norm_terms = self._check_data_keys_and_times(
+            self.norm_terms_def, "norm_terms_def", cast=self._cast_timerangex
+        )
+        self._x_diag_fp_terms = self._check_data_keys_and_times(
+            self.diag_fp_terms_def,
+            "diag_fp_terms_def",
+            cast=self._cast_timerangex,
+        )
+        self._x_extra_fp_terms = (
+            dict()
+            if self.extra_fp_terms_def is None
+            else self.extra_fp_terms_def
+        )
+        if not all(
+            [isinstance(v, dict) for v in self._x_extra_fp_terms.values()]
+        ):
             raise ValueError("extra_fp_terms values need to be dictionaries")
-        self._x_extra_fp_terms = {k: self._check_data_keys_and_times(v,
-                                                                     'extra_fp_terms_def[{:s}]'.format(k),
-                                                                     cast=self._cast_timerangex)
-                                  for k, v in self._x_extra_fp_terms.items()}
-        self._x_secondary_diag_terms_def = (dict()
-                                            if self.secondary_diag_terms_def is None
-                                            else self.secondary_diag_terms_def)
-        if not all([isinstance(v, dict) for v in self._x_secondary_diag_terms_def.values()]):
+        self._x_extra_fp_terms = {
+            k: self._check_data_keys_and_times(
+                v,
+                "extra_fp_terms_def[{:s}]".format(k),
+                cast=self._cast_timerangex,
+            )
+            for k, v in self._x_extra_fp_terms.items()
+        }
+        self._x_secondary_diag_terms_def = (
+            dict()
+            if self.secondary_diag_terms_def is None
+            else self.secondary_diag_terms_def
+        )
+        if not all(
+            [
+                isinstance(v, dict)
+                for v in self._x_secondary_diag_terms_def.values()
+            ]
+        ):
             raise ValueError("extra_fp_terms values need to be dictionaries")
         self._x_secondary_diag_terms_def = {
-            k: self._check_data_keys_and_times(v,
-                                               'secondary_diag_terms_def[{:s}]'.format(k),
-                                               cast=self._cast_timerangex)
+            k: self._check_data_keys_and_times(
+                v,
+                "secondary_diag_terms_def[{:s}]".format(k),
+                cast=self._cast_timerangex,
+            )
             for k, v in self._x_secondary_diag_terms_def.items()
         }
         self._lookup_cache = dict()
@@ -1040,7 +1319,7 @@ class ArpIfsForecastTermConfTool(ConfTool):
     def _clone(self, **kwargs):
         my_args = self.footprint_as_shallow_dict()
         my_args.update(kwargs)
-        return self.__class__(** my_args)
+        return self.__class__(**my_args)
 
     @property
     def no_inline(self):
@@ -1054,7 +1333,7 @@ class ArpIfsForecastTermConfTool(ConfTool):
         return value
 
     def _cast_unique_value(self, value):
-        if self.fcterm_unit == 'hour':
+        if self.fcterm_unit == "hour":
             return Time(value)
         else:
             return int(value)
@@ -1063,7 +1342,7 @@ class ArpIfsForecastTermConfTool(ConfTool):
     def _cast_timerangex(value):
         if not (value is None or isinstance(value, str)):
             if isinstance(value, collections.abc.Iterable):
-                value = ','.join([str(e) for e in value])
+                value = ",".join([str(e) for e in value])
             else:
                 value = str(value)
         return value
@@ -1074,8 +1353,10 @@ class ArpIfsForecastTermConfTool(ConfTool):
         if data is None:
             return dict(default=dict(default=None))
         else:
-            if not set(data.keys()) <= {'assim', 'production', 'default'}:
-                raise ValueError('Impoper value ({!s}) for "{:s}".'.format(data, dataname))
+            if not set(data.keys()) <= {"assim", "production", "default"}:
+                raise ValueError(
+                    'Impoper value ({!s}) for "{:s}".'.format(data, dataname)
+                )
             return data
 
     def _check_data_keys_and_times(self, data, dataname, cast=None):
@@ -1085,14 +1366,25 @@ class ArpIfsForecastTermConfTool(ConfTool):
         new_data = dict()
         for data_k, data_v in data.items():
             if not isinstance(data_v, dict):
-                raise ValueError('The {:s} "{:s}" entry should be a dictionary (got "{!s}")'
-                                 .format(dataname, data_k, data_v))
+                raise ValueError(
+                    'The {:s} "{:s}" entry should be a dictionary (got "{!s}")'.format(
+                        dataname, data_k, data_v
+                    )
+                )
             try:
-                new_data[data_k] = {'default' if k == 'default' else Time(k): cast(v)
-                                    for k, v in data_v.items()}
+                new_data[data_k] = {
+                    "default" if k == "default" else Time(k): cast(v)
+                    for k, v in data_v.items()
+                }
             except ValueError as e:
-                raise ValueError("Error while processing {:s}'s {:s}: ".format(dataname, data_k) +
-                                 "Could not convert to Time (original message '{!s}')".format(e))
+                raise ValueError(
+                    "Error while processing {:s}'s {:s}: ".format(
+                        dataname, data_k
+                    )
+                    + "Could not convert to Time (original message '{!s}')".format(
+                        e
+                    )
+                )
         return new_data
 
     def _cutoff_hh_lookup(self, what_desc, cutoff, hh, rawdata=None):
@@ -1101,15 +1393,23 @@ class ArpIfsForecastTermConfTool(ConfTool):
             hh = Time(hh)
         if (what_desc, cutoff, hh) not in self._lookup_cache:
             if rawdata is None:
-                rawdata = getattr(self, '_x_{:s}'.format(what_desc))
-            cutoff_v = rawdata.get(cutoff, rawdata.get('default', self._UNDEFINED))
+                rawdata = getattr(self, "_x_{:s}".format(what_desc))
+            cutoff_v = rawdata.get(
+                cutoff, rawdata.get("default", self._UNDEFINED)
+            )
             if cutoff_v is self._UNDEFINED:
-                raise ValueError('Nothing is defined for cutoff="{:s}" in "{:s}"'
-                                 .format(cutoff, what_desc))
-            hh_v = cutoff_v.get(hh, cutoff_v.get('default', self._UNDEFINED))
+                raise ValueError(
+                    'Nothing is defined for cutoff="{:s}" in "{:s}"'.format(
+                        cutoff, what_desc
+                    )
+                )
+            hh_v = cutoff_v.get(hh, cutoff_v.get("default", self._UNDEFINED))
             if hh_v is self._UNDEFINED:
-                raise ValueError('Nothing is defined for cutoff="{:s}"/hh="{!s}" in "{:s}"'
-                                 .format(cutoff, hh, what_desc))
+                raise ValueError(
+                    'Nothing is defined for cutoff="{:s}"/hh="{!s}" in "{:s}"'.format(
+                        cutoff, hh, what_desc
+                    )
+                )
             self._lookup_cache[(what_desc, cutoff, hh)] = hh_v
         return self._lookup_cache[(what_desc, cutoff, hh)]
 
@@ -1117,26 +1417,34 @@ class ArpIfsForecastTermConfTool(ConfTool):
         """Look for a particular cutoff in self._x_what_desc and resolve the rangex."""
         if (what_desc, cutoff, hh) not in self._lookup_rangex_cache:
             try:
-                what = self._cutoff_hh_lookup(what_desc, cutoff, hh, rawdata=rawdata)
+                what = self._cutoff_hh_lookup(
+                    what_desc, cutoff, hh, rawdata=rawdata
+                )
             except ValueError:
                 what = None
             if what is None:
                 self._lookup_rangex_cache[(what_desc, cutoff, hh)] = list()
             else:
-                finalterm = self._cutoff_hh_lookup('fcterm', cutoff, hh)
-                if 'finalterm' in what:
-                    what = what.replace('finalterm', str(finalterm))
+                finalterm = self._cutoff_hh_lookup("fcterm", cutoff, hh)
+                if "finalterm" in what:
+                    what = what.replace("finalterm", str(finalterm))
                 try:
                     tir = timeintrangex(what)
                 except (TypeError, ValueError):
                     raise ValueError(
-                        'Could not process "{:s}" using timeintrangex (from "{:s}" with cutoff={:s}/hh={!s})'
-                        .format(what, what_desc, cutoff, hh)
+                        'Could not process "{:s}" using timeintrangex (from "{:s}" with cutoff={:s}/hh={!s})'.format(
+                            what, what_desc, cutoff, hh
+                        )
                     )
-                if self.fcterm_unit == 'timestep' and not all([isinstance(i, int) for i in tir]):
-                    raise ValueError('No hours/minutes allowed when fcterm_unit is "timestep" ' +
-                                     '(from "{:s}" with cutoff={:s}/hh={!s})'
-                                     .format(what_desc, cutoff, hh))
+                if self.fcterm_unit == "timestep" and not all(
+                    [isinstance(i, int) for i in tir]
+                ):
+                    raise ValueError(
+                        'No hours/minutes allowed when fcterm_unit is "timestep" '
+                        + '(from "{:s}" with cutoff={:s}/hh={!s})'.format(
+                            what_desc, cutoff, hh
+                        )
+                    )
                 self._lookup_rangex_cache[(what_desc, cutoff, hh)] = sorted(
                     [t for t in tir if t <= finalterm]
                 )
@@ -1144,7 +1452,7 @@ class ArpIfsForecastTermConfTool(ConfTool):
 
     def fcterm(self, cutoff, hh):
         """The forecast term for **cutoff** and **hh**."""
-        fcterm = self._cutoff_hh_lookup('fcterm', cutoff, hh)
+        fcterm = self._cutoff_hh_lookup("fcterm", cutoff, hh)
         if isinstance(fcterm, Time) and fcterm.minute == 0:
             return fcterm.hour
         else:
@@ -1152,22 +1460,22 @@ class ArpIfsForecastTermConfTool(ConfTool):
 
     def hist_terms(self, cutoff, hh):
         """The list of terms for requested/archived historical files."""
-        return self._cutoff_hh_rangex_lookup('hist_terms', cutoff, hh)
+        return self._cutoff_hh_rangex_lookup("hist_terms", cutoff, hh)
 
     def surf_terms(self, cutoff, hh):
         """The list of terms for historical surface files."""
-        return self._cutoff_hh_rangex_lookup('surf_terms', cutoff, hh)
+        return self._cutoff_hh_rangex_lookup("surf_terms", cutoff, hh)
 
     def norm_terms(self, cutoff, hh):
         """The list of terms for norm calculations."""
-        return self._cutoff_hh_rangex_lookup('norm_terms', cutoff, hh)
+        return self._cutoff_hh_rangex_lookup("norm_terms", cutoff, hh)
 
     def inline_terms(self, cutoff, hh):
         """The list of terms for inline diagnostics."""
         if self.use_inline_fp:
             return sorted(
-                set(self._cutoff_hh_rangex_lookup('diag_fp_terms', cutoff, hh)) |
-                self._secondary_diag_terms_set(cutoff, hh)
+                set(self._cutoff_hh_rangex_lookup("diag_fp_terms", cutoff, hh))
+                | self._secondary_diag_terms_set(cutoff, hh)
             )
         else:
             return list()
@@ -1178,8 +1486,8 @@ class ArpIfsForecastTermConfTool(ConfTool):
             return list()
         else:
             return sorted(
-                set(self._cutoff_hh_rangex_lookup('diag_fp_terms', cutoff, hh)) |
-                self._secondary_diag_terms_set(cutoff, hh)
+                set(self._cutoff_hh_rangex_lookup("diag_fp_terms", cutoff, hh))
+                | self._secondary_diag_terms_set(cutoff, hh)
             )
 
     def diag_terms_fplist(self, cutoff, hh):
@@ -1188,15 +1496,21 @@ class ArpIfsForecastTermConfTool(ConfTool):
         return FPList(flist) if flist else []
 
     def _extra_fp_terms_item_fplist(self, item, cutoff, hh):
-        flist = self._cutoff_hh_rangex_lookup('extra_fp_terms[{:s}]'.format(item),
-                                              cutoff, hh,
-                                              rawdata=self._x_extra_fp_terms[item])
+        flist = self._cutoff_hh_rangex_lookup(
+            "extra_fp_terms[{:s}]".format(item),
+            cutoff,
+            hh,
+            rawdata=self._x_extra_fp_terms[item],
+        )
         return FPList(flist) if flist else []
 
     def _secondary_diag_terms_item_fplist(self, item, cutoff, hh):
-        flist = self._cutoff_hh_rangex_lookup('secondary_diag_terms[{:s}]'.format(item),
-                                              cutoff, hh,
-                                              rawdata=self._x_secondary_diag_terms_def[item])
+        flist = self._cutoff_hh_rangex_lookup(
+            "secondary_diag_terms[{:s}]".format(item),
+            cutoff,
+            hh,
+            rawdata=self._x_secondary_diag_terms_def[item],
+        )
         return FPList(flist) if flist else []
 
     @secure_getattr
@@ -1204,37 +1518,65 @@ class ArpIfsForecastTermConfTool(ConfTool):
         actual_m = self._ACTUAL_T_RE.match(item)
         actual_fplist_m = self._ACTUAL_FPLIST_T_RE.match(item)
         if actual_m and actual_m.group(1) in self._x_extra_fp_terms.keys():
-            return functools.partial(self._cutoff_hh_rangex_lookup,
-                                     'extra_fp_terms[{:s}]'.format(actual_m.group(1)),
-                                     rawdata=self._x_extra_fp_terms[actual_m.group(1)])
-        elif actual_fplist_m and actual_fplist_m.group(1) in self._x_extra_fp_terms.keys():
-            return functools.partial(self._extra_fp_terms_item_fplist,
-                                     actual_fplist_m.group(1))
-        elif actual_m and actual_m.group(1) in self._x_secondary_diag_terms_def.keys():
-            return functools.partial(self._cutoff_hh_rangex_lookup,
-                                     'secondary_diag_terms[{:s}]'.format(actual_m.group(1)),
-                                     rawdata=self._x_secondary_diag_terms_def[actual_m.group(1)])
-        elif actual_fplist_m and actual_fplist_m.group(1) in self._x_secondary_diag_terms_def.keys():
-            return functools.partial(self._secondary_diag_terms_item_fplist,
-                                     actual_fplist_m.group(1))
+            return functools.partial(
+                self._cutoff_hh_rangex_lookup,
+                "extra_fp_terms[{:s}]".format(actual_m.group(1)),
+                rawdata=self._x_extra_fp_terms[actual_m.group(1)],
+            )
+        elif (
+            actual_fplist_m
+            and actual_fplist_m.group(1) in self._x_extra_fp_terms.keys()
+        ):
+            return functools.partial(
+                self._extra_fp_terms_item_fplist, actual_fplist_m.group(1)
+            )
+        elif (
+            actual_m
+            and actual_m.group(1) in self._x_secondary_diag_terms_def.keys()
+        ):
+            return functools.partial(
+                self._cutoff_hh_rangex_lookup,
+                "secondary_diag_terms[{:s}]".format(actual_m.group(1)),
+                rawdata=self._x_secondary_diag_terms_def[actual_m.group(1)],
+            )
+        elif (
+            actual_fplist_m
+            and actual_fplist_m.group(1)
+            in self._x_secondary_diag_terms_def.keys()
+        ):
+            return functools.partial(
+                self._secondary_diag_terms_item_fplist,
+                actual_fplist_m.group(1),
+            )
         else:
             raise AttributeError('Attribute "{:s}" was not found'.format(item))
 
     def _fpoff_terms_set(self, cutoff, hh):
         fpoff_terms = set()
         for k, v in self._x_extra_fp_terms.items():
-            fpoff_terms.update(self._cutoff_hh_rangex_lookup('extra_fp_terms[{:s}]'.format(k),
-                                                             cutoff, hh, rawdata=v))
+            fpoff_terms.update(
+                self._cutoff_hh_rangex_lookup(
+                    "extra_fp_terms[{:s}]".format(k), cutoff, hh, rawdata=v
+                )
+            )
         if not self.use_inline_fp:
-            fpoff_terms.update(self._cutoff_hh_rangex_lookup('diag_fp_terms', cutoff, hh))
+            fpoff_terms.update(
+                self._cutoff_hh_rangex_lookup("diag_fp_terms", cutoff, hh)
+            )
             fpoff_terms.update(self._secondary_diag_terms_set(cutoff, hh))
         return fpoff_terms
 
     def _secondary_diag_terms_set(self, cutoff, hh):
         sec_terms = set()
         for k, v in self._x_secondary_diag_terms_def.items():
-            sec_terms.update(self._cutoff_hh_rangex_lookup('secondary_diag_terms[{:s}]'.format(k),
-                                                           cutoff, hh, rawdata=v))
+            sec_terms.update(
+                self._cutoff_hh_rangex_lookup(
+                    "secondary_diag_terms[{:s}]".format(k),
+                    cutoff,
+                    hh,
+                    rawdata=v,
+                )
+            )
         return sec_terms
 
     def extra_hist_terms(self, cutoff, hh):
@@ -1256,14 +1598,17 @@ class ArpIfsForecastTermConfTool(ConfTool):
 
     def fpoff_items(self, cutoff, hh, discard=None, only=None):
         """List of active offline post-processing domains."""
-        items = {k
-                 for k, v in self._x_extra_fp_terms.items()
-                 if self._cutoff_hh_rangex_lookup('extra_fp_terms[{:s}]'.format(k),
-                                                  cutoff,
-                                                  hh,
-                                                  rawdata=v)}
-        if not self.use_inline_fp and self._cutoff_hh_rangex_lookup('diag_fp_terms', cutoff, hh):
-            items.add('diag')
+        items = {
+            k
+            for k, v in self._x_extra_fp_terms.items()
+            if self._cutoff_hh_rangex_lookup(
+                "extra_fp_terms[{:s}]".format(k), cutoff, hh, rawdata=v
+            )
+        }
+        if not self.use_inline_fp and self._cutoff_hh_rangex_lookup(
+            "diag_fp_terms", cutoff, hh
+        ):
+            items.add("diag")
         if discard:
             items -= set(discard)
         if only:
@@ -1272,13 +1617,17 @@ class ArpIfsForecastTermConfTool(ConfTool):
 
     def fpoff_terms_map(self, cutoff, hh):
         """The mapping dictionary between offline post-processing terms and domains."""
-        return {k: getattr(self, '{:s}_terms'.format(k))(cutoff, hh)
-                for k in self.fpoff_items(cutoff, hh)}
+        return {
+            k: getattr(self, "{:s}_terms".format(k))(cutoff, hh)
+            for k in self.fpoff_items(cutoff, hh)
+        }
 
     def fpoff_terms_fpmap(self, cutoff, hh):
         """The mapping dictionary between offline post-processing terms and domains (as a FPlist)."""
-        return {k: getattr(self, '{:s}_terms_fplist'.format(k))(cutoff, hh)
-                for k in self.fpoff_items(cutoff, hh)}
+        return {
+            k: getattr(self, "{:s}_terms_fplist".format(k))(cutoff, hh)
+            for k in self.fpoff_items(cutoff, hh)
+        }
 
 
 class TimeSlotsConfTool(AbstractObjectProxyConfTool):
@@ -1294,18 +1643,19 @@ class TimeSlotsConfTool(AbstractObjectProxyConfTool):
     """
 
     _footprint = dict(
-        info = 'Gives easy access to a Timeslots object.',
-        attr = dict(
-            timeslots_def = dict(
-                info        = "The timeslots specification",
+        info="Gives easy access to a Timeslots object.",
+        attr=dict(
+            timeslots_def=dict(
+                info="The timeslots specification",
             ),
-        )
+        ),
     )
 
     def _create_proxied_obj(self):
         return TimeSlots(self.timeslots_def)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/src/vortex/nwp/tools/drhook.py
+++ b/src/vortex/nwp/tools/drhook.py
@@ -5,7 +5,11 @@ Common interest classes to help setup the DrHook library environment.
 import footprints
 from bronx.fancies import loggers
 
-from vortex.algo.components import AlgoComponentDecoMixin, Parallel, algo_component_deco_mixin_autodoc
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    Parallel,
+    algo_component_deco_mixin_autodoc,
+)
 
 #: No automatic export
 __all__ = []
@@ -28,14 +32,15 @@ class DrHookDecoMixin(AlgoComponentDecoMixin):
         footprints.Footprint(
             attr=dict(
                 drhookprof=dict(
-                    info='Activate the DrHook profiling.',
+                    info="Activate the DrHook profiling.",
                     optional=True,
                     type=bool,
                     default=False,
                     doc_zorder=-50,
                 ),
             ),
-        )]
+        )
+    ]
 
     def _drhook_varexport(self, rh, opts):  # @UnusedVariable
         """Export proper DrHook variables"""
@@ -45,8 +50,8 @@ class DrHookDecoMixin(AlgoComponentDecoMixin):
                 ("DR_HOOK_OPT", "prof"),
                 ("DR_HOOK_IGNORE_SIGNALS", "-1"),
             ]
-            if self.drhookprof else
-            [("DR_HOOK", "0"), ("DR_HOOK_IGNORE_SIGNALS", "-1")]
+            if self.drhookprof
+            else [("DR_HOOK", "0"), ("DR_HOOK_IGNORE_SIGNALS", "-1")]
         )
         if not isinstance(self, Parallel):
             drhook_vars += [
@@ -55,8 +60,7 @@ class DrHookDecoMixin(AlgoComponentDecoMixin):
                 ("DR_HOOK_ASSERT_MPI_INITIALIZED", "0"),
             ]
         for k, v in drhook_vars:
-            logger.info('Setting DRHOOK env %s = %s', k, v)
+            logger.info("Setting DRHOOK env %s = %s", k, v)
             self.env[k] = v
 
-
-    _MIXIN_PREPARE_HOOKS = (_drhook_varexport, )
+    _MIXIN_PREPARE_HOOKS = (_drhook_varexport,)

--- a/src/vortex/nwp/tools/grib.py
+++ b/src/vortex/nwp/tools/grib.py
@@ -71,7 +71,9 @@ class _GenericFilter:
             elif isinstance(a_filter, str):
                 self._filters.append(json.loads(a_filter))
             elif isinstance(a_filter, Context):
-                for a_request in a_filter.sequence.effective_inputs(kind='filtering_request'):
+                for a_request in a_filter.sequence.effective_inputs(
+                    kind="filtering_request"
+                ):
                     self._filters.append(a_request.rh.contents.data)
 
     def __len__(self):
@@ -84,7 +86,7 @@ class _GenericFilter:
         superset_ok = True
         for k, v in subset.items():
             # Ignore the comments...
-            if k.startswith('comment'):
+            if k.startswith("comment"):
                 continue
             # Check for the key inside the full dictionary
             try:
@@ -105,12 +107,14 @@ class _GenericFilter:
 
     def _filter_process(self, fid, a_filter):
         """Check if the data's fid complies with the filter."""
-        includes = a_filter.get('fields_include', [])
-        excludes = a_filter.get('fields_exclude', [])
+        includes = a_filter.get("fields_include", [])
+        excludes = a_filter.get("fields_exclude", [])
         try:
-            fid = fid[a_filter['fid_format']]
+            fid = fid[a_filter["fid_format"]]
         except KeyboardInterrupt:
-            raise ValueError("Please specify a valid fid_format in the filter description")
+            raise ValueError(
+                "Please specify a valid fid_format in the filter description"
+            )
         # First process includes
         includes_ok = True
         for include in includes:
@@ -127,13 +131,13 @@ class _GenericFilter:
 
     def __call__(self, inputfile, outfile_fmt):
         """Apply the various filters on *inputfile*. Should be implemented..."""
-        raise NotImplementedError('This method have to be overwritten.')
+        raise NotImplementedError("This method have to be overwritten.")
 
 
 class GRIBFilter(_GenericFilter):
     """Class in charge of filtering GRIB files."""
 
-    CONCATENATE_FILTER = 'concatenate'
+    CONCATENATE_FILTER = "concatenate"
 
     def __init__(self, concatenate=False):
         """
@@ -142,7 +146,7 @@ class GRIBFilter(_GenericFilter):
         """
         super().__init__()
         self.concatenate = concatenate
-        self._xgrib_support = 'grib' in self._sh.loaded_addons()
+        self._xgrib_support = "grib" in self._sh.loaded_addons()
 
     def __len__(self):
         """Returns the number of active filters (concatenate included)."""
@@ -151,16 +155,21 @@ class GRIBFilter(_GenericFilter):
     def _simple_cat(self, gribfile, outfile_fmt, intent):
         """Just concatenate a multipart GRIB."""
         if self._xgrib_support and self._sh.is_xgrib(gribfile):
-            self._sh.xgrib_pack(gribfile,
-                                outfile_fmt.format(filtername=self.CONCATENATE_FILTER),
-                                intent=intent)
+            self._sh.xgrib_pack(
+                gribfile,
+                outfile_fmt.format(filtername=self.CONCATENATE_FILTER),
+                intent=intent,
+            )
         else:
             # Just make a copy with the appropriate name...
-            self._sh.cp(gribfile,
-                        outfile_fmt.format(filtername=self.CONCATENATE_FILTER),
-                        intent=intent, fmt='grib')
+            self._sh.cp(
+                gribfile,
+                outfile_fmt.format(filtername=self.CONCATENATE_FILTER),
+                intent=intent,
+                fmt="grib",
+            )
 
-    def __call__(self, gribfile, outfile_fmt, intent='in'):
+    def __call__(self, gribfile, outfile_fmt, intent="in"):
         """Apply the various filters on *gribfile*.
 
         :param gribfile: The path to the input GRIB file
@@ -178,52 +187,63 @@ class GRIBFilter(_GenericFilter):
         if not self._filters:
             if self.concatenate:
                 self._simple_cat(gribfile, outfile_fmt, intent=intent)
-                return [outfile_fmt.format(filtername=self.CONCATENATE_FILTER), ]
+                return [
+                    outfile_fmt.format(filtername=self.CONCATENATE_FILTER),
+                ]
             else:
                 raise ValueError("Set concatenate=True or provide a filter.")
 
         # Open the input file using Epygram
         from ..util import usepygram
-        if not usepygram.epygram_checker.is_available(version='1.0.0'):
+
+        if not usepygram.epygram_checker.is_available(version="1.0.0"):
             raise AlgoComponentError("Epygram (v1.0.0) needs to be available")
 
         if self._xgrib_support and self._sh.is_xgrib(gribfile):
             idx = self._sh.xgrib_index_get(gribfile)
-            in_data = [footprints.proxy.dataformat(
-                filename=self._sh.path.realpath(a_gribfile),
-                openmode='r',
-                format='GRIB',
-            ) for a_gribfile in idx]
+            in_data = [
+                footprints.proxy.dataformat(
+                    filename=self._sh.path.realpath(a_gribfile),
+                    openmode="r",
+                    format="GRIB",
+                )
+                for a_gribfile in idx
+            ]
         else:
-            in_data = [footprints.proxy.dataformat(
-                filename=self._sh.path.realpath(gribfile),
-                openmode='r',
-                format='GRIB',
-            ), ]
+            in_data = [
+                footprints.proxy.dataformat(
+                    filename=self._sh.path.realpath(gribfile),
+                    openmode="r",
+                    format="GRIB",
+                ),
+            ]
 
         # Open output files
         out_data = list()
         out_filelist = list()
         for a_filter in self._filters:
-            f_name = outfile_fmt.format(filtername=a_filter['filter_name'])
+            f_name = outfile_fmt.format(filtername=a_filter["filter_name"])
             out_filelist.append(f_name)
             # It would be a lot better to use io.open but grib_api is very annoying !
-            out_data.append(open(f_name, 'wb'))
+            out_data.append(open(f_name, "wb"))
         if self.concatenate:
             f_name = outfile_fmt.format(filtername=self.CONCATENATE_FILTER)
             out_filelist.append(f_name)
             # It would be a lot better to use io.open but grib_api is very annoying !
-            out_cat = open(f_name, 'wb')
+            out_cat = open(f_name, "wb")
 
         with usepygram.epy_env_prepare(sessions.current()):
             for a_in_data in in_data:
                 msg = a_in_data.iter_messages(headers_only=False)
                 while msg is not None:
-                    for (a_out_data, a_filter) in zip(out_data, self._filters):
+                    for a_out_data, a_filter in zip(out_data, self._filters):
                         thefid = msg.genfid()
                         if self._filter_process(thefid, a_filter):
-                            logger.debug("Select succeed for filter %s: %s",
-                                         a_filter['filter_name'], thefid)
+                            logger.debug(
+                                "Select succeed for filter %s: %s",
+                                a_filter["filter_name"],
+                                thefid,
+                            )
                             msg.write_to_file(a_out_data)
                     if self.concatenate:
                         msg.write_to_file(out_cat)
@@ -248,14 +268,16 @@ def grib_inplace_cat(t, rh):
     :param t: A :class:`vortex.sessions.Ticket` object
     :param rh: A :class:`vortex.data.handlers.Handler` object
     """
-    xgrib_support = 'grib' in t.sh.loaded_addons()
+    xgrib_support = "grib" in t.sh.loaded_addons()
     if xgrib_support:
         if t.sh.is_xgrib(rh.container.localpath()):
             # Some cleanup...
             rh.reset_contents()
             rh.container.close()
             # Move the index file prior to the concatenation
-            tmpfile = rh.container.localpath() + '_concat' + t.sh.safe_filesuffix()
+            tmpfile = (
+                rh.container.localpath() + "_concat" + t.sh.safe_filesuffix()
+            )
             t.sh.move(rh.container.localpath(), tmpfile)
             # Concatenate
             t.sh.xgrib_pack(tmpfile, rh.container.localpath())
@@ -263,6 +285,10 @@ def grib_inplace_cat(t, rh):
             t.sh.grib_remove(tmpfile)
             logger.info("The multipart GRIB has been concatenated.")
         else:
-            logger.info("The localpath is not a multipart GRIB: nothing to do.")
+            logger.info(
+                "The localpath is not a multipart GRIB: nothing to do."
+            )
     else:
-        logger.info("Multipart GRIB support is not activated: nothing can be done.")
+        logger.info(
+            "Multipart GRIB support is not activated: nothing can be done."
+        )

--- a/src/vortex/nwp/tools/gribdiff.py
+++ b/src/vortex/nwp/tools/gribdiff.py
@@ -18,7 +18,7 @@ class _GRIBDIFF_Plus_St:
         self._result = result
 
     def __str__(self):
-        return '{:s} | rc={:d}>'.format(repr(self).rstrip('>'), self.rc)
+        return "{:s} | rc={:d}>".format(repr(self).rstrip(">"), self.rc)
 
     @property
     def result(self):
@@ -38,8 +38,9 @@ class _GRIBDIFF_Plus_Res:
         self._epydiff_res = epydiff_res
 
     def __str__(self):
-        return ('{0:s} | gribapi_rc={1:d} epydiff_done={2:d}>'.
-                format(repr(self).rstrip('>'), self._gapi, self._epydiff))
+        return "{0:s} | gribapi_rc={1:d} epydiff_done={2:d}>".format(
+            repr(self).rstrip(">"), self._gapi, self._epydiff
+        )
 
     def differences(self):
         """Print detailed informations about the diff."""
@@ -52,17 +53,17 @@ class GRIBDIFF_Plus(GRIBAPI_Tool):
     """
 
     _footprint = dict(
-        info = 'Default GRIBAPI system interface',
-        attr = dict(
-            maxepydiff = dict(
-                info = 'Epygram diffs are costfull, they will run only maxepydiff times',
-                type = int,
-                default = 2,
-                optional = True,
+        info="Default GRIBAPI system interface",
+        attr=dict(
+            maxepydiff=dict(
+                info="Epygram diffs are costfull, they will run only maxepydiff times",
+                type=int,
+                default=2,
+                optional=True,
             ),
         ),
-        priority = dict(
-            level = footprints.priorities.top.TOOLBOX  # @UndefinedVariable
+        priority=dict(
+            level=footprints.priorities.top.TOOLBOX  # @UndefinedVariable
         ),
     )
 
@@ -76,10 +77,12 @@ class GRIBDIFF_Plus(GRIBAPI_Tool):
         if not rc:
             if self._epyavail is None:
                 from ..util.usepygram import epygram_checker
-                self._epyavail = epygram_checker.is_available(version='1.0.0')
+
+                self._epyavail = epygram_checker.is_available(version="1.0.0")
             if self._epyavail:
                 if self._epycount < self.maxepydiff:
                     from ..util.diffpygram import EpyGribDiff
+
                     gdiff = EpyGribDiff(grib2, grib1)  # Ref file is first...
                     self._epycount += 1
                     res = _GRIBDIFF_Plus_Res(rc, True, str(gdiff))
@@ -88,12 +91,14 @@ class GRIBDIFF_Plus(GRIBAPI_Tool):
                         outfh.write(gdiff.format_diff(detailed=True))
                 else:
                     res = _GRIBDIFF_Plus_Res(
-                        rc, False,
-                        "grib_compare failed (but the Epygram diffs max number is exceeded...)"
+                        rc,
+                        False,
+                        "grib_compare failed (but the Epygram diffs max number is exceeded...)",
                     )
             else:
-                res = _GRIBDIFF_Plus_Res(rc, False,
-                                         "grib_compare failed (Epygram unavailable)")
+                res = _GRIBDIFF_Plus_Res(
+                    rc, False, "grib_compare failed (Epygram unavailable)"
+                )
         else:
             res = _GRIBDIFF_Plus_Res(rc, False, "")
         return _GRIBDIFF_Plus_St(rc, res)

--- a/src/vortex/nwp/tools/ifstools.py
+++ b/src/vortex/nwp/tools/ifstools.py
@@ -30,7 +30,7 @@ class _IfsOutputsTimesListDesc:
             instance._tlists_store.pop(self._attr, None)
         else:
             if not isinstance(value, list):
-                raise ValueError('**value** should be a list.')
+                raise ValueError("**value** should be a list.")
             instance._tlists_store[self._attr] = [Time(t) for t in value]
 
     def __delete__(self, instance):
@@ -41,40 +41,41 @@ class IfsOutputsAbstractConfigurator(footprints.FootprintBase):
     """Abstract utility class to configure the IFS model regarding output data."""
 
     _abstract = True
-    _collector = ('ifsoutputs_configurator', )
+    _collector = ("ifsoutputs_configurator",)
     _footprint = [
         model,
         arpifs_cycle,
         dict(
             attr=dict(
-                fcterm_unit = dict(
-                    info     = 'The unit used in the *fcterm* attribute.',
-                    values   = ['h', 't']
+                fcterm_unit=dict(
+                    info="The unit used in the *fcterm* attribute.",
+                    values=["h", "t"],
                 ),
             )
-        )
+        ),
     ]
 
-    def __init__(self, * kargs, ** kwargs):
-        super().__init__(* kargs, ** kwargs)
+    def __init__(self, *kargs, **kwargs):
+        super().__init__(*kargs, **kwargs)
         self._tlists_store = dict()
 
     modelstate = _IfsOutputsTimesListDesc(
-        "modelstate",
-        "The list of terms for modelstate outputs."
+        "modelstate", "The list of terms for modelstate outputs."
     )
 
     surf_modelstate = _IfsOutputsTimesListDesc(
         "surf_modelstate",
-        "The list of terms for surface scheme modelstate outputs.")
+        "The list of terms for surface scheme modelstate outputs.",
+    )
 
     spectral_diag = _IfsOutputsTimesListDesc(
         "spectral_diag",
-        "The list of terms for spectral space diagnostics outputs.")
+        "The list of terms for spectral space diagnostics outputs.",
+    )
 
     post_processing = _IfsOutputsTimesListDesc(
         "post_processing",
-        "The list of terms for inline post-processing outputs."
+        "The list of terms for inline post-processing outputs.",
     )
 
     def _setup_nam_obj(self, namelist_object, namelist_name):
@@ -105,59 +106,98 @@ class IfsOutputsConfigurator(IfsOutputsAbstractConfigurator):
     def _set_namvar_value(namblock, var, value, namname):
         """Set a value in a **namblock** namelist and log it."""
         namblock[var] = value
-        logger.info('Setup &%s %s=%s / (file: %s)',
-                    namblock.name, var, namblock.nice(value), namname)
+        logger.info(
+            "Setup &%s %s=%s / (file: %s)",
+            namblock.name,
+            var,
+            namblock.nice(value),
+            namname,
+        )
 
     @staticmethod
     def _clean_namvar(namblock, var, namname):
         """Clean the **var** value from the **namblock** namelist."""
-        todo = {k for k in namblock.keys() if re.match(var + r'($|\(|%)', k)}
+        todo = {k for k in namblock.keys() if re.match(var + r"($|\(|%)", k)}
         if todo:
             for k in todo:
                 namblock.delvar(k)
-            logger.info('Cleaning %s variable in namelist &%s (file: %s)',
-                        var, namblock.name, namname)
+            logger.info(
+                "Cleaning %s variable in namelist &%s (file: %s)",
+                var,
+                namblock.name,
+                namname,
+            )
 
     def _generic_terms_setup(self, namct0, namct1, what, terms, namname):
         """Setup a given kind of output data (in a generic way)."""
         if terms is not None:
-            sign = -1 if self.fcterm_unit == 'h' else 1
+            sign = -1 if self.fcterm_unit == "h" else 1
             with_minutes = any([t.minute > 0 for t in terms])
-            self._clean_namvar(namct0, 'NFR{:s}'.format(what), namname)
-            self._clean_namvar(namct0, 'N{:s}TS'.format(what), namname)
-            self._clean_namvar(namct0, 'N{:s}TSMIN'.format(what), namname)
-            self._set_namvar_value(namct1, 'N1{:s}'.format(what), 1 if terms else 0, namname)
+            self._clean_namvar(namct0, "NFR{:s}".format(what), namname)
+            self._clean_namvar(namct0, "N{:s}TS".format(what), namname)
+            self._clean_namvar(namct0, "N{:s}TSMIN".format(what), namname)
+            self._set_namvar_value(
+                namct1, "N1{:s}".format(what), 1 if terms else 0, namname
+            )
             if terms:
-                self._set_namvar_value(namct0, 'N{:s}TS(0)'.format(what), sign * len(terms), namname)
+                self._set_namvar_value(
+                    namct0,
+                    "N{:s}TS(0)".format(what),
+                    sign * len(terms),
+                    namname,
+                )
                 if with_minutes:
-                    if 'cy46' <= self.cycle < 'cy47':  # Temporary fix for cy46 only
-                        self._set_namvar_value(namct0, 'N{:s}TSMIN(0)'.format(what),
-                                               len(terms), namname)
-                logger.info('Setting up N%sTS and N%sTSMIN in &%s (file: %s)',
-                            what, what, namct0.name, namname)
+                    if (
+                        "cy46" <= self.cycle < "cy47"
+                    ):  # Temporary fix for cy46 only
+                        self._set_namvar_value(
+                            namct0,
+                            "N{:s}TSMIN(0)".format(what),
+                            len(terms),
+                            namname,
+                        )
+                logger.info(
+                    "Setting up N%sTS and N%sTSMIN in &%s (file: %s)",
+                    what,
+                    what,
+                    namct0.name,
+                    namname,
+                )
                 for i, t in enumerate(terms):
-                    namct0['N{:s}TS({:d})'.format(what, i + 1)] = sign * t.hour
+                    namct0["N{:s}TS({:d})".format(what, i + 1)] = sign * t.hour
                 if with_minutes:
                     for i, t in enumerate(terms):
-                        namct0['N{:s}TSMIN({:d})'.format(what, i + 1)] = t.minute
+                        namct0["N{:s}TSMIN({:d})".format(what, i + 1)] = (
+                            t.minute
+                        )
 
     def _setup_nam_obj(self, namelist_object, namelist_name):
         """Actualy tweak the IFS namelist."""
-        namoph = self._get_namblock(namelist_object, 'NAMOPH')
-        namct0 = self._get_namblock(namelist_object, 'NAMCT0')
-        namct1 = self._get_namblock(namelist_object, 'NAMCT1')
+        namoph = self._get_namblock(namelist_object, "NAMOPH")
+        namct0 = self._get_namblock(namelist_object, "NAMCT0")
+        namct1 = self._get_namblock(namelist_object, "NAMCT1")
         # First take into account the **fcterm_unit**
-        self._set_namvar_value(namoph, 'LINC', self.fcterm_unit == 'h', namelist_name)
+        self._set_namvar_value(
+            namoph, "LINC", self.fcterm_unit == "h", namelist_name
+        )
         # Setup outputs
-        self._generic_terms_setup(namct0, namct1, 'HIS', self.modelstate, namelist_name)
-        self._generic_terms_setup(namct0, namct1, 'SFXHIS', self.surf_modelstate, namelist_name)
-        self._generic_terms_setup(namct0, namct1, 'SDI', self.spectral_diag, namelist_name)
-        self._generic_terms_setup(namct0, namct1, 'POS', self.post_processing, namelist_name)
+        self._generic_terms_setup(
+            namct0, namct1, "HIS", self.modelstate, namelist_name
+        )
+        self._generic_terms_setup(
+            namct0, namct1, "SFXHIS", self.surf_modelstate, namelist_name
+        )
+        self._generic_terms_setup(
+            namct0, namct1, "SDI", self.spectral_diag, namelist_name
+        )
+        self._generic_terms_setup(
+            namct0, namct1, "POS", self.post_processing, namelist_name
+        )
         # Extra fixup for fullpos
         if self.post_processing is not None:
             if not self.post_processing:
-                self._set_namvar_value(namct0, 'NFPOS', 0, namelist_name)
+                self._set_namvar_value(namct0, "NFPOS", 0, namelist_name)
             else:
                 # Do not overwrite a pre-existing positive value:
-                if 'NFPOS' not in namct0 or namct0['NFPOS'] == 0:
-                    self._set_namvar_value(namct0, 'NFPOS', 1, namelist_name)
+                if "NFPOS" not in namct0 or namct0["NFPOS"] == 0:
+                    self._set_namvar_value(namct0, "NFPOS", 1, namelist_name)

--- a/src/vortex/nwp/tools/igastuff.py
+++ b/src/vortex/nwp/tools/igastuff.py
@@ -11,56 +11,70 @@ __all__ = []
 fuzzystr = dict(
     histfix=dict(
         historic=dict(
-            pearp='prev', arome='AROM', arpege='arpe', arp_court='arpe',
-            aearp='arpe', aladin='ALAD', surfex='SURF'
+            pearp="prev",
+            arome="AROM",
+            arpege="arpe",
+            arp_court="arpe",
+            aearp="arpe",
+            aladin="ALAD",
+            surfex="SURF",
         )
     ),
     prefix=dict(
         # LFM 2016/12/30: It was dble='PA' but apparently it's wrong. No idea why...
-        gridpoint=dict(oper='PE', dble='PE', mirr='PE', hycom_grb='vent'),
-        historic=dict(hycom='s_init0_', mfwam='BLS_', mfwam_BLS='BLS_', mfwam_LAW='LAW_'),
-        analysis=dict(hycom='s_init0_', mfwam='LAW_')
+        gridpoint=dict(oper="PE", dble="PE", mirr="PE", hycom_grb="vent"),
+        historic=dict(
+            hycom="s_init0_", mfwam="BLS_", mfwam_BLS="BLS_", mfwam_LAW="LAW_"
+        ),
+        analysis=dict(hycom="s_init0_", mfwam="LAW_"),
     ),
     suffix=dict(
-        bgstderr=dict(input='in', output='out'),
-        analysis=dict(hycom_hycom='.gz', hycom_surcotes='.gz', hycom_surcotes_oi='.gz'),
-        historic=dict(surfex_arpege='.sfx', surfex_aearp='.sfx',
-                      hycom_hycom='.gz', hycom_surcotes='.gz', hycom_surcotes_oi='.gz'),
-        gridpoint=dict(hycom_grb='grb'),
+        bgstderr=dict(input="in", output="out"),
+        analysis=dict(
+            hycom_hycom=".gz", hycom_surcotes=".gz", hycom_surcotes_oi=".gz"
+        ),
+        historic=dict(
+            surfex_arpege=".sfx",
+            surfex_aearp=".sfx",
+            hycom_hycom=".gz",
+            hycom_surcotes=".gz",
+            hycom_surcotes_oi=".gz",
+        ),
+        gridpoint=dict(hycom_grb="grb"),
     ),
     term0003=dict(
-        bgstderr=dict(input='', output='_assim'),
+        bgstderr=dict(input="", output="_assim"),
     ),
     term0009=dict(
-        bgstderr=dict(input='', output='_production'),
+        bgstderr=dict(input="", output="_production"),
     ),
     term0012=dict(
-        bgstderr=dict(input='_production_dsbscr', output='_production_dsbscr'),
+        bgstderr=dict(input="_production_dsbscr", output="_production_dsbscr"),
     ),
     varbcarpege=dict(
-        varbc=dict(input='.cycle_arp', output='.cycle'),
+        varbc=dict(input=".cycle_arp", output=".cycle"),
     ),
     varbcaladin=dict(
-        varbc=dict(input='.cycle_alad', output='.cycle'),
+        varbc=dict(input=".cycle_alad", output=".cycle"),
     ),
     varbcarome=dict(
-        varbc=dict(input='.cycle_aro', output='.cycle'),
+        varbc=dict(input=".cycle_aro", output=".cycle"),
     ),
     surf0000=dict(
-        histsurf=dict(input='INIT_SURF', output='INIT_SURF'),
-        historic=dict(input='INIT_SURF', output='INIT_SURF'),
+        histsurf=dict(input="INIT_SURF", output="INIT_SURF"),
+        historic=dict(input="INIT_SURF", output="INIT_SURF"),
     ),
     surf0003=dict(
-        histsurf=dict(input='PREP', output='AROMOUT_.0003'),
-        historic=dict(input='PREP', output='AROMOUT_.0003'),
+        histsurf=dict(input="PREP", output="AROMOUT_.0003"),
+        historic=dict(input="PREP", output="AROMOUT_.0003"),
     ),
     surf0006=dict(
-        histsurf=dict(input='PREP', output='AROMOUT_.0006'),
-        historic=dict(input='PREP', output='AROMOUT_.0006'),
+        histsurf=dict(input="PREP", output="AROMOUT_.0006"),
+        historic=dict(input="PREP", output="AROMOUT_.0006"),
     ),
 )
 
-arpcourt_vconf = ('courtfr', 'frcourt', 'court')
+arpcourt_vconf = ("courtfr", "frcourt", "court")
 
 
 def fuzzyname(entry, realkind, key, default=None):
@@ -81,35 +95,21 @@ def archive_suffix(model, cutoff, date, vconf=None):
     for h in hh:
         hrange.append("%02d" % h)
 
-    if cutoff == 'assim':
-        rr = dict(
-            zip(
-                zip(
-                    (cutoff,) * len(hrange),
-                    hh
-                ),
-                hrange
-            )
-        )
+    if cutoff == "assim":
+        rr = dict(zip(zip((cutoff,) * len(hrange), hh), hrange))
     else:
-        if re.search(r'court|arome', model) or vconf in arpcourt_vconf:
+        if re.search(r"court|arome", model) or vconf in arpcourt_vconf:
             rr = dict(
                 zip(
-                    zip(
-                        (cutoff,) * len(hrange),
-                        hh
-                    ),
-                    ('CM', 'TR', 'SX', 'NF', 'PM', 'QZ', 'DH', 'VU')
+                    zip((cutoff,) * len(hrange), hh),
+                    ("CM", "TR", "SX", "NF", "PM", "QZ", "DH", "VU"),
                 )
             )
         else:
             rr = dict(
                 zip(
-                    zip(
-                        (cutoff,) * len(hrange),
-                        hh
-                    ),
-                    ('AM', 'TR', 'SX', 'NF', 'PM', 'QZ', 'DH', 'VU')
+                    zip((cutoff,) * len(hrange), hh),
+                    ("AM", "TR", "SX", "NF", "PM", "QZ", "DH", "VU"),
                 )
             )
 
@@ -123,7 +123,7 @@ class _BaseIgakeyFactory(str):
     Needs to be subclassed !
     """
 
-    _re_appconf = re.compile(r'^(\w+)/([\w@]+)$')
+    _re_appconf = re.compile(r"^(\w+)/([\w@]+)$")
     _keymap = {}
 
     def __new__(cls, value):
@@ -134,9 +134,9 @@ class _BaseIgakeyFactory(str):
         """
         val_split = cls._re_appconf.match(value)
         if val_split:
-            value = cls._keymap.get(val_split.group(1),
-                                    {}).get(val_split.group(2),
-                                            val_split.group(1))
+            value = cls._keymap.get(val_split.group(1), {}).get(
+                val_split.group(2), val_split.group(1)
+            )
         return str.__new__(cls, value)
 
 
@@ -145,52 +145,65 @@ class IgakeyFactoryArchive(_BaseIgakeyFactory):
     Given the vapp/vconf, returns a default value for the igakey attribute
     """
 
-    _keymap = {'arpege': {'4dvarfr': 'arpege',
-                          '4dvar': 'arpege',
-                          'pearp': 'pearp',
-                          'aearp': 'aearp',
-                          'courtfr': 'arpege',
-                          'frcourt': 'arpege',
-                          'court': 'arpege', },
-               'mocage': {'camsfcst': 'macc',
-                          'camsassim': 'macc', },
-               'arome': {'3dvarfr': 'arome',
-                         'france': 'arome',
-                         'pegase': 'pegase', },
-               'aladin': {'antiguy': 'antiguy',
-                          'caledonie': 'caledonie',
-                          'nc': 'caledonie',
-                          'polynesie': 'polynesie',
-                          'reunion': 'reunion', },
-               'hycom': {'atl@anarp': 'surcotes',
-                         'med@anarp': 'surcotes',
-                         'atl@fcarp': 'surcotes',
-                         'med@fcarp': 'surcotes',
-                         'atl@anaro': 'surcotes',
-                         'med@anaro': 'surcotes',
-                         'atl@fcaro': 'surcotes',
-                         'med@fcaro': 'surcotes',
-                         'atl@fcaoc': 'surcotes',
-                         'med@fcaoc': 'surcotes',
-                         'oin@ancep': 'surcotes_oi',
-                         'oin@fcaro': 'surcotes_oi', },
-               'mfwam': {'globalcep02': 'mfwamglocep02',
-                         'globalcep01': 'mfwamglocep01',
-                         'reuaro01': 'mfwamreuaro',
-                         'polyaro01': 'mfwampolyaro',
-                         'caledaro01': 'mfwamcaledaro',
-                         'globalarp02': 'mfwamgloarp02',
-                         'globalarpc02': 'mfwamgloarpc02',
-                         'atourxarp01': 'mfwamatourx01arp',
-                         'euratarpc01': 'mfwameurcourt',
-                         'frangparo0025': 'mfwamfrangp0025',
-                         'frangparoifs0025': 'mfwamfrangp0025ifs',
-                         'assmp1': 'mfwamassmp1',
-                         'assmp2': 'mfwamassmp2',
-                         'assms1': 'mfwamassms1',
-                         'assms2': 'mfwamassms2',
-                         'angola0025': 'mfwamangola', },
-               }
+    _keymap = {
+        "arpege": {
+            "4dvarfr": "arpege",
+            "4dvar": "arpege",
+            "pearp": "pearp",
+            "aearp": "aearp",
+            "courtfr": "arpege",
+            "frcourt": "arpege",
+            "court": "arpege",
+        },
+        "mocage": {
+            "camsfcst": "macc",
+            "camsassim": "macc",
+        },
+        "arome": {
+            "3dvarfr": "arome",
+            "france": "arome",
+            "pegase": "pegase",
+        },
+        "aladin": {
+            "antiguy": "antiguy",
+            "caledonie": "caledonie",
+            "nc": "caledonie",
+            "polynesie": "polynesie",
+            "reunion": "reunion",
+        },
+        "hycom": {
+            "atl@anarp": "surcotes",
+            "med@anarp": "surcotes",
+            "atl@fcarp": "surcotes",
+            "med@fcarp": "surcotes",
+            "atl@anaro": "surcotes",
+            "med@anaro": "surcotes",
+            "atl@fcaro": "surcotes",
+            "med@fcaro": "surcotes",
+            "atl@fcaoc": "surcotes",
+            "med@fcaoc": "surcotes",
+            "oin@ancep": "surcotes_oi",
+            "oin@fcaro": "surcotes_oi",
+        },
+        "mfwam": {
+            "globalcep02": "mfwamglocep02",
+            "globalcep01": "mfwamglocep01",
+            "reuaro01": "mfwamreuaro",
+            "polyaro01": "mfwampolyaro",
+            "caledaro01": "mfwamcaledaro",
+            "globalarp02": "mfwamgloarp02",
+            "globalarpc02": "mfwamgloarpc02",
+            "atourxarp01": "mfwamatourx01arp",
+            "euratarpc01": "mfwameurcourt",
+            "frangparo0025": "mfwamfrangp0025",
+            "frangparoifs0025": "mfwamfrangp0025ifs",
+            "assmp1": "mfwamassmp1",
+            "assmp2": "mfwamassmp2",
+            "assms1": "mfwamassms1",
+            "assms2": "mfwamassms2",
+            "angola0025": "mfwamangola",
+        },
+    }
 
 
 class IgakeyFactoryInline(_BaseIgakeyFactory):
@@ -198,52 +211,63 @@ class IgakeyFactoryInline(_BaseIgakeyFactory):
     Given the vapp/vconf, returns a default value for the igakey attribute
     """
 
-    _keymap = {'arpege': {'4dvarfr': 'france',
-                          '4dvar': 'france',
-                          'pearp': 'pearp',
-                          'aearp': 'aearp',
-                          'courtfr': 'frcourt',
-                          'frcourt': 'frcourt',
-                          'court': 'frcourt', },
-               'arome': {'3dvarfr': 'france',
-                         'france': 'france',
-                         'pegase': 'pegase', },
-               'aladin': {'antiguy': 'antiguy',
-                          'caledonie': 'caledonie',
-                          'nc': 'caledonie',
-                          'polynesie': 'polynesie',
-                          'reunion': 'reunion', },
-               'hycom': {'atl@anarp': 'surcotes',
-                         'med@anarp': 'surcotes',
-                         'atl@fcarp': 'surcotes',
-                         'med@fcarp': 'surcotes',
-                         'atl@ancep': 'surcotes',
-                         'med@ancep': 'surcotes',
-                         'atl@fccep': 'surcotes',
-                         'med@fccep': 'surcotes',
-                         'atl@anaro': 'surcotes',
-                         'med@anaro': 'surcotes',
-                         'atl@fcaro': 'surcotes',
-                         'med@fcaro': 'surcotes',
-                         'atl@red': 'surcotes',
-                         'med@red': 'surcotes',
-                         'oin@ancep': 'surcotes_oi',
-                         'oin@fcaro': 'surcotes_oi',
-                         'oin@red': 'surcotes_oi', },
-               'mfwam': {'globalcep02': 'mfwamglocep02',
-                         'globalcep01': 'mfwamglocep01',
-                         'reuaro01': 'mfwamreuaro',
-                         'polyaro01': 'mfwampolyaro',
-                         'caledaro01': 'mfwamcaledaro',
-                         'globalarp02': 'mfwamgloarp02',
-                         'globalarpc02': 'mfwamgloarpc02',
-                         'atourxarp01': 'mfwamatourx01arp',
-                         'euratarpc01': 'mfwameurcourt',
-                         'frangparo0025': 'mfwamfrangp0025',
-                         'frangparoifs0025': 'mfwamfrangp0025ifs',
-                         'assmp1': 'mfwamassmp1',
-                         'assmp2': 'mfwamassmp2',
-                         'assms1': 'mfwamassms1',
-                         'assms2': 'mfwamassms2',
-                         'angola0025': 'mfwamangola', },
-               }
+    _keymap = {
+        "arpege": {
+            "4dvarfr": "france",
+            "4dvar": "france",
+            "pearp": "pearp",
+            "aearp": "aearp",
+            "courtfr": "frcourt",
+            "frcourt": "frcourt",
+            "court": "frcourt",
+        },
+        "arome": {
+            "3dvarfr": "france",
+            "france": "france",
+            "pegase": "pegase",
+        },
+        "aladin": {
+            "antiguy": "antiguy",
+            "caledonie": "caledonie",
+            "nc": "caledonie",
+            "polynesie": "polynesie",
+            "reunion": "reunion",
+        },
+        "hycom": {
+            "atl@anarp": "surcotes",
+            "med@anarp": "surcotes",
+            "atl@fcarp": "surcotes",
+            "med@fcarp": "surcotes",
+            "atl@ancep": "surcotes",
+            "med@ancep": "surcotes",
+            "atl@fccep": "surcotes",
+            "med@fccep": "surcotes",
+            "atl@anaro": "surcotes",
+            "med@anaro": "surcotes",
+            "atl@fcaro": "surcotes",
+            "med@fcaro": "surcotes",
+            "atl@red": "surcotes",
+            "med@red": "surcotes",
+            "oin@ancep": "surcotes_oi",
+            "oin@fcaro": "surcotes_oi",
+            "oin@red": "surcotes_oi",
+        },
+        "mfwam": {
+            "globalcep02": "mfwamglocep02",
+            "globalcep01": "mfwamglocep01",
+            "reuaro01": "mfwamreuaro",
+            "polyaro01": "mfwampolyaro",
+            "caledaro01": "mfwamcaledaro",
+            "globalarp02": "mfwamgloarp02",
+            "globalarpc02": "mfwamgloarpc02",
+            "atourxarp01": "mfwamatourx01arp",
+            "euratarpc01": "mfwameurcourt",
+            "frangparo0025": "mfwamfrangp0025",
+            "frangparoifs0025": "mfwamfrangp0025ifs",
+            "assmp1": "mfwamassmp1",
+            "assmp2": "mfwamassmp2",
+            "assms1": "mfwamassms1",
+            "assms2": "mfwamassms2",
+            "angola0025": "mfwamangola",
+        },
+    }

--- a/src/vortex/nwp/tools/mars.py
+++ b/src/vortex/nwp/tools/mars.py
@@ -14,16 +14,19 @@ logger = loggers.getLogger(__name__)
 
 class MarsError(Exception):
     """General Mars error."""
+
     pass
 
 
 class MarsConfigurationError(MarsError):
     """Specific Mars configuration error."""
+
     pass
 
 
 class MarsGetError(MarsError):
     """Generic Mars get error."""
+
     pass
 
 
@@ -35,7 +38,9 @@ def findMarsExtractCommand(sh, inifile=None, command=None):
             actual_command = sh.default_target.get("mars:command", None)
         else:
             actual_config = GenericConfigParser(inifile=actual_inifile)
-            if actual_config.has_section('mars') and actual_config.has_option('mars', 'command'):
+            if actual_config.has_section("mars") and actual_config.has_option(
+                "mars", "command"
+            ):
                 actual_command = actual_config.get("mars", "command")
         if actual_command is None:
             raise MarsConfigurationError("Could not find a proper command.")
@@ -53,4 +58,11 @@ def callMarsExtract(sh, query_file, command=None, fatal=True):
     :return: The return code of the Mars extraction.
     """
     command_line = " ".join([command, query_file])
-    return sh.spawn([command_line, ], shell=True, output=False, fatal=fatal)
+    return sh.spawn(
+        [
+            command_line,
+        ],
+        shell=True,
+        output=False,
+        fatal=fatal,
+    )

--- a/src/vortex/nwp/tools/odb.py
+++ b/src/vortex/nwp/tools/odb.py
@@ -13,6 +13,7 @@ from vortex.algo.components import (
     AlgoComponentError,
     algo_component_deco_mixin_autodoc,
 )
+from vortex import config
 from vortex.layout.dataflow import intent
 
 from ..syntax.stdattrs import ArpIfsSimplifiedCycle
@@ -233,8 +234,8 @@ class OdbDriver:
     def _default_iocreate_path(self):
         """The location to the default create_ioassign utility."""
         return self.sh.path.join(
-            from_config(section="nwp-tools", key="odb"),
-            get_from_config_w_default(
+            config.from_config(section="nwp-tools", key="odb"),
+            config.get_from_config_w_default(
                 section="nwp-tools",
                 key="iocreate_cmd",
                 default="create_ioassign",
@@ -245,8 +246,8 @@ class OdbDriver:
     def _default_iomerge_path(self):
         """The location to the default merge_ioassign utility."""
         return self.sh.path.join(
-            from_config(section="nwp-tools", key="odb"),
-            get_from_config_w_default(
+            config.from_config(section="nwp-tools", key="odb"),
+            config.get_from_config_w_default(
                 section="nwp-tools",
                 key="iomerge_cmd",
                 default="merge_ioassign",

--- a/src/vortex/nwp/tools/odb.py
+++ b/src/vortex/nwp/tools/odb.py
@@ -8,7 +8,11 @@ from bronx.fancies import loggers
 from bronx.stdtypes import date as bdate
 import footprints
 
-from vortex.algo.components import AlgoComponentDecoMixin, AlgoComponentError, algo_component_deco_mixin_autodoc
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    AlgoComponentError,
+    algo_component_deco_mixin_autodoc,
+)
 from vortex.layout.dataflow import intent
 
 from ..syntax.stdattrs import ArpIfsSimplifiedCycle
@@ -22,16 +26,18 @@ logger = loggers.getLogger(__name__)
 class TimeSlots:
     """Handling of assimilation time slots."""
 
-    def __init__(self, nslot=7, start='-PT3H', window='PT6H', chunk=None, center=True):
+    def __init__(
+        self, nslot=7, start="-PT3H", window="PT6H", chunk=None, center=True
+    ):
         if isinstance(nslot, str):
-            info = [x.strip() for x in nslot.split('/')]
+            info = [x.strip() for x in nslot.split("/")]
             nslot = info[0]
             if len(info) > 1:
                 start = info[1]
             if len(info) > 2:
                 window = info[2]
             if len(info) > 3:
-                if re.match('^regular', info[3]):
+                if re.match("^regular", info[3]):
                     center = False
                 else:
                     chunk = info[3]
@@ -41,7 +47,9 @@ class TimeSlots:
         self.window = bdate.Period(window)
         if chunk is None:
             cslot = self.nslot - 1 if self.center else self.nslot
-            chunk = 'PT' + str((self.window.length // max(1, cslot)) // 60) + 'M'
+            chunk = (
+                "PT" + str((self.window.length // max(1, cslot)) // 60) + "M"
+            )
         self.chunk = self.window if self.nslot < 2 else bdate.Period(chunk)
 
     def __eq__(self, other):
@@ -50,31 +58,38 @@ class TimeSlots:
                 other = TimeSlots(other)
             except ValueError:
                 pass
-        return (isinstance(other, TimeSlots) and
-                self.nslot == other.nslot and self.center == other.center and
-                self.start == other.start and self.window == other.window and
-                self.chunk == other.chunk)
+        return (
+            isinstance(other, TimeSlots)
+            and self.nslot == other.nslot
+            and self.center == other.center
+            and self.start == other.start
+            and self.window == other.window
+            and self.chunk == other.chunk
+        )
 
     def __str__(self):
-        chunky = self.chunk.isoformat() if self.center else 'regular'
-        return '{0.nslot:d}/{1:s}/{2:s}/{3:s}'.format(self,
-                                                      self.start.isoformat(),
-                                                      self.window.isoformat(),
-                                                      chunky)
+        chunky = self.chunk.isoformat() if self.center else "regular"
+        return "{0.nslot:d}/{1:s}/{2:s}/{3:s}".format(
+            self, self.start.isoformat(), self.window.isoformat(), chunky
+        )
 
     def __repr__(self, *args, **kwargs):
-        return super().__repr__()[:-1] + ' | {!s}>'.format(self)
+        return super().__repr__()[:-1] + " | {!s}>".format(self)
 
     def as_slots(self):
         """Return a list of slots in seconds."""
         if self.center:
-            slots = [self.chunk.length, ] * self.nslot
+            slots = [
+                self.chunk.length,
+            ] * self.nslot
             nb = self.window.length // self.chunk.length
             if nb != self.nslot:
                 slots[0] = slots[-1] = self.chunk.length // 2
         else:
             islot = self.window.length // self.nslot
-            slots = [islot, ] * self.nslot
+            slots = [
+                islot,
+            ] * self.nslot
         return slots
 
     def as_centers_fromstart(self):
@@ -85,7 +100,9 @@ class TimeSlots:
         for i in range(len(slots)):
             fromstart.append(acc + slots[i] / 2)
             acc += slots[i]
-        if self.center and (self.window.length // self.chunk.length != self.nslot):
+        if self.center and (
+            self.window.length // self.chunk.length != self.nslot
+        ):
             fromstart[0] = 0
             fromstart[-1] = self.window.length
         return [bdate.Period(seconds=t) for t in fromstart]
@@ -93,7 +110,9 @@ class TimeSlots:
     def as_bounds(self, date):
         """Return time slots as a list of compact date values."""
         date = bdate.Date(date)
-        boundlist = [date + self.start, ]
+        boundlist = [
+            date + self.start,
+        ]
         for x in self.as_slots():
             boundlist.append(boundlist[-1] + x)
         boundlist = [x.compact() for x in boundlist]
@@ -111,16 +130,21 @@ class TimeSlots:
 
     def as_environment(self):
         """Return a dictionary of ready-to-export variables that describe the timeslots."""
-        thelen = self.chunk.length // 60 if self.center and self.nslot > 1 else 0
-        return dict(BATOR_WINDOW_LEN=self.window.length // 60,
-                    BATOR_WINDOW_SHIFT=int(self.start.total_seconds()) // 60,
-                    BATOR_SLOT_LEN=thelen, BATOR_CENTER_LEN=thelen)
+        thelen = (
+            self.chunk.length // 60 if self.center and self.nslot > 1 else 0
+        )
+        return dict(
+            BATOR_WINDOW_LEN=self.window.length // 60,
+            BATOR_WINDOW_SHIFT=int(self.start.total_seconds()) // 60,
+            BATOR_SLOT_LEN=thelen,
+            BATOR_CENTER_LEN=thelen,
+        )
 
     def as_file(self, date, filename):
         """Fill the specified ``filename`` wih the current list of time slots at this ``date``."""
-        with open(filename, 'w') as fd:
+        with open(filename, "w") as fd:
             for x in self.as_bounds(date):
-                fd.write(str(x) + '\n')
+                fd.write(str(x) + "\n")
             nbx = fd.tell()
         return nbx
 
@@ -136,15 +160,23 @@ class OdbDriver:
         self.cycle = cycle
         self.sh = sh
         if self.sh is None:
-            logger.critical('%s created with a proper shell access [%s]', self.__class__, self)
+            logger.critical(
+                "%s created with a proper shell access [%s]",
+                self.__class__,
+                self,
+            )
         self.env = env
         if self.env is None:
-            logger.critical('%s created with a proper environment access [%s]', self.__class__, self)
+            logger.critical(
+                "%s created with a proper environment access [%s]",
+                self.__class__,
+                self,
+            )
 
-    def setup(self, date, npool=1, nslot=1, iomethod=1, layout='ecma'):
+    def setup(self, date, npool=1, nslot=1, iomethod=1, layout="ecma"):
         """Setup given environment with default ODB env variables."""
 
-        logger.info('ODB: generic setup called.'),
+        (logger.info("ODB: generic setup called."),)
         self.env.update(
             ODB_CMA=layout.upper(),
             ODB_IO_METHOD=iomethod,
@@ -156,7 +188,7 @@ class OdbDriver:
             ODB_REPRODUCIBLE_SEQNO=4,
             ODB_STATIC_LINKING=1,
             ODB_ANALYSIS_DATE=date.ymd,
-            ODB_ANALYSIS_TIME=date.hm + '00',
+            ODB_ANALYSIS_TIME=date.hm + "00",
             TO_ODB_ECMWF=0,
             TO_ODB_SWAPOUT=0,
         )
@@ -167,15 +199,17 @@ class OdbDriver:
                 ODB_IO_FILESIZE=128,
             )
 
-        if self.sh.path.exists('IOASSIGN'):
+        if self.sh.path.exists("IOASSIGN"):
             self.env.default(
-                IOASSIGN=self.sh.path.abspath('IOASSIGN'),
+                IOASSIGN=self.sh.path.abspath("IOASSIGN"),
             )
 
     def force_overwrite_method(self):
         """Force ODB_OVERWRITE_METHOD if necessary."""
-        if not int(self.env.get('ODB_OVERWRITE_METHOD', 0)):
-            logger.info('ODB: Some input ODB databases are read-only. Setting ODB_OVERWRITE_METHOD to 1.')
+        if not int(self.env.get("ODB_OVERWRITE_METHOD", 0)):
+            logger.info(
+                "ODB: Some input ODB databases are read-only. Setting ODB_OVERWRITE_METHOD to 1."
+            )
             self.env.ODB_OVERWRITE_METHOD = 1
 
     def _process_layout_dbpath(self, layout, dbpath=None):
@@ -191,9 +225,9 @@ class OdbDriver:
         if env is None:
             env = self.env
         layout, dbpath, _ = self._process_layout_dbpath(layout, dbpath)
-        logger.info('ODB: Fix %s path: %s', layout, dbpath)
-        env['ODB_SRCPATH_{:s}'.format(layout)] = dbpath
-        env['ODB_DATAPATH_{:s}'.format(layout)] = dbpath
+        logger.info("ODB: Fix %s path: %s", layout, dbpath)
+        env["ODB_SRCPATH_{:s}".format(layout)] = dbpath
+        env["ODB_DATAPATH_{:s}".format(layout)] = dbpath
 
     @property
     def _default_iocreate_path(self):
@@ -203,7 +237,7 @@ class OdbDriver:
             get_from_config_w_default(
                 section="nwp-tools",
                 key="iocreate_cmd",
-                default="create_ioassign"
+                default="create_ioassign",
             ),
         )
 
@@ -215,12 +249,18 @@ class OdbDriver:
             get_from_config_w_default(
                 section="nwp-tools",
                 key="iomerge_cmd",
-                default="merge_ioassign"
+                default="merge_ioassign",
             ),
         )
 
-    def ioassign_create(self, ioassign='ioassign.x', npool=1, layout='ecma',
-                        dbpath=None, iocreate_path=None):
+    def ioassign_create(
+        self,
+        ioassign="ioassign.x",
+        npool=1,
+        layout="ecma",
+        dbpath=None,
+        iocreate_path=None,
+    ):
         """Build IO-Assign table."""
         layout, dbpath, _ = self._process_layout_dbpath(layout, dbpath)
         if iocreate_path is None:
@@ -229,17 +269,28 @@ class OdbDriver:
         self.sh.xperm(ioassign, force=True)
         self.sh.mkdir(dbpath)
         with self.env.clone() as lenv:
-            lenv['ODB_IOASSIGN_BINARY'] = ioassign
+            lenv["ODB_IOASSIGN_BINARY"] = ioassign
             self.fix_db_path(layout, dbpath, env=lenv)
-            self.sh.spawn([iocreate_path,
-                           '-d' + dbpath,
-                           '-l' + layout,
-                           '-n' + str(npool)],
-                          output=False)
+            self.sh.spawn(
+                [
+                    iocreate_path,
+                    "-d" + dbpath,
+                    "-l" + layout,
+                    "-n" + str(npool),
+                ],
+                output=False,
+            )
         return dbpath
 
-    def ioassign_merge(self, ioassign='ioassign.x', layout='ecma', odbnames=None,
-                       dbpath=None, iomerge_path=None, iocreate_path=None):
+    def ioassign_merge(
+        self,
+        ioassign="ioassign.x",
+        layout="ecma",
+        odbnames=None,
+        dbpath=None,
+        iomerge_path=None,
+        iocreate_path=None,
+    ):
         """Build IO-Assign table."""
         layout, dbpath, thispwd = self._process_layout_dbpath(layout, dbpath)
         if iomerge_path is None:
@@ -250,35 +301,39 @@ class OdbDriver:
         ioassign = self.sh.path.abspath(ioassign)
         self.sh.xperm(ioassign, force=True)
         with self.sh.cdcontext(dbpath, create=True):
-            iocmd.extend(['-d', thispwd])
+            iocmd.extend(["-d", thispwd])
             for dbname in odbnames:
-                iocmd.extend(['-t', dbname])
+                iocmd.extend(["-t", dbname])
             with self.env.clone() as lenv:
-                lenv['ODB_IOASSIGN_BINARY'] = ioassign
-                if 'ODB_IOCREATE_COMMAND' not in lenv:
-                    lenv['ODB_IOCREATE_COMMAND'] = iocreate_path
+                lenv["ODB_IOASSIGN_BINARY"] = ioassign
+                if "ODB_IOCREATE_COMMAND" not in lenv:
+                    lenv["ODB_IOCREATE_COMMAND"] = iocreate_path
                 self.fix_db_path(layout, dbpath, env=lenv)
                 self.sh.spawn(iocmd, output=False)
         return dbpath
 
     def _ioassign_process(self, dbpaths, wmode):
-        with open('IOASSIGN', wmode) as fhgather:
+        with open("IOASSIGN", wmode) as fhgather:
             for dbpath in dbpaths:
-                with open(self.sh.path.join(dbpath, 'IOASSIGN')) as fhlay:
+                with open(self.sh.path.join(dbpath, "IOASSIGN")) as fhlay:
                     for line in fhlay:
                         fhgather.write(line)
 
     def ioassign_gather(self, *dbpaths):
         """Gather IOASSIGN data from **dbpaths** databases and create a global IOASSIGN file."""
-        logger.info('ODB: creating a global IOASSIGN file from: %s',
-                    ','.join([self.sh.path.basename(db) for db in dbpaths]))
-        self._ioassign_process(dbpaths, 'w')
+        logger.info(
+            "ODB: creating a global IOASSIGN file from: %s",
+            ",".join([self.sh.path.basename(db) for db in dbpaths]),
+        )
+        self._ioassign_process(dbpaths, "w")
 
     def ioassign_append(self, *dbpaths):
         """Append IOASSIGN data from **dbpaths** databases into the global IOASSIGN file."""
-        logger.info('ODB: extending the IOASSIGN file with: %s',
-                    ','.join([self.sh.path.basename(db) for db in dbpaths]))
-        self._ioassign_process(dbpaths, 'a')
+        logger.info(
+            "ODB: extending the IOASSIGN file with: %s",
+            ",".join([self.sh.path.basename(db) for db in dbpaths]),
+        )
+        self._ioassign_process(dbpaths, "a")
 
     def shuffle_setup(self, slots, mergedirect=False, ccmadirect=False):
         """Setup environment variables to control ODB shuffle behaviour.
@@ -286,8 +341,11 @@ class OdbDriver:
         :param bool mergedirect: Run the shuffle procedure on the input database.
         :param bool ccmadirect: Create a CCMA database at the end of the run.
         """
-        logger.info('ODB: shuffle_setup: mergedirect=%s, ccmadirect=%s',
-                    str(mergedirect), str(ccmadirect))
+        logger.info(
+            "ODB: shuffle_setup: mergedirect=%s, ccmadirect=%s",
+            str(mergedirect),
+            str(ccmadirect),
+        )
         if mergedirect or ccmadirect:
             self.env.update(
                 ODB_CCMA_TSLOTS=slots.nslot,
@@ -304,38 +362,63 @@ class OdbDriver:
     def create_poolmask(self, layout, dbpath=None):
         """Request the poolmask file creation."""
         layout, dbpath, _ = self._process_layout_dbpath(layout, dbpath)
-        logger.info('ODB: requesting poolmask file for: %s (layout=%s).', dbpath, layout)
+        logger.info(
+            "ODB: requesting poolmask file for: %s (layout=%s).",
+            dbpath,
+            layout,
+        )
         self.env.update(
             ODB_CCMA_CREATE_POOLMASK=1,
-            ODB_CCMA_POOLMASK_FILE=self.sh.path.join(dbpath, layout + '.poolmask'),
+            ODB_CCMA_POOLMASK_FILE=self.sh.path.join(
+                dbpath, layout + ".poolmask"
+            ),
         )
 
     def change_layout(self, layout, layout_new, dbpath=None):
         """Make the appropriate renaming of files in ECMA to CCMA."""
         layout, dbpath, _ = self._process_layout_dbpath(layout, dbpath)
         layout_new = layout_new.upper()
-        logger.info('ODB: changing layout (%s -> %s) for %s.', layout, layout_new, dbpath)
+        logger.info(
+            "ODB: changing layout (%s -> %s) for %s.",
+            layout,
+            layout_new,
+            dbpath,
+        )
         to_cleanup = set()
         for f in self.sh.ls(dbpath):
             if self.sh.path.islink(self.sh.path.join(dbpath, f)):
                 fullpath = self.sh.path.join(dbpath, f)
                 target = self.sh.readlink(fullpath)
                 self.sh.unlink(fullpath)
-                self.sh.symlink(target.replace(layout, layout_new),
-                                fullpath.replace(layout, layout_new))
+                self.sh.symlink(
+                    target.replace(layout, layout_new),
+                    fullpath.replace(layout, layout_new),
+                )
                 continue
-            if f in [n.format(layout) for n in ('{:s}.dd', '{:s}.flags')]:
-                self.sh.mv(self.sh.path.join(dbpath, f),
-                           self.sh.path.join(dbpath, f.replace(layout, layout_new)))
-            if f in [n.format(layout) for n in ('{:s}.iomap', '{:s}.sch',
-                                                '{:s}.IOASSIGN', 'IOASSIGN.{:s}', 'IOASSIGN')]:
-                tmp_target = self.sh.path.join(dbpath, f + '.tmp_new')
+            if f in [n.format(layout) for n in ("{:s}.dd", "{:s}.flags")]:
+                self.sh.mv(
+                    self.sh.path.join(dbpath, f),
+                    self.sh.path.join(dbpath, f.replace(layout, layout_new)),
+                )
+            if f in [
+                n.format(layout)
+                for n in (
+                    "{:s}.iomap",
+                    "{:s}.sch",
+                    "{:s}.IOASSIGN",
+                    "IOASSIGN.{:s}",
+                    "IOASSIGN",
+                )
+            ]:
+                tmp_target = self.sh.path.join(dbpath, f + ".tmp_new")
                 with open(self.sh.path.join(dbpath, f)) as inodb:
-                    with open(tmp_target, 'w') as outodb:
+                    with open(tmp_target, "w") as outodb:
                         for line in inodb:
                             outodb.write(line.replace(layout, layout_new))
-                self.sh.mv(tmp_target,
-                           self.sh.path.join(dbpath, f.replace(layout, layout_new)))
+                self.sh.mv(
+                    tmp_target,
+                    self.sh.path.join(dbpath, f.replace(layout, layout_new)),
+                )
                 if layout in f:
                     to_cleanup.add(self.sh.path.join(dbpath, f))
         for f_name in to_cleanup:
@@ -347,44 +430,45 @@ odbmix_attributes = footprints.Footprint(
     info="Abstract ODB footprints' attributes.",
     attr=dict(
         npool=dict(
-            info='The number of pool(s) in the ODB database.',
+            info="The number of pool(s) in the ODB database.",
             type=int,
             optional=True,
             default=1,
         ),
         iomethod=dict(
-            info='The io_method of the ODB database.',
+            info="The io_method of the ODB database.",
             type=int,
             optional=True,
             default=1,
             doc_zorder=-50,
         ),
         slots=dict(
-            info='The timeslots of the assimilation window.',
+            info="The timeslots of the assimilation window.",
             type=TimeSlots,
             optional=True,
-            default=TimeSlots(7, chunk='PT1H'),
+            default=TimeSlots(7, chunk="PT1H"),
         ),
         virtualdb=dict(
-            info='The type of the virtual ODB database.',
+            info="The type of the virtual ODB database.",
             optional=True,
-            default='ecma',
-            access='rwx',
+            default="ecma",
+            access="rwx",
             doc_visibility=footprints.doc.visibility.ADVANCED,
         ),
         date=dict(
-            info='The current run date.',
+            info="The current run date.",
             optional=True,
-            access='rwx',
+            access="rwx",
             type=bdate.Date,
             doc_zorder=-50,
         ),
         ioassign=dict(
-            info='The path to the ioassign binary (needed for merge/create actions',
+            info="The path to the ioassign binary (needed for merge/create actions",
             optional=True,
-            default='ioassign.x',
-        )
-    ))
+            default="ioassign.x",
+        ),
+    ),
+)
 
 
 @algo_component_deco_mixin_autodoc
@@ -402,12 +486,14 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
     manually if needed.
     """
 
-    _MIXIN_EXTRA_FOOTPRINTS = [odbmix_attributes, ]
+    _MIXIN_EXTRA_FOOTPRINTS = [
+        odbmix_attributes,
+    ]
 
     def _odbobj_init(self, rh, opts):  # @UnusedVariable
         """Setup the OdbDriver object."""
-        cycle = ArpIfsSimplifiedCycle('cy01')
-        if rh and hasattr(rh.resource, 'cycle'):
+        cycle = ArpIfsSimplifiedCycle("cy01")
+        if rh and hasattr(rh.resource, "cycle"):
             cycle = rh.resource.cycle
         self._odb = OdbDriver(
             cycle=cycle,
@@ -436,20 +522,23 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
     @property
     def odb(self):
         """Access to a properly initialised :class:`OdbDriver` object."""
-        if not hasattr(self, '_odb'):
-            raise RuntimeError('Uninitialised *odb* object.')
+        if not hasattr(self, "_odb"):
+            raise RuntimeError("Uninitialised *odb* object.")
         return self._odb
 
     def lookupodb(self, fatal=True):
         """Return a list of effective input resources which are odb observations."""
         allodb = [
-            x for x in self.context.sequence.effective_inputs(kind='observations')
-            if x.rh.container.actualfmt == 'odb'
+            x
+            for x in self.context.sequence.effective_inputs(
+                kind="observations"
+            )
+            if x.rh.container.actualfmt == "odb"
         ]
         allodb.sort(key=lambda s: s.rh.resource.part)
         if not allodb and fatal:
-            logger.critical('Missing ODB input data for %s', self.fullname())
-            raise ValueError('Missing ODB input data')
+            logger.critical("Missing ODB input data for %s", self.fullname())
+            raise ValueError("Missing ODB input data")
         return allodb
 
     def odb_date_and_layout_from_sections(self, odbsections):
@@ -465,23 +554,32 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
             raise AlgoComponentError("Inconsistent ODB dates")
         self.virtualdb = alllayouts.pop()
         self.date = alldates.pop()
-        logger.info('ODB: Detected from ODB database(s). self.date=%s, self.virtualdb=%s.',
-                    self.date.stdvortex, self.virtualdb)
+        logger.info(
+            "ODB: Detected from ODB database(s). self.date=%s, self.virtualdb=%s.",
+            self.date.stdvortex,
+            self.virtualdb,
+        )
 
     def _odb_find_ioassign_script(self, purpose):
         """Look for ioassign script of *purpose" attribute, return path."""
-        scripts = [x.rh.container.abspath
-                   for x in self.context.sequence.effective_inputs(kind='ioassign_script')
-                   if x.rh.resource.purpose == purpose]
+        scripts = [
+            x.rh.container.abspath
+            for x in self.context.sequence.effective_inputs(
+                kind="ioassign_script"
+            )
+            if x.rh.resource.purpose == purpose
+        ]
         if len(scripts) > 1:
-            raise AlgoComponentError("More than one purpose={} ioassign_script found in resources.")
+            raise AlgoComponentError(
+                "More than one purpose={} ioassign_script found in resources."
+            )
         elif len(scripts) == 1:
             self.system.xperm(scripts[0], force=True)
             return scripts[0]
         else:
             return None
 
-    def odb_merge_if_needed(self, odbsections, subdir='.'):
+    def odb_merge_if_needed(self, odbsections, subdir="."):
         """
         If multiple ODB databases are listed in the **odsections** section list,
         start an ODB merge.
@@ -489,10 +587,10 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
         :return: The path to the ODB database (the virtual database if a merge is
                  performed).
         """
-        if len(odbsections) > 1 or self.virtualdb.lower() == 'ecma':
-            logger.info('ODB: merge for: %s.', self.virtualdb)
-            iomerge_p = self._odb_find_ioassign_script('merge')
-            iocreate_p = self._odb_find_ioassign_script('create')
+        if len(odbsections) > 1 or self.virtualdb.lower() == "ecma":
+            logger.info("ODB: merge for: %s.", self.virtualdb)
+            iomerge_p = self._odb_find_ioassign_script("merge")
+            iocreate_p = self._odb_find_ioassign_script("create")
             with self.system.cdcontext(subdir):
                 virtualdb_path = self.odb.ioassign_merge(
                     layout=self.virtualdb,
@@ -502,7 +600,9 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
                     iocreate_path=iocreate_p,
                 )
         else:
-            virtualdb_path = self.system.path.abspath(odbsections[0].rh.container.localpath())
+            virtualdb_path = self.system.path.abspath(
+                odbsections[0].rh.container.localpath()
+            )
         return virtualdb_path
 
     def odb_create_db(self, layout, dbpath=None):
@@ -517,28 +617,36 @@ class OdbComponentDecoMixin(AlgoComponentDecoMixin):
             npool=self.npool,
             ioassign=self._x_ioassign,
             dbpath=dbpath,
-            iocreate_path=self._odb_find_ioassign_script('create')
+            iocreate_path=self._odb_find_ioassign_script("create"),
         )
-        logger.info('ODB: database created: %s (layout=%s).', dbout, layout)
+        logger.info("ODB: database created: %s (layout=%s).", dbout, layout)
         return dbout
 
     def odb_handle_raw_dbs(self):
         """Look for extras ODB raw databases and fix the environment accordingly."""
         odbraw = [
-            x.rh for x in self.context.sequence.effective_inputs(kind='odbraw')
-            if x.rh.container.actualfmt == 'odb'
+            x.rh
+            for x in self.context.sequence.effective_inputs(kind="odbraw")
+            if x.rh.container.actualfmt == "odb"
         ]
         if not odbraw:
-            logger.error('No ODB raw databases found.')
+            logger.error("No ODB raw databases found.")
         else:
             for rraw in odbraw:
                 rawpath = rraw.container.localpath()
                 self.odb.fix_db_path(rraw.resource.layout, rawpath)
-                for badlink in [bl
-                                for bl in self.system.glob(self.system.path.join(rawpath, '*.h'))
-                                if self.system.path.islink(bl) and not self.system.path.exists(bl)]:
+                for badlink in [
+                    bl
+                    for bl in self.system.glob(
+                        self.system.path.join(rawpath, "*.h")
+                    )
+                    if self.system.path.islink(bl)
+                    and not self.system.path.exists(bl)
+                ]:
                     self.system.unlink(badlink)
-            self.odb.ioassign_append(* [rraw.container.localpath() for rraw in odbraw])
+            self.odb.ioassign_append(
+                *[rraw.container.localpath() for rraw in odbraw]
+            )
         return odbraw
 
     def odb_rw_or_overwrite_method(self, *dbsections):

--- a/src/vortex/nwp/tools/satrad.py
+++ b/src/vortex/nwp/tools/satrad.py
@@ -29,28 +29,43 @@ class SatRadDecoMixin(AlgoComponentDecoMixin):
 
     def _satrad_coeffdir_setup(self, rh, opts):  # @UnusedVariable
         """Look for RTTOV coefficient files and act on it."""
-        rtcoefs = self.context.sequence.effective_inputs(role='RtCoef', kind='rtcoef')
+        rtcoefs = self.context.sequence.effective_inputs(
+            role="RtCoef", kind="rtcoef"
+        )
         if rtcoefs:
             sh = self.system
-            rtpaths = {sh.path.dirname(sh.path.realpath(rtcoef.rh.container.localpath()))
-                       for rtcoef in rtcoefs}
+            rtpaths = {
+                sh.path.dirname(
+                    sh.path.realpath(rtcoef.rh.container.localpath())
+                )
+                for rtcoef in rtcoefs
+            }
             if len(rtpaths) != 1:
-                raise AlgoComponentError('The Radiative Transfer Coefficients are scattered in' +
-                                         'several directories: {!s}'.format(rtpaths))
+                raise AlgoComponentError(
+                    "The Radiative Transfer Coefficients are scattered in"
+                    + "several directories: {!s}".format(rtpaths)
+                )
             rtpath = rtpaths.pop()
-            logger.info('Setting %s = %s', 'RTTOV_COEFDIR', rtpath)
-            self.env['RTTOV_COEFDIR'] = rtpath
+            logger.info("Setting %s = %s", "RTTOV_COEFDIR", rtpath)
+            self.env["RTTOV_COEFDIR"] = rtpath
 
-    _MIXIN_PREPARE_HOOKS = (_satrad_coeffdir_setup, )
+    _MIXIN_PREPARE_HOOKS = (_satrad_coeffdir_setup,)
 
     def setchannels(self):
         """Look up for channels namelists in effective inputs."""
         namchan = [
-            x.rh for x in self.context.sequence.effective_inputs(kind='namelist')
-            if 'channel' in x.rh.options
+            x.rh
+            for x in self.context.sequence.effective_inputs(kind="namelist")
+            if "channel" in x.rh.options
         ]
         for thisnam in namchan:
-            thisloc = re.sub(r'\d+$', '', thisnam.options['channel']) + 'channels'
+            thisloc = (
+                re.sub(r"\d+$", "", thisnam.options["channel"]) + "channels"
+            )
             if thisloc != thisnam.container.localpath():
-                logger.info('Linking < %s > to < %s >', thisnam.container.localpath(), thisloc)
+                logger.info(
+                    "Linking < %s > to < %s >",
+                    thisnam.container.localpath(),
+                    thisloc,
+                )
                 self.system.softlink(thisnam.container.localpath(), thisloc)

--- a/src/vortex/nwp/util/async.py
+++ b/src/vortex/nwp/util/async.py
@@ -18,7 +18,7 @@ def _double_ssh(sh, loginnode, transfernode):
 
     May return None when network problems occur.
     """
-    cmd = ['ssh', '-x', loginnode, 'ssh', '-x', transfernode, 'hostname', '-s']
+    cmd = ["ssh", "-x", loginnode, "ssh", "-x", transfernode, "hostname", "-s"]
     rc = sh.spawn(cmd, shell=False, output=True, fatal=False)
     if not rc:
         return None
@@ -33,54 +33,73 @@ def system_ftput(pnum, ask, config, logger, **opts):
     obtained by a double ssh.
     """
 
-    logger.info('System', todo=ask.todo, pnum=pnum, opts=opts)
-    value = dict(rpool='retry')
+    logger.info("System", todo=ask.todo, pnum=pnum, opts=opts)
+    value = dict(rpool="retry")
 
-    phasemode = opts.get('phasemode', False)
-    nbtries = opts.get('attempts', 1)
+    phasemode = opts.get("phasemode", False)
+    nbtries = opts.get("attempts", 1)
     if phasemode:
         rawftput = False
     else:
-        rawftput = opts.get('rawftput', False)
+        rawftput = opts.get("rawftput", False)
     trynum = 0
 
-    profile = config['driver'].get('profile', None)
+    profile = config["driver"].get("profile", None)
     with VortexWorker(logger=logger, profile=profile) as vwork:
         sh = vwork.session.sh
-        sh.trace = 'log'
-        sh.ftpflavour = systems.FTP_FLAVOUR.STD  # Because errors are handled directly by jeeves
+        sh.trace = "log"
+        sh.ftpflavour = (
+            systems.FTP_FLAVOUR.STD
+        )  # Because errors are handled directly by jeeves
 
         data = vwork.get_dataset(ask)
-        logger.info('ftput', source=data.source, destination=data.destination)
+        logger.info("ftput", source=data.source, destination=data.destination)
         if not sh.path.exists(data.source):
-            logger.error('The source file is missing - sorry')
-            return pnum, False, dict(rpool='error')
+            logger.error("The source file is missing - sorry")
+            return pnum, False, dict(rpool="error")
 
         if phasemode:
-            data.hostname = _double_ssh(sh, data.phase_loginnode, data.phase_transfernode)
+            data.hostname = _double_ssh(
+                sh, data.phase_loginnode, data.phase_transfernode
+            )
             if data.hostname is None:
-                return pnum, False, dict(rpool='retry')
+                return pnum, False, dict(rpool="retry")
 
-        cpipeline = (None if not hasattr(data, 'cpipeline') or not data.cpipeline
-                     else compression.CompressionPipeline(sh, data.cpipeline))
+        cpipeline = (
+            None
+            if not hasattr(data, "cpipeline") or not data.cpipeline
+            else compression.CompressionPipeline(sh, data.cpipeline)
+        )
 
-        logger.info('FTPut host', hostname=data.hostname, logname=data.logname)
-        logger.info('FTPut data', source=data.source, destination=data.destination)
+        logger.info("FTPut host", hostname=data.hostname, logname=data.logname)
+        logger.info(
+            "FTPut data", source=data.source, destination=data.destination
+        )
         while trynum < nbtries:
             trynum += 1
             if nbtries > 1:
-                logger.info('FTPut loop', attempt=trynum)
+                logger.info("FTPut loop", attempt=trynum)
             try:
                 if rawftput:
-                    putrc = sh.rawftput(data.source, data.destination, hostname=data.hostname,
-                                        logname=data.logname, cpipeline=cpipeline,
-                                        fmt=data.fmt)
+                    putrc = sh.rawftput(
+                        data.source,
+                        data.destination,
+                        hostname=data.hostname,
+                        logname=data.logname,
+                        cpipeline=cpipeline,
+                        fmt=data.fmt,
+                    )
                 else:
-                    putrc = sh.ftput(data.source, data.destination, hostname=data.hostname,
-                                     logname=data.logname, cpipeline=cpipeline,
-                                     fmt=data.fmt)
+                    putrc = sh.ftput(
+                        data.source,
+                        data.destination,
+                        hostname=data.hostname,
+                        logname=data.logname,
+                        cpipeline=cpipeline,
+                        fmt=data.fmt,
+                    )
             except Exception as e:
-                logger.warning('FTPut failed', attempt=trynum, error=e)
+                logger.warning("FTPut failed", attempt=trynum, error=e)
                 putrc = False
             if putrc:
                 value = dict(clear=sh.rm(data.source, fmt=data.fmt))
@@ -92,23 +111,23 @@ def system_ftput(pnum, ask, config, logger, **opts):
 def system_cp(pnum, ask, config, logger, **opts):
     """Local transfers (between filesystems) on a given host."""
 
-    logger.info('System', todo=ask.todo, pnum=pnum, opts=opts)
-    value = dict(rpool='retry')
+    logger.info("System", todo=ask.todo, pnum=pnum, opts=opts)
+    value = dict(rpool="retry")
 
-    profile = config['driver'].get('profile', None)
+    profile = config["driver"].get("profile", None)
     with VortexWorker(logger=logger, profile=profile) as vwork:
         sh = vwork.session.sh
-        sh.trace = 'log'
+        sh.trace = "log"
         data = vwork.get_dataset(ask)
-        logger.info('cp', source=data.source, destination=data.destination)
+        logger.info("cp", source=data.source, destination=data.destination)
         if not sh.path.exists(data.source):
-            logger.error('The source file is missing - sorry')
-            return pnum, False, dict(rpool='error')
+            logger.error("The source file is missing - sorry")
+            return pnum, False, dict(rpool="error")
 
         try:
             rc = sh.cp(data.source, data.destination, fmt=data.fmt)
         except Exception as e:
-            logger.warning('cp failed', error=e)
+            logger.warning("cp failed", error=e)
             rc = False
         if rc:
             value = dict(clear=sh.rm(data.source, fmt=data.fmt))
@@ -123,33 +142,42 @@ def system_scp(pnum, ask, config, logger, **opts):
     In phase mode, raw ftp is not allowed, and the hostname is dynamically
     obtained by a double ssh.
     """
-    logger.info('System', todo=ask.todo, pnum=pnum, opts=opts)
-    value = dict(rpool='retry')
+    logger.info("System", todo=ask.todo, pnum=pnum, opts=opts)
+    value = dict(rpool="retry")
 
-    phasemode = opts.get('phasemode', False)
+    phasemode = opts.get("phasemode", False)
 
-    profile = config['driver'].get('profile', None)
+    profile = config["driver"].get("profile", None)
     with VortexWorker(logger=logger, profile=profile) as vwork:
         sh = vwork.session.sh
-        sh.trace = 'log'
+        sh.trace = "log"
 
         data = vwork.get_dataset(ask)
-        logger.info('scp', source=data.source, destination=data.destination)
+        logger.info("scp", source=data.source, destination=data.destination)
         if not sh.path.exists(data.source):
-            logger.error('The source file is missing - sorry')
-            return pnum, False, dict(rpool='error')
+            logger.error("The source file is missing - sorry")
+            return pnum, False, dict(rpool="error")
 
         if phasemode:
-            data.hostname = _double_ssh(sh, data.phase_loginnode, data.phase_transfernode)
+            data.hostname = _double_ssh(
+                sh, data.phase_loginnode, data.phase_transfernode
+            )
             if data.hostname is None:
                 return pnum, False, value
-        logger.info('scp host', hostname=data.hostname, logname=data.logname)
-        logger.info('scp data', source=data.source, destination=data.destination)
+        logger.info("scp host", hostname=data.hostname, logname=data.logname)
+        logger.info(
+            "scp data", source=data.source, destination=data.destination
+        )
         try:
-            putrc = sh.scpput(data.source, data.destination, hostname=data.hostname,
-                              logname=data.logname, fmt=data.fmt)
+            putrc = sh.scpput(
+                data.source,
+                data.destination,
+                hostname=data.hostname,
+                logname=data.logname,
+                fmt=data.fmt,
+            )
         except Exception as e:
-            logger.warning('scp failed', error=e)
+            logger.warning("scp failed", error=e)
             putrc = False
         if putrc:
             value = dict(clear=sh.rm(data.source, fmt=data.fmt))
@@ -162,23 +190,23 @@ def system_noop(pnum, ask, config, logger, **opts):
 
     Used to desactivate jeeves when mirroring the operational suite.
     """
-    logger.info('Noop', todo=ask.todo, pnum=pnum, opts=opts)
+    logger.info("Noop", todo=ask.todo, pnum=pnum, opts=opts)
 
-    profile = config['driver'].get('profile', None)
+    profile = config["driver"].get("profile", None)
     with VortexWorker(logger=logger, profile=profile) as vwork:
         sh = vwork.session.sh
-        sh.trace = 'log'
+        sh.trace = "log"
         data = vwork.get_dataset(ask)
         value = dict(clear=sh.rm(data.source, fmt=data.fmt))
 
     return pnum, vwork.rc, value
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import vortex
 
     t = vortex.ticket()
     main_sh = t.sh
     main_sh.trace = True
     main_sh.verbose = True
-    print(_double_ssh(main_sh, 'beaufixoper', 'beaufixtransfert-agt'))
+    print(_double_ssh(main_sh, "beaufixoper", "beaufixtransfert-agt"))

--- a/src/vortex/nwp/util/beacon.py
+++ b/src/vortex/nwp/util/beacon.py
@@ -23,18 +23,18 @@ def beaconfunction(options):
     rst = dict()
 
     # Find out if a resource handler is present and load the elements to be written
-    rhdict = options.get('rhandler', None)
+    rhdict = options.get("rhandler", None)
     if rhdict:
-        rst['vapp'] = rhdict.get('provider', {}).get('vapp', '')
-        rst['vconf'] = rhdict.get('provider', {}).get('vconf', '')
-        rst['model'] = rhdict.get('resource', {}).get('model', '')
-        rst['date'] = rhdict.get('resource', {}).get('date', '')
-        rst['cutoff'] = rhdict.get('resource', {}).get('cutoff', '')
-        member = rhdict.get('provider', {}).get('member', None)
+        rst["vapp"] = rhdict.get("provider", {}).get("vapp", "")
+        rst["vconf"] = rhdict.get("provider", {}).get("vconf", "")
+        rst["model"] = rhdict.get("resource", {}).get("model", "")
+        rst["date"] = rhdict.get("resource", {}).get("date", "")
+        rst["cutoff"] = rhdict.get("resource", {}).get("cutoff", "")
+        member = rhdict.get("provider", {}).get("member", None)
         if member is not None:
-            rst['member'] = member
+            rst["member"] = member
     else:
-        rst['error'] = 'No resource handler here'
+        rst["error"] = "No resource handler here"
     outstr = json.dumps(rst)
     # Return the string, which has to be converted to a file like object
-    return io.BytesIO(outstr.encode(encoding='utf_8'))
+    return io.BytesIO(outstr.encode(encoding="utf_8"))

--- a/src/vortex/nwp/util/diffpygram.py
+++ b/src/vortex/nwp/util/diffpygram.py
@@ -27,20 +27,24 @@ class HGeoDesc:
         self.grid = geo.grid
         self.dimensions = geo.dimensions
         self.name = geo.name
-        self.projection = None if not geo.projected_geometry else geo.projection
+        self.projection = (
+            None if not geo.projected_geometry else geo.projection
+        )
         sio = io.StringIO()
         geo.what(out=sio, vertical_geometry=False)
         sio.seek(0)
         self._what = sio.readlines()[3:]
 
     def __eq__(self, other):
-        return ((self.grid == other.grid) and
-                (self.dimensions == other.dimensions) and
-                (self.name == other.name) and
-                (self.projection == other.projection))
+        return (
+            (self.grid == other.grid)
+            and (self.dimensions == other.dimensions)
+            and (self.name == other.name)
+            and (self.projection == other.projection)
+        )
 
     def __str__(self):
-        return ''.join(self._what)
+        return "".join(self._what)
 
 
 class DataDesc:
@@ -51,7 +55,7 @@ class DataDesc:
         :param epyfied: An epygram fild object.
         """
         self.stats = epyfield.stats()
-        self.stats.pop('quadmean', None)  # We do not want quadmean
+        self.stats.pop("quadmean", None)  # We do not want quadmean
         s256 = hashlib.sha256()
         s256.update(epyfield.data.tobytes())
         self.checksum = s256.digest()
@@ -60,7 +64,9 @@ class DataDesc:
         return self.checksum == other.checksum
 
     def __str__(self):
-        return ', '.join(['{:s}={!s}'.format(k, v) for k, v in self.stats.items()])
+        return ", ".join(
+            ["{:s}={!s}".format(k, v) for k, v in self.stats.items()]
+        )
 
 
 class HGeoLibrary:
@@ -87,11 +93,11 @@ class HGeoLibrary:
         return found[0]
 
     def __str__(self):
-        outstr = ''
+        outstr = ""
         for i, g in enumerate(self._geolist):
-            outstr += 'HORIZONTAL GEOMETRY #{:d}\n\n'.format(i)
+            outstr += "HORIZONTAL GEOMETRY #{:d}\n\n".format(i)
             outstr += str(g)
-            outstr += '\n'
+            outstr += "\n"
         return outstr
 
 
@@ -110,32 +116,45 @@ class FieldDesc:
         Compute the comparison score of the present field with respect to a
         reference one (*other*).
         """
-        fidscore = functools.reduce(operator.add,
-                                    [int(self.fid[k] == other.fid[k])
-                                     for k in self.fid.keys() if k in other.fid])
-        fidscore = 5. * float(fidscore) / float(max(len(self.fid), len(other.fid)))
-        return (int(self.valid != other.valid) * -5. +
-                int(self.hgeoid != other.hgeoid) * -5. +
-                int(self.vgeo != other.vgeo) * -4. +
-                int(self.datadesc == other.datadesc) * 5. +
-                fidscore)
+        fidscore = functools.reduce(
+            operator.add,
+            [
+                int(self.fid[k] == other.fid[k])
+                for k in self.fid.keys()
+                if k in other.fid
+            ],
+        )
+        fidscore = (
+            5.0 * float(fidscore) / float(max(len(self.fid), len(other.fid)))
+        )
+        return (
+            int(self.valid != other.valid) * -5.0
+            + int(self.hgeoid != other.hgeoid) * -5.0
+            + int(self.vgeo != other.vgeo) * -4.0
+            + int(self.datadesc == other.datadesc) * 5.0
+            + fidscore
+        )
 
     def ranking_summary(self, other):
         """Returns detailed comparison information (including the ranking)."""
-        return (self.datadesc == other.datadesc,
-                self.valid == other.valid,
-                self.hgeoid == other.hgeoid and self.vgeo == other.vgeo,
-                self.ranking(other))
+        return (
+            self.datadesc == other.datadesc,
+            self.valid == other.valid,
+            self.hgeoid == other.hgeoid and self.vgeo == other.vgeo,
+            self.ranking(other),
+        )
 
     def __str__(self):
-        out = "HGeo=#{:d} ; Validity={!s} ; metadata are:\n".format(self.hgeoid, self.valid)
+        out = "HGeo=#{:d} ; Validity={!s} ; metadata are:\n".format(
+            self.hgeoid, self.valid
+        )
         out += pprint.pformat(self.fid) + "\n"
         out += "Data: {!s}".format(self.datadesc)
         return out
 
     def prefixed_str(self, prefix):
         """A representation of this object prefixed with the *prefix* string."""
-        return '\n'.join([prefix + l for l in str(self).split('\n')])
+        return "\n".join([prefix + l for l in str(self).split("\n")])
 
 
 class FieldBundle:
@@ -157,23 +176,28 @@ class FieldBundle:
         ddesc = DataDesc(fld)
         hgeo_id = self._hgeolib.register(hgeo)
         fid = copy.copy(fid)
-        fid['datebasis'] = fld.validity.getbasis()
-        fid['term'] = fld.validity.term()
-        fid['cumulativeduration'] = fld.validity.cumulativeduration()
+        fid["datebasis"] = fld.validity.getbasis()
+        fid["term"] = fld.validity.term()
+        fid["cumulativeduration"] = fld.validity.cumulativeduration()
         return FieldDesc(hgeo_id, vgeo, ddesc, fid, valid)
 
-    @usepygram.epygram_checker.disabled_if_unavailable(version='1.0.0')
+    @usepygram.epygram_checker.disabled_if_unavailable(version="1.0.0")
     def read_grib(self, filename):
         """Read in a GRIB file."""
         with usepygram.epy_env_prepare(sessions.current()):
-            gribdata = footprints.proxy.dataformat(filename=filename,
-                                                   openmode='r', format='GRIB')
-            fld = gribdata.iter_fields(get_info_as_json=('centre', 'subCentre'))
+            gribdata = footprints.proxy.dataformat(
+                filename=filename, openmode="r", format="GRIB"
+            )
+            fld = gribdata.iter_fields(
+                get_info_as_json=("centre", "subCentre")
+            )
             while fld:
-                fid = fld.fid.get('GRIB2', fld.fid.get('GRIB1'))
+                fid = fld.fid.get("GRIB2", fld.fid.get("GRIB1"))
                 fid.update(json.loads(fld.comment))
                 self._fields.append(self._common_processing(fld, fid))
-                fld = gribdata.iter_fields(get_info_as_json=('centre', 'subCentre'))
+                fld = gribdata.iter_fields(
+                    get_info_as_json=("centre", "subCentre")
+                )
 
 
 class FieldBundles:
@@ -203,22 +227,28 @@ class FieldBundles:
 class EpyGribDiff(FieldBundles):
     """A specialised version of :class:`FieldBundles` that deals with GRIB files."""
 
-    _FMT_COUNTER = '[{:04d}] '
-    _HEAD_COUNTER = ' ' * len(_FMT_COUNTER.format(0))
+    _FMT_COUNTER = "[{:04d}] "
+    _HEAD_COUNTER = " " * len(_FMT_COUNTER.format(0))
 
-    _FMT_SHORT = "#{n:>4d} id={id:16s} l={level:<6d} c={centre:<3d},{scentre:3d}"
+    _FMT_SHORT = (
+        "#{n:>4d} id={id:16s} l={level:<6d} c={centre:<3d},{scentre:3d}"
+    )
     _HEAD_SHORT = "Mess. ParamId/ShortN      Level    Centre,S "
 
     _FMT_MIDDLE = " | {0:1s} {1:1s} {2:1s} {3:6s} | "
     _HEAD_MIDDLE = " | {:1s} {:1s} {:1s}  {:5s} | "
-    _ELTS_MIDDLE = ('data', 'valid', 'geo', 'score')
+    _ELTS_MIDDLE = ("data", "valid", "geo", "score")
 
-    _SPACER = (_HEAD_COUNTER +
-               'REF ' + '-' * (len(_HEAD_SHORT) - 4) +
-               ' | -----  ----- | ' +
-               'NEW ' + '-' * (len(_HEAD_SHORT) - 4))
+    _SPACER = (
+        _HEAD_COUNTER
+        + "REF "
+        + "-" * (len(_HEAD_SHORT) - 4)
+        + " | -----  ----- | "
+        + "NEW "
+        + "-" * (len(_HEAD_SHORT) - 4)
+    )
 
-    _DETAILED_SUMARY = 'Data: {0:1s} ; Validity Date: {1:1s} ; HGeometry: {2:s} ; Score: {3:6s}'
+    _DETAILED_SUMARY = "Data: {0:1s} ; Validity Date: {1:1s} ; HGeometry: {2:s} ; Score: {3:6s}"
 
     def __init__(self, ref, new):
         """
@@ -226,9 +256,9 @@ class EpyGribDiff(FieldBundles):
         :param str new: Path to the new GRIB file
         """
         super().__init__()
-        self._new = self.new_bundle('New')
+        self._new = self.new_bundle("New")
         self._new.read_grib(new)
-        self._ref = self.new_bundle('Ref')
+        self._ref = self.new_bundle("Ref")
         self._ref.read_grib(ref)
 
     def _compute_diff(self):
@@ -250,7 +280,7 @@ class EpyGribDiff(FieldBundles):
             # If the score is >= 3 the fields are paired...
             # Note: Their might be several field combinations with the same
             # ranking score
-            if highest >= 3.:
+            if highest >= 3.0:
                 refs = rscore[highest]
                 couples.append((i, refs, highest, rsummary[highest]))
                 found.update(refs)
@@ -266,52 +296,79 @@ class EpyGribDiff(FieldBundles):
         """Returns the comparison table header."""
         out = cls._SPACER + "\n"
         e_len = max([len(e) for e in cls._ELTS_MIDDLE])
-        e_new = [('{:>' + str(e_len) + 's}').format(e.upper()) for e in cls._ELTS_MIDDLE]
+        e_new = [
+            ("{:>" + str(e_len) + "s}").format(e.upper())
+            for e in cls._ELTS_MIDDLE
+        ]
         if e_len > 1:
             for i in range(e_len - 1):
-                out += (cls._HEAD_COUNTER + ' ' * len(cls._HEAD_SHORT) +
-                        cls._HEAD_MIDDLE.format(* [e[i] for e in e_new]) +
-                        ' ' * len(cls._HEAD_SHORT) + "\n")
-        out += (cls._HEAD_COUNTER + cls._HEAD_SHORT +
-                cls._HEAD_MIDDLE.format(* [e[-1] for e in e_new]) +
-                cls._HEAD_SHORT + "\n") + cls._SPACER + "\n"
+                out += (
+                    cls._HEAD_COUNTER
+                    + " " * len(cls._HEAD_SHORT)
+                    + cls._HEAD_MIDDLE.format(*[e[i] for e in e_new])
+                    + " " * len(cls._HEAD_SHORT)
+                    + "\n"
+                )
+        out += (
+            (
+                cls._HEAD_COUNTER
+                + cls._HEAD_SHORT
+                + cls._HEAD_MIDDLE.format(*[e[-1] for e in e_new])
+                + cls._HEAD_SHORT
+                + "\n"
+            )
+            + cls._SPACER
+            + "\n"
+        )
         return out
 
     @classmethod
     def _str_field_summary(cls, n, field):
         """Returns a string that summarise a field properties."""
-        if 'paramId' in field.fid:
+        if "paramId" in field.fid:
             # GRIB1
-            sid = str(field.fid['paramId']) + '/' + field.fid['shortName']
+            sid = str(field.fid["paramId"]) + "/" + field.fid["shortName"]
         else:
             # GRIB2
-            sid = (str(field.fid['parameterCategory']) + '-' +
-                   str(field.fid['parameterNumber']) + '/' +
-                   field.fid['shortName'])
+            sid = (
+                str(field.fid["parameterCategory"])
+                + "-"
+                + str(field.fid["parameterNumber"])
+                + "/"
+                + field.fid["shortName"]
+            )
         if len(sid) > 16:  # Truncate if the string is too long
-            sid = sid[:15] + '*'
-        return cls._FMT_SHORT.format(n=n, id=sid, level=field.fid.get('level', -99),
-                                     centre=field.fid['centre'],
-                                     scentre=field.fid.get('subCentre', -99))
+            sid = sid[:15] + "*"
+        return cls._FMT_SHORT.format(
+            n=n,
+            id=sid,
+            level=field.fid.get("level", -99),
+            centre=field.fid["centre"],
+            scentre=field.fid.get("subCentre", -99),
+        )
 
     @classmethod
     def _str_rsummary_format(cls, rsum, fmt):
         """Format the ranking_summary output."""
-        dmap = {True: '=', False: '!'}
-        return fmt.format(dmap[rsum[0]], dmap[rsum[1]], dmap[rsum[2]],
-                          '======' if rsum[3] == 10 else '{:6.2f}'.format(rsum[3]))
+        dmap = {True: "=", False: "!"}
+        return fmt.format(
+            dmap[rsum[0]],
+            dmap[rsum[1]],
+            dmap[rsum[2]],
+            "======" if rsum[3] == 10 else "{:6.2f}".format(rsum[3]),
+        )
 
     @staticmethod
     def _embedded_counter(c):
         """Return the formatted comparison counter."""
-        return '[{:04d}] '.format(c)
+        return "[{:04d}] ".format(c)
 
     def format_diff(self, detailed=True):
         """Return a string that contains the comparison results.
 
         :param bool detailed: If False, just returns the comparison table.
         """
-        out = ''
+        out = ""
         counter = 0
         for couple in self._compute_diff():
             if couple[0] is None:
@@ -319,39 +376,70 @@ class EpyGribDiff(FieldBundles):
                     counter += 1
                     out += self._embedded_counter(counter)
                     if detailed:
-                        out += 'Unmatched reference field\n'
-                        out += self.bundles['Ref'].fields[n].prefixed_str('  REF| ') + "\n"
+                        out += "Unmatched reference field\n"
+                        out += (
+                            self.bundles["Ref"]
+                            .fields[n]
+                            .prefixed_str("  REF| ")
+                            + "\n"
+                        )
                     else:
-                        out += self._str_field_summary(n, self.bundles['Ref'].fields[n])
-                        out += self._FMT_MIDDLE.format('?', '?', '?', '     ?') + '\n'
+                        out += self._str_field_summary(
+                            n, self.bundles["Ref"].fields[n]
+                        )
+                        out += (
+                            self._FMT_MIDDLE.format("?", "?", "?", "     ?")
+                            + "\n"
+                        )
             else:
-                new = self.bundles['New'].fields[couple[0]]
+                new = self.bundles["New"].fields[couple[0]]
                 if len(couple[1]):
                     for i, n in enumerate(couple[1]):
                         counter += 1
-                        ref = self.bundles['Ref'].fields[n]
+                        ref = self.bundles["Ref"].fields[n]
                         out += self._embedded_counter(counter)
                         if detailed:
-                            out += self._str_rsummary_format(couple[3][i], self._DETAILED_SUMARY) + "\n"
-                            out += ref.prefixed_str('  REF| ') + "\n  vs\n" + new.prefixed_str('  NEW| ') + "\n"
+                            out += (
+                                self._str_rsummary_format(
+                                    couple[3][i], self._DETAILED_SUMARY
+                                )
+                                + "\n"
+                            )
+                            out += (
+                                ref.prefixed_str("  REF| ")
+                                + "\n  vs\n"
+                                + new.prefixed_str("  NEW| ")
+                                + "\n"
+                            )
                         else:
                             out += self._str_field_summary(n, ref)
-                            out += self._str_rsummary_format(couple[3][i], self._FMT_MIDDLE)
-                            out += self._str_field_summary(couple[0], new) if i == 0 else '  idem.'
-                            out += '\n'
+                            out += self._str_rsummary_format(
+                                couple[3][i], self._FMT_MIDDLE
+                            )
+                            out += (
+                                self._str_field_summary(couple[0], new)
+                                if i == 0
+                                else "  idem."
+                            )
+                            out += "\n"
                 else:
                     counter += 1
                     out += self._embedded_counter(counter)
                     if detailed:
-                        out += 'Unmatched new field \n'
-                        out += self.bundles['New'].fields[couple[0]].prefixed_str('  NEW| ') + "\n"
+                        out += "Unmatched new field \n"
+                        out += (
+                            self.bundles["New"]
+                            .fields[couple[0]]
+                            .prefixed_str("  NEW| ")
+                            + "\n"
+                        )
                     else:
-                        out += ' ' * len(self._HEAD_SHORT)
-                        out += self._FMT_MIDDLE.format('?', '?', '?', '     ?')
-                        out += self._str_field_summary(couple[0], new) + '\n'
-            out += "\n" if detailed else ''
+                        out += " " * len(self._HEAD_SHORT)
+                        out += self._FMT_MIDDLE.format("?", "?", "?", "     ?")
+                        out += self._str_field_summary(couple[0], new) + "\n"
+            out += "\n" if detailed else ""
         if detailed:
-            out += 'LIST OF HORIZONTAL GEOMETRIES:\n\n'
+            out += "LIST OF HORIZONTAL GEOMETRIES:\n\n"
             out += str(self.hgeo_library)
         return out
 

--- a/src/vortex/nwp/util/hooks.py
+++ b/src/vortex/nwp/util/hooks.py
@@ -21,10 +21,15 @@ def update_namelist(t, rh, *completive_rh):
     touched = False
     for crh in completive_rh:
         if not isinstance(crh, (list, tuple)):
-            crh = [crh, ]
+            crh = [
+                crh,
+            ]
         for arh in crh:
-            logger.info('Merging: {!r} :\n{:s}'.format(arh.container,
-                                                       arh.contents.dumps()))
+            logger.info(
+                "Merging: {!r} :\n{:s}".format(
+                    arh.container, arh.contents.dumps()
+                )
+            )
             rh.contents.merge(arh.contents)
             touched = True
     if touched:
@@ -36,14 +41,16 @@ def concatenate(t, rh, *rhlist):
     blocksize = 32 * 1024 * 1024  # 32Mb
     rh.container.close()
     with rh.container.iod_context():
-        myfh = rh.container.iodesc(mode='ab')
+        myfh = rh.container.iodesc(mode="ab")
         for crh in rhlist:
             if not isinstance(crh, (list, tuple)):
-                crh = [crh, ]
+                crh = [
+                    crh,
+                ]
             for arh in crh:
-                logger.info('Appending %s to self.', str(arh.container))
+                logger.info("Appending %s to self.", str(arh.container))
                 with arh.container.iod_context():
-                    afh = arh.container.iodesc(mode='rb')
+                    afh = arh.container.iodesc(mode="rb")
                     stuff = afh.read(blocksize)
                     while stuff:
                         myfh.write(stuff)
@@ -64,14 +71,17 @@ def insert_cutoffs(t, rh, rh_cutoff_source, fuse_per_obstype=False):
             ValueError("The resource handler's list is empty.")
     # Get the CutoffDispenser
     import vortex.tools.listings
+
     assert vortex.tools.listings
-    if rh_cutoff_source.container.actualfmt == 'bdmbufr_listing':
+    if rh_cutoff_source.container.actualfmt == "bdmbufr_listing":
         c_disp_callback = functools.partial(
             rh_cutoff_source.contents.data.cutoffs_dispenser,
-            fuse_per_obstype=fuse_per_obstype
+            fuse_per_obstype=fuse_per_obstype,
         )
     else:
-        raise RuntimeError("Incompatible < {!s} > ressource handler".format(rh_cutoff_source))
+        raise RuntimeError(
+            "Incompatible < {!s} > ressource handler".format(rh_cutoff_source)
+        )
     # Fill the gaps in the original request
     rh.contents.add_cutoff_info(c_disp_callback())
     # Actually save the result to file
@@ -79,7 +89,6 @@ def insert_cutoffs(t, rh, rh_cutoff_source, fuse_per_obstype=False):
 
 
 def _new_static_cutoff_dispencer(base_date, cutoffs_def):
-
     def x_period(p):
         try:
             return Period(p)
@@ -89,8 +98,10 @@ def _new_static_cutoff_dispencer(base_date, cutoffs_def):
     if not isinstance(base_date, Date):
         base_date = Date(base_date)
     if isinstance(cutoffs_def, collections.abc.Mapping):
-        cutoffs_def = {(k if isinstance(k, Period) else x_period(k)): v
-                       for k, v in cutoffs_def.items()}
+        cutoffs_def = {
+            (k if isinstance(k, Period) else x_period(k)): v
+            for k, v in cutoffs_def.items()
+        }
         cutoffs = {base_date + k: v for k, v in cutoffs_def.items()}
         c_disp = StaticCutoffDispenser(max(cutoffs.keys()), cutoffs)
     else:
@@ -110,19 +121,19 @@ def insert_static_cutoffs(t, rh, base_date, cutoffs_def):
                         associates a cutoff with a list of `obstypes`.
     """
     # Fill the gaps in the original request
-    rh.contents.add_cutoff_info(_new_static_cutoff_dispencer(base_date, cutoffs_def))
+    rh.contents.add_cutoff_info(
+        _new_static_cutoff_dispencer(base_date, cutoffs_def)
+    )
     # Actually save the result to files
     rh.save()
 
 
 def arpifs_obs_error_correl_legacy2oops(t, rh):
     """Convert a constant file that contains observation errors correlations."""
-    if rh.resource.realkind != 'correlations':
-        raise ValueError('Incompatible resource: {!s}'.format(rh))
+    if rh.resource.realkind != "correlations":
+        raise ValueError("Incompatible resource: {!s}".format(rh))
     if rh.contents[0].startswith("SIGMAO"):
         logger.warning("Non conversion is needed...")
     else:
-        rh.contents[:0] = ["SIGMAO unused\n",
-                           "1 1.2\n",
-                           "CORRELATIONS\n"]
+        rh.contents[:0] = ["SIGMAO unused\n", "1 1.2\n", "CORRELATIONS\n"]
         rh.save()

--- a/src/vortex/nwp/util/taskdeco.py
+++ b/src/vortex/nwp/util/taskdeco.py
@@ -34,15 +34,17 @@ def process_needs_lfi_stuff(*kargs, **kwargs):
                 pass
 
     """
-    cyclekey = kwargs.pop('cyclekey', 'cycle')
+    cyclekey = kwargs.pop("cyclekey", "cycle")
 
     def decorate_process(cls):
         """Decorator for Task: get LFI stuff before calling process."""
-        original_process = getattr(cls, 'process', None)
+        original_process = getattr(cls, "process", None)
         if original_process is not None:
+
             def process(self, *args, **kwargs):
                 _get_lfi_stuff(self, cyclekey)
                 original_process(self, *args, **kwargs)
+
             process.__doc__ = original_process.__doc__
             cls.process = process
         return cls
@@ -55,27 +57,29 @@ def process_needs_lfi_stuff(*kargs, **kwargs):
 
 def _get_lfi_stuff(self, cyclekey):
     """Get LFI stuff method (called from process)."""
-    if 'early-fetch' in self.steps or 'fetch' in self.steps:
-
+    if "early-fetch" in self.steps or "fetch" in self.steps:
         actualcycle = getattr(self.conf, cyclekey)
 
-        self.sh.title('Toolbox input tblfiscripts')
-        toolbox.input(role='LFIScripts',
-                      genv=actualcycle,
-                      kind='lfiscripts',
-                      local='usualtools/tools.lfi.tgz',
-                      )
-        self.sh.title('Toolbox input tbiopoll')
-        toolbox.input(role='IOPoll',
-                      format='unknown',
-                      genv=actualcycle,
-                      kind='iopoll',
-                      language='perl',
-                      local='usualtools/io_poll',
-                      )
-        self.sh.title('Toolbox input tblfitools')
-        toolbox.input(role='LFITOOLS',
-                      genv=actualcycle,
-                      kind='lfitools',
-                      local='usualtools/lfitools'
-                      )
+        self.sh.title("Toolbox input tblfiscripts")
+        toolbox.input(
+            role="LFIScripts",
+            genv=actualcycle,
+            kind="lfiscripts",
+            local="usualtools/tools.lfi.tgz",
+        )
+        self.sh.title("Toolbox input tbiopoll")
+        toolbox.input(
+            role="IOPoll",
+            format="unknown",
+            genv=actualcycle,
+            kind="iopoll",
+            language="perl",
+            local="usualtools/io_poll",
+        )
+        self.sh.title("Toolbox input tblfitools")
+        toolbox.input(
+            role="LFITOOLS",
+            genv=actualcycle,
+            kind="lfitools",
+            local="usualtools/lfitools",
+        )

--- a/src/vortex/nwp/util/usetnt.py
+++ b/src/vortex/nwp/util/usetnt.py
@@ -14,7 +14,7 @@ from vortex.util.roles import setrole
 
 logger = loggers.getLogger(__name__)
 
-tnt_checker = ExternalCodeImportChecker('thenamelisttool')
+tnt_checker = ExternalCodeImportChecker("thenamelisttool")
 with tnt_checker as tnt_register:
     import thenamelisttool
 
@@ -48,40 +48,54 @@ def compose_nam(options):
 
     :rtype: A file like object
     """
-    rhdict = options.get('rhandler', None)
-    source = rhdict['resource'].get('source', None)
+    rhdict = options.get("rhandler", None)
+    source = rhdict["resource"].get("source", None)
     if source is None:
         logger.error("Inapropriate type of resource. Got:\n%s", rhdict)
-        raise FunctionStoreCallbackError('Inapropriate type of resources.')
+        raise FunctionStoreCallbackError("Inapropriate type of resources.")
 
     t = sessions.current()
 
     def _get_pack_adress(role):
         role = setrole(role)
-        packlist = [sec.rh for sec in t.context.sequence.filtered_inputs(role=role)]
+        packlist = [
+            sec.rh for sec in t.context.sequence.filtered_inputs(role=role)
+        ]
         if len(packlist) != 1:
             logger.error("The number of namelist packs with role=%s is not 1.")
-            raise FunctionStoreCallbackError('Incorrect number of namelist packs.')
+            raise FunctionStoreCallbackError(
+                "Incorrect number of namelist packs."
+            )
         packrh = packlist[0]
-        if packrh.resource.realkind != 'namelistpack':
-            logger.error("Incorrect resource type for role %s. Resource handler:\n%s",
-                         role, packrh.icdard())
-            raise FunctionStoreCallbackError('Incorrect resource type.')
+        if packrh.resource.realkind != "namelistpack":
+            logger.error(
+                "Incorrect resource type for role %s. Resource handler:\n%s",
+                role,
+                packrh.icdard(),
+            )
+            raise FunctionStoreCallbackError("Incorrect resource type.")
         if not packrh.container.filled:
-            logger.error("The resource handler's container is not filled for role %s", role)
-            raise FunctionStoreCallbackError('RH container is not filled.')
+            logger.error(
+                "The resource handler's container is not filled for role %s",
+                role,
+            )
+            raise FunctionStoreCallbackError("RH container is not filled.")
         return packrh.container.abspath
 
-    nampack_path = _get_pack_adress(options.get('nampack', 'Main Namelist Pack'))
-    dirpack_role = options.get('dirpack', None)
-    dirpack_path = _get_pack_adress(dirpack_role) if dirpack_role else nampack_path
+    nampack_path = _get_pack_adress(
+        options.get("nampack", "Main Namelist Pack")
+    )
+    dirpack_role = options.get("dirpack", None)
+    dirpack_path = (
+        _get_pack_adress(dirpack_role) if dirpack_role else nampack_path
+    )
 
     out_io = io.BytesIO()
     thenamelisttool.util.compose_namelist(
-        t.sh.path.join(dirpack_path, source + '.yaml'),
+        t.sh.path.join(dirpack_path, source + ".yaml"),
         sourcenam_directory=nampack_path,
         sorting=thenamelisttool.namadapter.FIRST_ORDER_SORTING,
         squeeze=False,
-        fhoutput=codecs.getwriter('utf-8')(out_io)
+        fhoutput=codecs.getwriter("utf-8")(out_io),
     )
     return out_io

--- a/src/vortex/sessions.py
+++ b/src/vortex/sessions.py
@@ -17,7 +17,7 @@ import footprints
 
 from vortex.tools.env import Environment
 
-from vortex import gloves  # @UnusedImport
+from vortex import gloves as gloves  # footprints import
 from vortex.layout import contexts
 
 #: No automatic export

--- a/src/vortex/sessions.py
+++ b/src/vortex/sessions.py
@@ -28,9 +28,13 @@ logger = loggers.getLogger(__name__)
 
 # Module Interface
 
+
 def get(**kw):
     """Return actual session ticket object matching description."""
-    if kw.get('tag', 'current') == 'current' and Ticket.tag_focus() is not None:
+    if (
+        kw.get("tag", "current") == "current"
+        and Ticket.tag_focus() is not None
+    ):
         return current()
     else:
         return Ticket(**kw)
@@ -73,7 +77,7 @@ def getglove(**kw):
 
 def system(**kw):
     """Returns the system associated to the current ticket."""
-    return get(tag=kw.pop('tag', Ticket.tag_focus())).system(**kw)
+    return get(tag=kw.pop("tag", Ticket.tag_focus())).system(**kw)
 
 
 # noinspection PyShadowingBuiltins
@@ -94,17 +98,19 @@ class Ticket(getbytag.GetByTag):
     Default session ticket class, defined by tag.
     """
 
-    _tag_default = 'root'
+    _tag_default = "root"
 
-    def __init__(self,
-                 active=False,
-                 topenv=None,
-                 glove=None,
-                 context=None,
-                 datastore=None,
-                 prompt='Vortex:'):
+    def __init__(
+        self,
+        active=False,
+        topenv=None,
+        glove=None,
+        context=None,
+        datastore=None,
+        prompt="Vortex:",
+    ):
         self.prompt = prompt
-        self.line = "\n" + '-' * 100 + "\n"
+        self.line = "\n" + "-" * 100 + "\n"
 
         self._started = date.now()
         self._closed = 0
@@ -120,18 +126,24 @@ class Ticket(getbytag.GetByTag):
         else:
             self._glove = getglove()
 
-        logger.debug('New session system is %s', self.system())
+        logger.debug("New session system is %s", self.system())
 
         self._rundir = self.sh.getcwd()
 
-        logger.debug('Open session %s %s', self.tag, self)
+        logger.debug("Open session %s %s", self.tag, self)
 
         if datastore is None:
-            datastore = DataStore(default_picklefile='{:s}_session_datastore.pickled'.format(self.tag))
+            datastore = DataStore(
+                default_picklefile="{:s}_session_datastore.pickled".format(
+                    self.tag
+                )
+            )
         self._dstore = datastore
 
         if context is None:
-            context = contexts.Context(tag=self.tag, topenv=self._topenv, path=self.path)
+            context = contexts.Context(
+                tag=self.tag, topenv=self._topenv, path=self.path
+            )
         self._last_context = context
 
         if active:
@@ -144,12 +156,20 @@ class Ticket(getbytag.GetByTag):
     def _set_rundir(self, path):
         """Set a new default rundir for this session."""
         if self._rundir:
-            logger.warning('Session <%s> is changing its working directory <%s>', self.tag, self._rundir)
+            logger.warning(
+                "Session <%s> is changing its working directory <%s>",
+                self.tag,
+                self._rundir,
+            )
         if self.sh.path.isdir(path):
             self._rundir = path
-            logger.info('Session <%s> set rundir <%s>', self.tag, self._rundir)
+            logger.info("Session <%s> set rundir <%s>", self.tag, self._rundir)
         else:
-            logger.error('Try to change session <%s> to invalid path <%s>', self.tag, path)
+            logger.error(
+                "Try to change session <%s> to invalid path <%s>",
+                self.tag,
+                path,
+            )
 
     rundir = property(_get_rundir, _set_rundir)
 
@@ -210,11 +230,14 @@ class Ticket(getbytag.GetByTag):
         Returns the current OS handler used or set a new one according
         to ``kw`` dictionary-like arguments.
         """
-        refill = kw.pop('refill', False)
+        refill = kw.pop("refill", False)
         if not self._system or kw or refill:
             self._system = footprints.proxy.system(glove=self.glove, **kw)
             if not self._system:
-                logger.critical('Could not load a system object with description %s', str(kw))
+                logger.critical(
+                    "Could not load a system object with description %s",
+                    str(kw),
+                )
         return self._system
 
     def duration(self):
@@ -237,27 +260,31 @@ class Ticket(getbytag.GetByTag):
     def close(self):
         """Closes the current session."""
         if self.closed:
-            logger.warning('Session %s already closed at %s', self.tag, self.closed)
+            logger.warning(
+                "Session %s already closed at %s", self.tag, self.closed
+            )
         else:
             self._closed = date.now()
-            logger.debug('Close session %s ( time = %s )', self.tag, self.duration())
+            logger.debug(
+                "Close session %s ( time = %s )", self.tag, self.duration()
+            )
 
     @property
     def path(self):
-        return '/' + self.tag
+        return "/" + self.tag
 
     @property
     def subcontexts(self):
         """The current contexts binded to this session."""
-        rootpath = self.path + '/'
+        rootpath = self.path + "/"
         return [x for x in contexts.values() if x.path.startswith(rootpath)]
 
     def exit(self):
         """Exit from the current session."""
         ok = True
-        logger.debug('Exit session %s %s', self.tag, self)
+        logger.debug("Exit session %s %s", self.tag, self)
         for kid in self.subcontexts:
-            logger.debug('Exit from context %s', kid)
+            logger.debug("Exit from context %s", kid)
             ok = ok and kid.exit()
         if self.opened:
             self.close()
@@ -295,20 +322,26 @@ class Ticket(getbytag.GetByTag):
         """
         Returns the logging level.
         """
-        v_logger = loggers.getLogger('vortex')
+        v_logger = loggers.getLogger("vortex")
         return logging.getLevelName(v_logger.getEffectiveLevel())
 
-    def idcard(self, indent='+ '):
+    def idcard(self, indent="+ "):
         """Returns a printable description of the current session."""
-        card = "\n".join((
-            '{0}Name     = {1:s}',
-            '{0}Started  = {2!s}',
-            '{0}Opened   = {3!s}',
-            '{0}Duration = {4!s}',
-            '{0}Loglevel = {5:s}'
-        )).format(
+        card = "\n".join(
+            (
+                "{0}Name     = {1:s}",
+                "{0}Started  = {2!s}",
+                "{0}Opened   = {3!s}",
+                "{0}Duration = {4!s}",
+                "{0}Loglevel = {5:s}",
+            )
+        ).format(
             indent,
-            self.tag, self.started, self.opened, self.duration(), self.loglevel
+            self.tag,
+            self.started,
+            self.opened,
+            self.duration(),
+            self.loglevel,
         )
         return card
 
@@ -333,7 +366,7 @@ class Ticket(getbytag.GetByTag):
             obj.catch_focus()
             return obj
         else:
-            logger.error('Try to switch to an undefined session: %s', tag)
+            logger.error("Try to switch to an undefined session: %s", tag)
             return None
 
     def __del__(self):

--- a/src/vortex/syntax/__init__.py
+++ b/src/vortex/syntax/__init__.py
@@ -6,4 +6,4 @@ The most important usage is done by :class:`FootprintBase` derivated objects.
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'VORTEX package where standard attributes are defined.'
+__tocinfoline__ = "VORTEX package where standard attributes are defined."

--- a/src/vortex/syntax/stdattrs.py
+++ b/src/vortex/syntax/stdattrs.py
@@ -13,46 +13,159 @@ from bronx.syntax.decorators import secure_getattr
 from bronx.system import hash as hashutils
 from vortex.tools import env
 
-from .stddeco import generic_pathname_insert, namebuilding_append, namebuilding_insert
+from .stddeco import (
+    generic_pathname_insert,
+    namebuilding_append,
+    namebuilding_insert,
+)
 
 #: Export a set of attributes :data:`a_model`, :data:`a_date`, etc..
 __all__ = [
-    'a_xpid', 'a_month', 'a_domain', 'a_truncation', 'a_model', 'a_member',
-    'a_date', 'a_cutoff', 'a_term', 'a_nativefmt', 'a_actualfmt', 'a_suite',
-    'a_namespace', 'a_hashalgo', 'a_compressionpipeline', 'a_block', 'a_number'
+    "a_xpid",
+    "a_month",
+    "a_domain",
+    "a_truncation",
+    "a_model",
+    "a_member",
+    "a_date",
+    "a_cutoff",
+    "a_term",
+    "a_nativefmt",
+    "a_actualfmt",
+    "a_suite",
+    "a_namespace",
+    "a_hashalgo",
+    "a_compressionpipeline",
+    "a_block",
+    "a_number",
 ]
 
 #: Possible values for the *model* attribute.
 models = {
-    'arpege', 'arp', 'arp_court', 'aladin', 'ald', 'arome', 'aro', 'aearp', 'pearp', 'mocage',
-    'mesonh', 'surfex', 'hycom', 'psy4', 'mercator_global', 'glo12', 'safran', 'ifs', 'aroifs', 'cifs',
-    'mfwam', 'pg1', 'alpha', 'eps', 'postproc', 'ww3', 'sympo', 'psym', 'petaroute', 'promethee',
-    'hycom3d', 'croco', 'alaro', 'harmoniearome', 'nemo', 'oasis',
+    "arpege",
+    "arp",
+    "arp_court",
+    "aladin",
+    "ald",
+    "arome",
+    "aro",
+    "aearp",
+    "pearp",
+    "mocage",
+    "mesonh",
+    "surfex",
+    "hycom",
+    "psy4",
+    "mercator_global",
+    "glo12",
+    "safran",
+    "ifs",
+    "aroifs",
+    "cifs",
+    "mfwam",
+    "pg1",
+    "alpha",
+    "eps",
+    "postproc",
+    "ww3",
+    "sympo",
+    "psym",
+    "petaroute",
+    "promethee",
+    "hycom3d",
+    "croco",
+    "alaro",
+    "harmoniearome",
+    "nemo",
+    "oasis",
 }
 
 #: Possible values for the most common binaries.
 binaries = {
-    'arpege', 'aladin', 'arome', 'aromeom_common', 'batodb', 'peace', 'mocage', 'sumo',
-    'corromegasurf', 'mesonh', 'safran', 'surfex', 'macc', 'mktopbd', 'ifs', 'oops',
-    'assistance', 'arpifs', 'mfwam', 'mfwam_interp', 'mfwam_interpbc', 'ww3', 'ww3_prnc',
-    'ww3_bound', 'ww3_ncgrb', 'ial', 'alaro', 'harmoniearome', 'nemo', 'oasis', 'arobase',
-    'xios',
+    "arpege",
+    "aladin",
+    "arome",
+    "aromeom_common",
+    "batodb",
+    "peace",
+    "mocage",
+    "sumo",
+    "corromegasurf",
+    "mesonh",
+    "safran",
+    "surfex",
+    "macc",
+    "mktopbd",
+    "ifs",
+    "oops",
+    "assistance",
+    "arpifs",
+    "mfwam",
+    "mfwam_interp",
+    "mfwam_interpbc",
+    "ww3",
+    "ww3_prnc",
+    "ww3_bound",
+    "ww3_ncgrb",
+    "ial",
+    "alaro",
+    "harmoniearome",
+    "nemo",
+    "oasis",
+    "arobase",
+    "xios",
 }
 
 #: Possible values for the most common utility programs.
-utilities = {'batodb'}
+utilities = {"batodb"}
 
 #: Known formats
 knownfmt = {
-    'auto', 'autoconfig', 'unknown', 'foo', 'arpifslist', 'bdmbufr_listing', 'ascii', 'txt',
-    'json', 'fa', 'lfi', 'lfa', 'netcdf', 'grib', 'grib1', 'grib2', 'bufr', 'hdf5', 'obsoul',
-    'odb', 'ecma', 'ccma', 'bullx', 'sx', 'ddhpack', 'tar', 'tgz', 'rawfiles', 'binary', 'bin',
-    'obslocationpack', 'obsfirepack', 'wbcpack', 'geo', 'nam', 'png', 'pdf', 'dir/hdr', 'yml',
-    'yaml', 'ini'
+    "auto",
+    "autoconfig",
+    "unknown",
+    "foo",
+    "arpifslist",
+    "bdmbufr_listing",
+    "ascii",
+    "txt",
+    "json",
+    "fa",
+    "lfi",
+    "lfa",
+    "netcdf",
+    "grib",
+    "grib1",
+    "grib2",
+    "bufr",
+    "hdf5",
+    "obsoul",
+    "odb",
+    "ecma",
+    "ccma",
+    "bullx",
+    "sx",
+    "ddhpack",
+    "tar",
+    "tgz",
+    "rawfiles",
+    "binary",
+    "bin",
+    "obslocationpack",
+    "obsfirepack",
+    "wbcpack",
+    "geo",
+    "nam",
+    "png",
+    "pdf",
+    "dir/hdr",
+    "yml",
+    "yaml",
+    "ini",
 }
 
 #: Default attributes excluded from `repr` display
-notinrepr = {'kind', 'unknown', 'clscontents', 'gvar', 'nativefmt'}
+notinrepr = {"kind", "unknown", "clscontents", "gvar", "nativefmt"}
 
 
 class DelayedEnvValue:
@@ -69,7 +182,7 @@ class DelayedEnvValue:
         self._frozen = False
 
     def as_dump(self):
-        return 'varname={},default={}'.format(self.varname, self.default)
+        return "varname={},default={}".format(self.varname, self.default)
 
     def footprint_value(self):
         """
@@ -104,10 +217,13 @@ class DelayedInit:
         return getattr(self.__proxied, name)
 
     def __repr__(self):
-        orig = re.sub('^<(.*)>$', r'\1', super().__repr__())
-        return '<{:s} | proxied={:s}>'.format(orig,
-                                              'Not yet Initialised' if self.__proxied is None
-                                              else repr(self.__proxied))
+        orig = re.sub("^<(.*)>$", r"\1", super().__repr__())
+        return "<{:s} | proxied={:s}>".format(
+            orig,
+            "Not yet Initialised"
+            if self.__proxied is None
+            else repr(self.__proxied),
+        )
 
     def __str__(self):
         return repr(self) if self.__proxied is None else str(self.__proxied)
@@ -116,13 +232,13 @@ class DelayedInit:
 class FmtInt(int):
     """Formated integer."""
 
-    def __new__(cls, value, fmt='02'):
+    def __new__(cls, value, fmt="02"):
         obj = int.__new__(cls, value)
         obj._fmt = fmt
         return obj
 
     def __str__(self):
-        return '{0:{fmt}d}'.format(self.__int__(), fmt=self._fmt)
+        return "{0:{fmt}d}".format(self.__int__(), fmt=self._fmt)
 
     def export_dict(self):
         """The pure dict/json output is the raw integer"""
@@ -130,11 +246,12 @@ class FmtInt(int):
 
     def nice(self, value):
         """Returns the specified ``value`` with the format of the current object."""
-        return '{0:{fmt}d}'.format(value, fmt=self._fmt)
+        return "{0:{fmt}d}".format(value, fmt=self._fmt)
 
 
 class XPid(str):
     """Basestring wrapper for experiment ids (abstract)."""
+
     pass
 
 
@@ -142,8 +259,8 @@ class LegacyXPid(XPid):
     """Basestring wrapper for experiment ids (Olive/Oper convention)."""
 
     def __new__(cls, value):
-        if len(value) != 4 or '@' in value:
-            raise ValueError('XPid should be a 4 digits string')
+        if len(value) != 4 or "@" in value:
+            raise ValueError("XPid should be a 4 digits string")
         return str.__new__(cls, value.upper())
 
     def isoper(self):
@@ -154,21 +271,24 @@ class LegacyXPid(XPid):
 class FreeXPid(XPid):
     """Basestring wrapper for experiment ids (User defined)."""
 
-    _re_valid = re.compile(r'^\S+@[-\w]+$')
+    _re_valid = re.compile(r"^\S+@[-\w]+$")
 
     def __new__(cls, value):
         if not cls._re_valid.match(value):
-            raise ValueError('XPid should be something like "id@location" (not "{:s}")'
-                             .format(value))
+            raise ValueError(
+                'XPid should be something like "id@location" (not "{:s}")'.format(
+                    value
+                )
+            )
         return str.__new__(cls, value)
 
     @property
     def id(self):
-        return self.split('@')[0]
+        return self.split("@")[0]
 
     @property
     def location(self):
-        return self.split('@')[1]
+        return self.split("@")[1]
 
 
 def any_vortex_xpid(xpidguess):
@@ -179,16 +299,23 @@ def any_vortex_xpid(xpidguess):
         except ValueError:
             xp = FreeXPid(xpidguess)
     except ValueError:
-        raise ValueError("'{:s}' could not be reclassed as a LegacyXPid or a FreeXPid")
+        raise ValueError(
+            "'{:s}' could not be reclassed as a LegacyXPid or a FreeXPid"
+        )
     return xp
 
 
 #: The list of operational experiment names.
-opsuites = {LegacyXPid(x) for x in (['OPER', 'DBLE', 'TEST', 'MIRR'] +
-                                    ['OP{:02d}'.format(i) for i in range(100)])}
+opsuites = {
+    LegacyXPid(x)
+    for x in (
+        ["OPER", "DBLE", "TEST", "MIRR"]
+        + ["OP{:02d}".format(i) for i in range(100)]
+    )
+}
 
 #: The list of experiemnt names dedicated to Vortex' demos
-demosuites = {LegacyXPid('DEMO'), LegacyXPid('DREF')}
+demosuites = {LegacyXPid("DEMO"), LegacyXPid("DREF")}
 
 
 class Namespace(str):
@@ -197,20 +324,22 @@ class Namespace(str):
     def __new__(cls, value):
         value = value.lower()
         full = value
-        if '@' in value:
-            netuser, value = value.split('@')
-            if ':' in netuser:
-                netuser, netpass = netuser.split(':')
+        if "@" in value:
+            netuser, value = value.split("@")
+            if ":" in netuser:
+                netuser, netpass = netuser.split(":")
             else:
                 netpass = None
         else:
             netuser, netpass = None, None
-        if ':' in value:
-            value, port = value.split(':')
+        if ":" in value:
+            value, port = value.split(":")
         else:
             port = None
-        if 0 < value.count('.') < 2:
-            raise ValueError('Namespace should contain one or at least 3 fields')
+        if 0 < value.count(".") < 2:
+            raise ValueError(
+                "Namespace should contain one or at least 3 fields"
+            )
         thisns = str.__new__(cls, value)
         thisns._port = int(port) if port else None
         thisns._user = netuser
@@ -220,12 +349,12 @@ class Namespace(str):
 
     @property
     def firstname(self):
-        return self.split('.', 1)[0]
+        return self.split(".", 1)[0]
 
     @property
     def domain(self):
-        if '.' in self.netloc:
-            return self.split('.', 1)[1]
+        if "." in self.netloc:
+            return self.split(".", 1)[1]
         else:
             return self.netloc
 
@@ -251,23 +380,23 @@ class Latitude(float):
 
     def __new__(cls, value):
         value = str(value).lower()
-        if value.endswith('n'):
+        if value.endswith("n"):
             value = value[:-1]
-        elif value.endswith('s'):
+        elif value.endswith("s"):
             value = value[:-1]
-            if not value.startswith('-'):
-                value = '-' + value
+            if not value.startswith("-"):
+                value = "-" + value
         if not -90 <= float(value) <= 90:
-            raise ValueError('Latitude out of bounds: ' + value)
+            raise ValueError("Latitude out of bounds: " + value)
         return float.__new__(cls, value)
 
     def nice(self):
-        ns = 'N' if self >= 0 else 'S'
-        return str(self).strip('-') + ns
+        ns = "N" if self >= 0 else "S"
+        return str(self).strip("-") + ns
 
     @property
     def hemisphere(self):
-        return 'North' if self >= 0 else 'South'
+        return "North" if self >= 0 else "South"
 
 
 class Longitude(float):
@@ -275,23 +404,23 @@ class Longitude(float):
 
     def __new__(cls, value):
         value = str(value).lower()
-        if value.endswith('e'):
+        if value.endswith("e"):
             value = value[:-1]
-        elif value.endswith('w'):
+        elif value.endswith("w"):
             value = value[:-1]
-            if not value.startswith('-'):
-                value = '-' + value
+            if not value.startswith("-"):
+                value = "-" + value
         if not -180 <= float(value) <= 180:
-            raise ValueError('Longitude out of bounds: ' + value)
+            raise ValueError("Longitude out of bounds: " + value)
         return float.__new__(cls, value)
 
     def nice(self):
-        ns = 'E' if self >= 0 else 'W'
-        return str(self).strip('-') + ns
+        ns = "E" if self >= 0 else "W"
+        return str(self).strip("-") + ns
 
     @property
     def hemisphere(self):
-        return 'East' if self >= 0 else 'West'
+        return "East" if self >= 0 else "West"
 
 
 # predefined attributes
@@ -303,46 +432,52 @@ a_xpid = dict(
     optional=False,
 )
 
-xpid = footprints.Footprint(info='Abstract experiment id',
-                            attr=dict(experiment=a_xpid))
+xpid = footprints.Footprint(
+    info="Abstract experiment id", attr=dict(experiment=a_xpid)
+)
 
 #: Usual definition for an Olive/Oper ``xpid`` (*e.g.* experiment name).
 a_legacy_xpid = copy.copy(a_xpid)
-a_legacy_xpid['type'] = LegacyXPid
+a_legacy_xpid["type"] = LegacyXPid
 
-legacy_xpid = footprints.Footprint(info='Abstract experiment id',
-                                   attr=dict(experiment=a_legacy_xpid))
+legacy_xpid = footprints.Footprint(
+    info="Abstract experiment id", attr=dict(experiment=a_legacy_xpid)
+)
 
 #: Usual definition for a user-defined ``xpid`` (*e.g.* experiment name).
 a_free_xpid = copy.copy(a_xpid)
-a_free_xpid['type'] = FreeXPid
+a_free_xpid["type"] = FreeXPid
 
-free_xpid = footprints.Footprint(info='Abstract experiment id',
-                                 attr=dict(experiment=a_free_xpid))
+free_xpid = footprints.Footprint(
+    info="Abstract experiment id", attr=dict(experiment=a_free_xpid)
+)
 
 #: Usual definition of the ``nativefmt`` attribute.
 a_nativefmt = dict(
     info="The resource's storage format.",
     optional=True,
-    default='foo',
+    default="foo",
     values=knownfmt,
-    remap=dict(auto='foo'),
+    remap=dict(auto="foo"),
 )
 
-nativefmt = footprints.Footprint(info='Native format', attr=dict(nativefmt=a_nativefmt))
+nativefmt = footprints.Footprint(
+    info="Native format", attr=dict(nativefmt=a_nativefmt)
+)
 
 
 def _namebuilding_insert_nativefmt(cls):
-
-    if hasattr(cls, 'namebuilding_info'):
+    if hasattr(cls, "namebuilding_info"):
         original_namebuilding_info = cls.namebuilding_info
 
         def namebuilding_info(self):
             vinfo = original_namebuilding_info(self)
-            ext_remap = getattr(self, '_extension_remap', dict())
+            ext_remap = getattr(self, "_extension_remap", dict())
             ext_value = ext_remap.get(self.nativefmt, self.nativefmt)
             if ext_value is not None:
-                vinfo.setdefault('fmt', ext_remap.get(self.nativefmt, self.nativefmt))
+                vinfo.setdefault(
+                    "fmt", ext_remap.get(self.nativefmt, self.nativefmt)
+                )
             return vinfo
 
         namebuilding_info.__doc__ = original_namebuilding_info.__doc__
@@ -353,67 +488,97 @@ def _namebuilding_insert_nativefmt(cls):
 
 nativefmt_deco = footprints.DecorativeFootprint(
     nativefmt,
-    decorator=[_namebuilding_insert_nativefmt,
-               generic_pathname_insert('nativefmt', lambda self: self.nativefmt, setdefault=True)])
+    decorator=[
+        _namebuilding_insert_nativefmt,
+        generic_pathname_insert(
+            "nativefmt", lambda self: self.nativefmt, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``actualfmt`` attribute.
 a_actualfmt = dict(
     info="The resource's format.",
     optional=True,
-    default='[nativefmt#unknown]',
-    alias=('format',),
+    default="[nativefmt#unknown]",
+    alias=("format",),
     values=knownfmt,
-    remap=dict(auto='foo'),
+    remap=dict(auto="foo"),
 )
 
-actualfmt = footprints.Footprint(info='Actual data format', attr=dict(actualfmt=a_actualfmt))
+actualfmt = footprints.Footprint(
+    info="Actual data format", attr=dict(actualfmt=a_actualfmt)
+)
 
 #: Usual definition of the ``cutoff`` attribute.
 a_cutoff = dict(
     info="The cutoff type of the generating process.",
     optional=False,
-    alias=('cut',),
+    alias=("cut",),
     values=[
-        'a', 'assim', 'assimilation', 'long',
-        'p', 'prod', 'production', 'short'
+        "a",
+        "assim",
+        "assimilation",
+        "long",
+        "p",
+        "prod",
+        "production",
+        "short",
     ],
     remap=dict(
-        a='assim',
-        p='production',
-        prod='production',
-        long='assim',
-        assimilation='assim'
-    )
+        a="assim",
+        p="production",
+        prod="production",
+        long="assim",
+        assimilation="assim",
+    ),
 )
 
-cutoff = footprints.Footprint(info='Abstract cutoff', attr=dict(cutoff=a_cutoff))
+cutoff = footprints.Footprint(
+    info="Abstract cutoff", attr=dict(cutoff=a_cutoff)
+)
 
 cutoff_deco = footprints.DecorativeFootprint(
     cutoff,
-    decorator=[namebuilding_append('flow',
-                                   lambda self: None if self.cutoff is None else {'shortcutoff': self.cutoff},
-                                   none_discard=True),
-               generic_pathname_insert('cutoff', lambda self: self.cutoff, setdefault=True)])
+    decorator=[
+        namebuilding_append(
+            "flow",
+            lambda self: None
+            if self.cutoff is None
+            else {"shortcutoff": self.cutoff},
+            none_discard=True,
+        ),
+        generic_pathname_insert(
+            "cutoff", lambda self: self.cutoff, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``model`` attribute.
 a_model = dict(
     info="The model name (from a source code perspective).",
-    alias=('turtle',),
+    alias=("turtle",),
     optional=False,
     values=models,
-    remap=dict(
-        arp='arpege',
-        ald='aladin',
-        aro='arome'
-    ),
+    remap=dict(arp="arpege", ald="aladin", aro="arome"),
 )
 
-model = footprints.Footprint(info='Abstract model', attr=dict(model=a_model))
+model = footprints.Footprint(info="Abstract model", attr=dict(model=a_model))
 
 model_deco = footprints.DecorativeFootprint(
     model,
-    decorator=[namebuilding_append('src', lambda self: [self.model, ]),
-               generic_pathname_insert('model', lambda self: self.model, setdefault=True)])
+    decorator=[
+        namebuilding_append(
+            "src",
+            lambda self: [
+                self.model,
+            ],
+        ),
+        generic_pathname_insert(
+            "model", lambda self: self.model, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``date`` attribute.
 a_date = dict(
@@ -422,31 +587,50 @@ a_date = dict(
     optional=False,
 )
 
-date = footprints.Footprint(info='Abstract date', attr=dict(date=a_date))
+date = footprints.Footprint(info="Abstract date", attr=dict(date=a_date))
 
 date_deco = footprints.DecorativeFootprint(
     date,
-    decorator=[namebuilding_append('flow', lambda self: {'date': self.date}),
-               generic_pathname_insert('date', lambda self: self.date, setdefault=True)])
+    decorator=[
+        namebuilding_append("flow", lambda self: {"date": self.date}),
+        generic_pathname_insert(
+            "date", lambda self: self.date, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``begindate`` and ``enddate`` attributes.
 
-dateperiod = footprints.Footprint(info='Abstract date period',
-                                  attr=dict(begindate=dict(info="The resource's begin date.",
-                                                           type=Date,
-                                                           optional=False),
-                                            enddate=dict(info="The resource's end date.",
-                                                         type=Date,
-                                                         optional=False),
-                                            ))
+dateperiod = footprints.Footprint(
+    info="Abstract date period",
+    attr=dict(
+        begindate=dict(
+            info="The resource's begin date.", type=Date, optional=False
+        ),
+        enddate=dict(
+            info="The resource's end date.", type=Date, optional=False
+        ),
+    ),
+)
 
 dateperiod_deco = footprints.DecorativeFootprint(
     dateperiod,
-    decorator=[namebuilding_append('flow',
-                                   lambda self: [{'begindate': self.begindate},
-                                                 {'enddate': self.enddate}]),
-               generic_pathname_insert('begindate', lambda self: self.begindate, setdefault=True),
-               generic_pathname_insert('enddate', lambda self: self.enddate, setdefault=True)])
+    decorator=[
+        namebuilding_append(
+            "flow",
+            lambda self: [
+                {"begindate": self.begindate},
+                {"enddate": self.enddate},
+            ],
+        ),
+        generic_pathname_insert(
+            "begindate", lambda self: self.begindate, setdefault=True
+        ),
+        generic_pathname_insert(
+            "enddate", lambda self: self.enddate, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``month`` attribute.
 a_month = dict(
@@ -454,21 +638,23 @@ a_month = dict(
     type=Month,
     args=dict(year=0),
     optional=False,
-    values=range(1, 13)
+    values=range(1, 13),
 )
 
-month = footprints.Footprint(info='Abstract month', attr=dict(month=a_month))
+month = footprints.Footprint(info="Abstract month", attr=dict(month=a_month))
 
 
 def _add_month2gget_basename(cls):
     """Decorator that appends the month's number at the end of the gget_basename"""
-    original_gget_basename = getattr(cls, 'gget_basename', None)
+    original_gget_basename = getattr(cls, "gget_basename", None)
     if original_gget_basename is not None:
 
         def gget_basename(self):
             """GGET specific naming convention."""
             b_dict = original_gget_basename(self)
-            b_dict['suffix'] = b_dict.get('suffix', '') + '.m{!s}'.format(self.month)
+            b_dict["suffix"] = b_dict.get("suffix", "") + ".m{!s}".format(
+                self.month
+            )
             return b_dict
 
         cls.gget_basename = gget_basename
@@ -477,12 +663,12 @@ def _add_month2gget_basename(cls):
 
 def _add_month2olive_basename(cls):
     """Decorator that appends the month's number at the end of the olive_basename."""
-    original_olive_basename = getattr(cls, 'olive_basename', None)
+    original_olive_basename = getattr(cls, "olive_basename", None)
     if original_olive_basename is not None:
 
         def olive_basename(self):
             """GGET specific naming convention."""
-            return original_olive_basename(self) + '.{!s}'.format(self.month)
+            return original_olive_basename(self) + ".{!s}".format(self.month)
 
         cls.olive_basename = olive_basename
     return cls
@@ -490,8 +676,12 @@ def _add_month2olive_basename(cls):
 
 month_deco = footprints.DecorativeFootprint(
     month,
-    decorator=[namebuilding_append('suffix', lambda self: {'month': self.month}),
-               _add_month2gget_basename, _add_month2olive_basename])
+    decorator=[
+        namebuilding_append("suffix", lambda self: {"month": self.month}),
+        _add_month2gget_basename,
+        _add_month2olive_basename,
+    ],
+)
 
 #: Usual definition of the ``truncation`` attribute.
 a_truncation = dict(
@@ -500,7 +690,9 @@ a_truncation = dict(
     optional=False,
 )
 
-truncation = footprints.Footprint(info='Abstract truncation', attr=dict(truncation=a_truncation))
+truncation = footprints.Footprint(
+    info="Abstract truncation", attr=dict(truncation=a_truncation)
+)
 
 #: Usual definition of the ``domain`` attribute.
 a_domain = dict(
@@ -508,7 +700,9 @@ a_domain = dict(
     optional=False,
 )
 
-domain = footprints.Footprint(info='Abstract domain', attr=dict(domain=a_domain))
+domain = footprints.Footprint(
+    info="Abstract domain", attr=dict(domain=a_domain)
+)
 
 #: Usual definition of the ``term`` attribute.
 a_term = dict(
@@ -517,39 +711,57 @@ a_term = dict(
     optional=False,
 )
 
-term = footprints.Footprint(info='Abstract term', attr=dict(term=a_term))
+term = footprints.Footprint(info="Abstract term", attr=dict(term=a_term))
 
 term_deco = footprints.DecorativeFootprint(
     term,
-    decorator=[namebuilding_insert('term',
-                                   lambda self: None if self.term is None else self.term.fmthm,
-                                   none_discard=True, setdefault=True), ])
+    decorator=[
+        namebuilding_insert(
+            "term",
+            lambda self: None if self.term is None else self.term.fmthm,
+            none_discard=True,
+            setdefault=True,
+        ),
+    ],
+)
 
 #: Usual definition of the ``begintime`` and ``endtime`` attributes.
 
-timeperiod = footprints.Footprint(info='Abstract Time Period',
-                                  attr=dict(begintime=dict(info="The resource's begin forecast term.",
-                                                           type=Time,
-                                                           optional=False),
-                                            endtime=dict(info="The resource's end forecast term.",
-                                                         type=Time,
-                                                         optional=False),
-                                            ))
+timeperiod = footprints.Footprint(
+    info="Abstract Time Period",
+    attr=dict(
+        begintime=dict(
+            info="The resource's begin forecast term.",
+            type=Time,
+            optional=False,
+        ),
+        endtime=dict(
+            info="The resource's end forecast term.", type=Time, optional=False
+        ),
+    ),
+)
 
 timeperiod_deco = footprints.DecorativeFootprint(
     timeperiod,
-    decorator=[namebuilding_insert('period',
-                                   lambda self: [{'begintime': self.begintime},
-                                                 {'endtime': self.endtime}]), ])
+    decorator=[
+        namebuilding_insert(
+            "period",
+            lambda self: [
+                {"begintime": self.begintime},
+                {"endtime": self.endtime},
+            ],
+        ),
+    ],
+)
 
 #: Usual definition of operational suite
 a_suite = dict(
     info="The operational suite identifier.",
-    values=['oper', 'dble', 'dbl', 'test', 'mirr', 'miroir'],
+    values=["oper", "dble", "dbl", "test", "mirr", "miroir"],
     remap=dict(
-        dbl='dble',
-        miroir='mirr',
-    )
+        dbl="dble",
+        miroir="mirr",
+    ),
 )
 
 #: Usual definition of the ``member`` attribute
@@ -559,7 +771,9 @@ a_member = dict(
     optional=True,
 )
 
-member = footprints.Footprint(info='Abstract member', attr=dict(member=a_member))
+member = footprints.Footprint(
+    info="Abstract member", attr=dict(member=a_member)
+)
 
 #: Usual definition of the ``scenario`` attribute
 a_scenario = dict(
@@ -567,27 +781,36 @@ a_scenario = dict(
     optional=True,
 )
 
-scenario = footprints.Footprint(info='Abstract scenario', attr=dict(scenario=a_scenario))
+scenario = footprints.Footprint(
+    info="Abstract scenario", attr=dict(scenario=a_scenario)
+)
 
 #: Usual definition of the ``number`` attribute (e.g. a perturbation number)
 a_number = dict(
     info="Any kind of numbering...",
     type=FmtInt,
-    args=dict(fmt='03'),
+    args=dict(fmt="03"),
 )
 
-number = footprints.Footprint(info='Abstract number', attr=dict(number=a_number))
+number = footprints.Footprint(
+    info="Abstract number", attr=dict(number=a_number)
+)
 
 number_deco = footprints.DecorativeFootprint(
     number,
-    decorator=[namebuilding_insert('number', lambda self: self.number, setdefault=True), ])
+    decorator=[
+        namebuilding_insert(
+            "number", lambda self: self.number, setdefault=True
+        ),
+    ],
+)
 
 #: Usual definition of the ``block`` attribute
 a_block = dict(
-    info='The subpath where to store the data.',
+    info="The subpath where to store the data.",
 )
 
-block = footprints.Footprint(info='Abstract block', attr=dict(block=a_block))
+block = footprints.Footprint(info="Abstract block", attr=dict(block=a_block))
 
 #: Usual definition of the ``namespace`` attribute
 a_namespace = dict(
@@ -596,17 +819,22 @@ a_namespace = dict(
     optional=True,
 )
 
-namespacefp = footprints.Footprint(info='Abstract namespace',
-                                   attr=dict(namespace=a_namespace))
+namespacefp = footprints.Footprint(
+    info="Abstract namespace", attr=dict(namespace=a_namespace)
+)
 
 #: Usual definition of the ``storehash`` attribute
 a_hashalgo = dict(
     info="The hash algorithm used to check data integrity",
     optional=True,
-    values=[None, ],
+    values=[
+        None,
+    ],
 )
 
-hashalgo = footprints.Footprint(info='Abstract Hash Algo', attr=dict(storehash=a_hashalgo))
+hashalgo = footprints.Footprint(
+    info="Abstract Hash Algo", attr=dict(storehash=a_hashalgo)
+)
 
 hashalgo_avail_list = hashutils.HashAdapter.algorithms()
 
@@ -616,13 +844,24 @@ a_compressionpipeline = dict(
     optional=True,
 )
 
-compressionpipeline = footprints.Footprint(info='Abstract Compression Pipeline',
-                                           attr=dict(store_compressed=a_compressionpipeline))
+compressionpipeline = footprints.Footprint(
+    info="Abstract Compression Pipeline",
+    attr=dict(store_compressed=a_compressionpipeline),
+)
 
 
 def show():
     """Returns available items and their type."""
     dmod = globals()
-    for stda in sorted(filter(lambda x: x.startswith('a_') or isinstance(dmod[x], footprints.Footprint),
-                              dmod.keys())):
-        print('{} ( {} ) :\n  {}\n'.format(stda, type(dmod[stda]).__name__, dmod[stda]))
+    for stda in sorted(
+        filter(
+            lambda x: x.startswith("a_")
+            or isinstance(dmod[x], footprints.Footprint),
+            dmod.keys(),
+        )
+    ):
+        print(
+            "{} ( {} ) :\n  {}\n".format(
+                stda, type(dmod[stda]).__name__, dmod[stda]
+            )
+        )

--- a/src/vortex/syntax/stddeco.py
+++ b/src/vortex/syntax/stddeco.py
@@ -5,7 +5,9 @@ attribute.
 """
 
 
-def namebuilding_insert(targetkey, valuecb, none_discard=False, setdefault=False):
+def namebuilding_insert(
+    targetkey, valuecb, none_discard=False, setdefault=False
+):
     """Insert/Overwrite an entry in the dictionary returned by namebuilding_info().
 
     :param str targetkey: The dictionary's key to alter.
@@ -16,8 +18,7 @@ def namebuilding_insert(targetkey, valuecb, none_discard=False, setdefault=False
     """
 
     def _namebuilding_insert_stuff(cls):
-
-        if hasattr(cls, 'namebuilding_info'):
+        if hasattr(cls, "namebuilding_info"):
             original_namebuilding_info = cls.namebuilding_info
 
             def namebuilding_info(self):
@@ -36,8 +37,9 @@ def namebuilding_insert(targetkey, valuecb, none_discard=False, setdefault=False
         return cls
 
     def _namebuilding_insert_stuff_as_dump():
-        return ("<class-decorator: replace/add the *{:s}* entry in the namebuilding_info dictionary>"
-                .format(targetkey))
+        return "<class-decorator: replace/add the *{:s}* entry in the namebuilding_info dictionary>".format(
+            targetkey
+        )
 
     _namebuilding_insert_stuff.as_dump = _namebuilding_insert_stuff_as_dump
 
@@ -54,22 +56,25 @@ def namebuilding_append(targetkey, valuecb, none_discard=False):
     """
 
     def _namebuilding_append_stuff(cls):
-
-        if hasattr(cls, 'namebuilding_info'):
+        if hasattr(cls, "namebuilding_info"):
             original_namebuilding_info = cls.namebuilding_info
 
             def namebuilding_info(self):
                 vinfo = original_namebuilding_info(self)
                 value = valuecb(self)
                 if not isinstance(value, list):
-                    value = [value, ]
+                    value = [
+                        value,
+                    ]
                 if none_discard:
                     value = [v for v in value if v is not None]
                 if not none_discard or value:
                     if targetkey in vinfo:
                         some_stuff = vinfo[targetkey]
                         if not isinstance(some_stuff, list):
-                            some_stuff = [some_stuff, ]
+                            some_stuff = [
+                                some_stuff,
+                            ]
                         some_stuff.extend(value)
                     else:
                         some_stuff = value
@@ -82,8 +87,9 @@ def namebuilding_append(targetkey, valuecb, none_discard=False):
         return cls
 
     def _namebuilding_append_stuff_as_dump():
-        return ("<class-decorator: append things in the *{:s}* entry of the namebuilding_info dictionary>"
-                .format(targetkey))
+        return "<class-decorator: append things in the *{:s}* entry of the namebuilding_info dictionary>".format(
+            targetkey
+        )
 
     _namebuilding_append_stuff.as_dump = _namebuilding_append_stuff_as_dump
 
@@ -97,8 +103,7 @@ def namebuilding_delete(targetkey):
     """
 
     def _namebuilding_delete_stuff(cls):
-
-        if hasattr(cls, 'namebuilding_info'):
+        if hasattr(cls, "namebuilding_info"):
             original_namebuilding_info = cls.namebuilding_info
 
             def namebuilding_info(self):
@@ -112,15 +117,18 @@ def namebuilding_delete(targetkey):
         return cls
 
     def _namebuilding_delete_stuff_as_dump():
-        return ("<class-decorator: delete the *{:s}* entry of the namebuilding_info dictionary>"
-                .format(targetkey))
+        return "<class-decorator: delete the *{:s}* entry of the namebuilding_info dictionary>".format(
+            targetkey
+        )
 
     _namebuilding_delete_stuff.as_dump = _namebuilding_delete_stuff_as_dump
 
     return _namebuilding_delete_stuff
 
 
-def generic_pathname_insert(targetkey, valuecb, none_discard=False, setdefault=False):
+def generic_pathname_insert(
+    targetkey, valuecb, none_discard=False, setdefault=False
+):
     """Insert/Overwrite an entry in the dictionary returned by generic_pathinfo().
 
     :param str targetkey: The dictionary's key to alter.
@@ -131,8 +139,7 @@ def generic_pathname_insert(targetkey, valuecb, none_discard=False, setdefault=F
     """
 
     def _generic_pathinfo_insert_stuff(cls):
-
-        if hasattr(cls, 'generic_pathinfo'):
+        if hasattr(cls, "generic_pathinfo"):
             original_generic_pathinfo = cls.generic_pathinfo
 
             def generic_pathinfo(self):
@@ -151,10 +158,13 @@ def generic_pathname_insert(targetkey, valuecb, none_discard=False, setdefault=F
         return cls
 
     def _generic_pathinfo_insert_stuff_as_dump():
-        return ("<class-decorator: replace/add the *{:s}* entry in the generic_pathinfo dictionary>"
-                .format(targetkey))
+        return "<class-decorator: replace/add the *{:s}* entry in the generic_pathinfo dictionary>".format(
+            targetkey
+        )
 
-    _generic_pathinfo_insert_stuff.as_dump = _generic_pathinfo_insert_stuff_as_dump
+    _generic_pathinfo_insert_stuff.as_dump = (
+        _generic_pathinfo_insert_stuff_as_dump
+    )
 
     return _generic_pathinfo_insert_stuff
 
@@ -166,7 +176,6 @@ def overwrite_realkind(thekind):
     """
 
     def _actual_overwrite_realkind(cls):
-
         def realkind(self):
             return thekind
 

--- a/src/vortex/toolbox.py
+++ b/src/vortex/toolbox.py
@@ -20,14 +20,14 @@ from vortex import sessions, data, proxy, VortexForceComplete
 from vortex.layout.dataflow import stripargs_section, intent, ixo, Section
 
 #: Automatic export of superstar interface.
-__all__ = ['rload', 'rget', 'rput']
+__all__ = ["rload", "rget", "rput"]
 
 logger = loggers.getLogger(__name__)
 
 #: Shortcut to footprint env defaults
 defaults = footprints.setup.defaults
 
-sectionmap = {'input': 'get', 'output': 'put', 'executable': 'get'}
+sectionmap = {"input": "get", "output": "put", "executable": "get"}
 
 
 # Toolbox defaults
@@ -55,34 +55,44 @@ active_incache = False
 active_batchinputs = True
 
 #: History recording
-history = History(tag='rload')
+history = History(tag="rload")
 
 
 # Most commonly used functions
 
+
 def show_toolbox_settings(ljust=24):
     """Print the current settings of the toolbox."""
-    for key in ['active_{}'.format(act) for act in
-                ('now', 'insitu', 'verbose', 'promise', 'clear',
-                 'metadatacheck', 'incache')]:
+    for key in [
+        "active_{}".format(act)
+        for act in (
+            "now",
+            "insitu",
+            "verbose",
+            "promise",
+            "clear",
+            "metadatacheck",
+            "incache",
+        )
+    ]:
         kval = globals().get(key, None)
         if kval is not None:
-            print('+', key.ljust(ljust), '=', kval)
+            print("+", key.ljust(ljust), "=", kval)
 
 
 def quickview(args, nb=0, indent=0):
     """Recursive call to any quick view of objects specified as arguments."""
     if not isinstance(args, list) and not isinstance(args, tuple):
-        args = (args, )
+        args = (args,)
     for x in args:
         if nb:
             print()
         nb += 1
-        quickview = getattr(x, 'quickview', None)
+        quickview = getattr(x, "quickview", None)
         if quickview:
             quickview(nb, indent)
         else:
-            print('{:02d}. {:s}'.format(nb, x))
+            print("{:02d}. {:s}".format(nb, x))
 
 
 class VortexToolboxDescError(Exception):
@@ -118,18 +128,18 @@ def rload(*args, **kw):
         if isinstance(a, dict):
             rd.update(a)
         else:
-            logger.warning('Discard rload argument <%s>', a)
+            logger.warning("Discard rload argument <%s>", a)
     rd.update(kw)
     if rd:
         history.append(rd.copy())
     rhx = []
     for x in footprints.util.expand(rd):
         picked_up = proxy.containers.pickup(  # @UndefinedVariable
-            * proxy.providers.pickup_and_cache(  # @UndefinedVariable
-                * proxy.resources.pickup_and_cache(x)  # @UndefinedVariable
+            *proxy.providers.pickup_and_cache(  # @UndefinedVariable
+                *proxy.resources.pickup_and_cache(x)  # @UndefinedVariable
             )
         )
-        logger.debug('Resource desc %s', picked_up)
+        logger.debug("Resource desc %s", picked_up)
         picked_rh = data.handlers.Handler(picked_up)
         if not picked_rh.complete:
             raise VortexToolboxDescError("The ResourceHandler is incomplete")
@@ -151,7 +161,7 @@ def rget(*args, **kw):
     This function calls the :meth:`get` method on any resource handler returned
     by the :func:`rload` function.
     """
-    loc_incache = kw.pop('incache', active_incache)
+    loc_incache = kw.pop("incache", active_incache)
     rl = rload(*args, **kw)
     for rh in rl:
         rh.get(incache=loc_incache)
@@ -163,7 +173,7 @@ def rput(*args, **kw):
     This function calls the :meth:`put` method on any resource handler returned
     by the :func:`rload` function.
     """
-    loc_incache = kw.pop('incache', active_incache)
+    loc_incache = kw.pop("incache", active_incache)
     rl = rload(*args, **kw)
     for rh in rl:
         rh.put(incache=loc_incache)
@@ -172,9 +182,9 @@ def rput(*args, **kw):
 
 def nicedump(msg, **kw):
     """Simple dump the **kw** dict content with ``msg`` as header."""
-    print('#', msg, ':')
+    print("#", msg, ":")
     for k, v in sorted(kw.items()):
-        print('+', k.ljust(12), '=', str(v))
+        print("+", k.ljust(12), "=", str(v))
     print()
 
 
@@ -238,32 +248,33 @@ def add_section(section, args, kw):
     t = sessions.current()
 
     # First, retrieve arguments of the toolbox command itself
-    now = kw.pop('now', active_now)
-    loglevel = kw.pop('loglevel', None)
-    talkative = kw.pop('verbose', active_verbose)
-    complete = kw.pop('complete', False)
-    insitu = kw.get('insitu', False)
-    batch = kw.pop('batch', False)
-    lastfatal = kw.pop('lastfatal', None)
+    now = kw.pop("now", active_now)
+    loglevel = kw.pop("loglevel", None)
+    talkative = kw.pop("verbose", active_verbose)
+    complete = kw.pop("complete", False)
+    insitu = kw.get("insitu", False)
+    batch = kw.pop("batch", False)
+    lastfatal = kw.pop("lastfatal", None)
 
     if complete:
-        kw['fatal'] = False
+        kw["fatal"] = False
 
     if batch:
-        if section not in ('input', 'excutable'):
-            logger.info("batch=True is not implemented for section=%s. overwriting to batch=Fase.",
-                        section)
+        if section not in ("input", "excutable"):
+            logger.info(
+                "batch=True is not implemented for section=%s. overwriting to batch=Fase.",
+                section,
+            )
             batch = False
 
     # Second, retrieve arguments that could be used by the now command
     cmdopts = dict(
-        incache=kw.pop('incache', active_incache),
-        force=kw.pop('force', False)
+        incache=kw.pop("incache", active_incache), force=kw.pop("force", False)
     )
 
     # Third, collect arguments for triggering some hook
     hooks = dict()
-    for ahook in [x for x in kw.keys() if x.startswith('hook_')]:
+    for ahook in [x for x in kw.keys() if x.startswith("hook_")]:
         cbhook = mktuple(kw.pop(ahook))
         cbfunc = cbhook[0]
         if not callable(cbfunc):
@@ -272,29 +283,30 @@ def add_section(section, args, kw):
 
     # Print the user inputs
     def print_user_inputs():
-        nicedump('New {:s} section with options'.format(section), **opts)
-        nicedump('Resource handler description', **kwclean)
+        nicedump("New {:s} section with options".format(section), **opts)
+        nicedump("Resource handler description", **kwclean)
         nicedump(
-            'This command options',
+            "This command options",
             complete=complete,
             loglevel=loglevel,
             now=now,
             verbose=talkative,
         )
         if hooks:
-            nicedump('Hooks triggered', **hooks)
+            nicedump("Hooks triggered", **hooks)
 
     with _tb_isolate(t, loglevel):
-
         # Distinguish between section arguments, and resource loader arguments
         opts, kwclean = stripargs_section(**kw)
 
         # Strip the metadatacheck option depending on active_metadatacheck
         if not active_metadatacheck and not insitu:
-            if kwclean.get('metadatacheck', False):
-                logger.info("The metadatacheck option is forced to False since " +
-                            "active_metadatacheck=False.")
-                kwclean['metadatacheck'] = False
+            if kwclean.get("metadatacheck", False):
+                logger.info(
+                    "The metadatacheck option is forced to False since "
+                    + "active_metadatacheck=False."
+                )
+                kwclean["metadatacheck"] = False
 
         # Show the actual set of arguments
         if talkative and not insitu:
@@ -311,23 +323,32 @@ def add_section(section, args, kw):
 
         # Create a section for each resource handler
         if rl and lastfatal is not None:
-            newsections = [push(rh=rhandler, **opts)[0] for rhandler in rl[:-1]]
+            newsections = [
+                push(rh=rhandler, **opts)[0] for rhandler in rl[:-1]
+            ]
             tmpopts = opts.copy()
-            tmpopts['fatal'] = lastfatal
+            tmpopts["fatal"] = lastfatal
             newsections.append(push(rh=rl[-1], **tmpopts)[0])
         else:
             newsections = [push(rh=rhandler, **opts)[0] for rhandler in rl]
 
         # If insitu and now, try a quiet get...
-        do_quick_insitu = section in ('input', 'executable') and insitu and now
+        do_quick_insitu = section in ("input", "executable") and insitu and now
         if do_quick_insitu:
-            quickget = [sec.rh.insitu_quickget(alternate=sec.alternate, **cmdopts) for sec in newsections]
+            quickget = [
+                sec.rh.insitu_quickget(alternate=sec.alternate, **cmdopts)
+                for sec in newsections
+            ]
             if all(quickget):
                 if len(quickget) > 1:
-                    logger.info("The insitu get succeeded for all of the %d resource handlers.",
-                                len(rl))
+                    logger.info(
+                        "The insitu get succeeded for all of the %d resource handlers.",
+                        len(rl),
+                    )
                 else:
-                    logger.info("The insitu get succeeded for this resource handler.")
+                    logger.info(
+                        "The insitu get succeeded for this resource handler."
+                    )
                 rlok = [sec.rh for sec in newsections]
             else:
                 # Start again with the usual get sequence
@@ -338,64 +359,118 @@ def add_section(section, args, kw):
             if now:
                 with t.sh.ftppool():
                     # Create a section for each resource handler, and perform action on demand
-                    batchflags = [None, ] * len(newsections)
+                    batchflags = [
+                        None,
+                    ] * len(newsections)
                     if batch:
                         if talkative:
-                            t.sh.subtitle('Early-{:s} for all resources.'.format(doitmethod))
+                            t.sh.subtitle(
+                                "Early-{:s} for all resources.".format(
+                                    doitmethod
+                                )
+                            )
                         for ir, newsection in enumerate(newsections):
                             rhandler = newsection.rh
-                            batchflags[ir] = getattr(newsection, 'early' + doitmethod)(**cmdopts)
+                            batchflags[ir] = getattr(
+                                newsection, "early" + doitmethod
+                            )(**cmdopts)
                         if talkative:
                             if any(batchflags):
                                 for ir, newsection in enumerate(newsections):
                                     if talkative and batchflags[ir]:
-                                        logger.info('Resource no %02d/%02d: Early-%s registered with id: %s.',
-                                                    ir + 1, len(rl), doitmethod, str(batchflags[ir]))
+                                        logger.info(
+                                            "Resource no %02d/%02d: Early-%s registered with id: %s.",
+                                            ir + 1,
+                                            len(rl),
+                                            doitmethod,
+                                            str(batchflags[ir]),
+                                        )
                                     else:
-                                        logger.debug('Resource no %02d/%02d: Early-%s registered with id: %s.',
-                                                     ir + 1, len(rl), doitmethod, str(batchflags[ir]))
+                                        logger.debug(
+                                            "Resource no %02d/%02d: Early-%s registered with id: %s.",
+                                            ir + 1,
+                                            len(rl),
+                                            doitmethod,
+                                            str(batchflags[ir]),
+                                        )
                             else:
-                                logger.info('Early-%s was unavailable for all of the resources.',
-                                            doitmethod)
+                                logger.info(
+                                    "Early-%s was unavailable for all of the resources.",
+                                    doitmethod,
+                                )
                         # trigger finalise for all of the DelayedActions
-                        tofinalise = [r_id for r_id in batchflags if r_id and r_id is not True]
+                        tofinalise = [
+                            r_id
+                            for r_id in batchflags
+                            if r_id and r_id is not True
+                        ]
                         if tofinalise:
                             if talkative:
-                                t.sh.subtitle('Finalising all of the delayed actions...')
-                            t.context.delayedactions_hub.finalise(* tofinalise)
+                                t.sh.subtitle(
+                                    "Finalising all of the delayed actions..."
+                                )
+                            t.context.delayedactions_hub.finalise(*tofinalise)
                     secok = list()
                     for ir, newsection in enumerate(newsections):
                         rhandler = newsection.rh
                         # If quick get was ok for this resource don't call get again...
                         if talkative:
-                            t.sh.subtitle('Resource no {:02d}/{:02d}'.format(ir + 1, len(rl)))
+                            t.sh.subtitle(
+                                "Resource no {:02d}/{:02d}".format(
+                                    ir + 1, len(rl)
+                                )
+                            )
                             rhandler.quickview(nb=ir + 1, indent=0)
-                            if batchflags[ir] is not True or (do_quick_insitu and quickget[ir]):
-                                t.sh.highlight('Action {:s} on {:s}'.format(doitmethod.upper(),
-                                                                            rhandler.location(fatal=False)))
+                            if batchflags[ir] is not True or (
+                                do_quick_insitu and quickget[ir]
+                            ):
+                                t.sh.highlight(
+                                    "Action {:s} on {:s}".format(
+                                        doitmethod.upper(),
+                                        rhandler.location(fatal=False),
+                                    )
+                                )
                         ok = do_quick_insitu and quickget[ir]
                         if batchflags[ir]:
-                            actual_doitmethod = 'finalise' + doitmethod
+                            actual_doitmethod = "finalise" + doitmethod
                             ok = ok or getattr(newsection, actual_doitmethod)()
                         else:
                             actual_doitmethod = doitmethod
-                            ok = ok or getattr(newsection, actual_doitmethod)(**cmdopts)
+                            ok = ok or getattr(newsection, actual_doitmethod)(
+                                **cmdopts
+                            )
                         if talkative:
-                            t.sh.highlight('Result from {:s}: [{!s}]'.format(actual_doitmethod, ok))
+                            t.sh.highlight(
+                                "Result from {:s}: [{!s}]".format(
+                                    actual_doitmethod, ok
+                                )
+                            )
                         if talkative and not ok:
-                            logger.error('Could not %s resource %s',
-                                         doitmethod, rhandler.container.localpath())
+                            logger.error(
+                                "Could not %s resource %s",
+                                doitmethod,
+                                rhandler.container.localpath(),
+                            )
                         if not ok:
                             if complete:
-                                logger.warning('Force complete for %s',
-                                               rhandler.location(fatal=False))
-                                raise VortexForceComplete('Force task complete on resource error')
+                                logger.warning(
+                                    "Force complete for %s",
+                                    rhandler.location(fatal=False),
+                                )
+                                raise VortexForceComplete(
+                                    "Force task complete on resource error"
+                                )
                         else:
                             secok.append(newsection)
                         if t.sh.trace:
                             print()
-                    rlok.extend([newsection.rh for newsection in secok
-                                 if newsection.any_coherentgroup_opened])
+                    rlok.extend(
+                        [
+                            newsection.rh
+                            for newsection in secok
+                            if newsection.any_coherentgroup_opened
+                        ]
+                    )
             else:
                 rlok.extend([newsection.rh for newsection in newsections])
 
@@ -414,9 +489,9 @@ def input(*args, **kw):  # @ReservedAssignment
     :return: A list of :class:`vortex.data.handlers.Handler` objects (associated
         with the newly created class:`~vortex.layout.dataflow.Section` objects).
     """
-    kw.setdefault('insitu', active_insitu)
-    kw.setdefault('batch', active_batchinputs)
-    return add_section('input', args, kw)
+    kw.setdefault("insitu", active_insitu)
+    kw.setdefault("batch", active_batchinputs)
+    return add_section("input", args, kw)
 
 
 def inputs(ticket=None, context=None):
@@ -445,7 +520,7 @@ def show_inputs(context=None):
     """
     t = sessions.current()
     for csi in inputs(ticket=t):
-        t.sh.header('Input ' + str(csi))
+        t.sh.header("Input " + str(csi))
         csi.show(ticket=t, context=context)
         print()
 
@@ -462,11 +537,14 @@ def output(*args, **kw):
     """
     # Strip the metadatacheck option depending on active_metadatacheck
     if not active_promise:
-        for target in ('promised', 'expected'):
+        for target in ("promised", "expected"):
             if target in kw and kw[target]:
-                logger.info("The %s argument is removed since active_promise=False.", target)
+                logger.info(
+                    "The %s argument is removed since active_promise=False.",
+                    target,
+                )
                 del kw[target]
-    return add_section('output', args, kw)
+    return add_section("output", args, kw)
 
 
 def outputs(ticket=None, context=None):
@@ -493,7 +571,7 @@ def show_outputs(context=None):
     """
     t = sessions.current()
     for cso in outputs(ticket=t):
-        t.sh.header('Output ' + str(cso))
+        t.sh.header("Output " + str(cso))
         cso.show(ticket=t, context=context)
         print()
 
@@ -517,9 +595,9 @@ def promise(*args, **kw):
         now=active_promise,
     )
     if not active_promise:
-        kw.setdefault('verbose', False)
-        logger.warning('Promise flag is <%s> in that context', active_promise)
-    return add_section('output', args, kw)
+        kw.setdefault("verbose", False)
+        logger.warning("Promise flag is <%s> in that context", active_promise)
+    return add_section("output", args, kw)
 
 
 def executable(*args, **kw):
@@ -533,8 +611,8 @@ def executable(*args, **kw):
     :return: A list of :class:`vortex.data.handlers.Handler` objects (associated
         with the newly created class:`~vortex.layout.dataflow.Section` objects).
     """
-    kw.setdefault('insitu', active_insitu)
-    return add_section('executable', args, kw)
+    kw.setdefault("insitu", active_insitu)
+    return add_section("executable", args, kw)
 
 
 def algo(*args, **kw):
@@ -559,13 +637,12 @@ def algo(*args, **kw):
     t = sessions.current()
 
     # First, retrieve arguments of the toolbox command itself
-    loglevel = kw.pop('loglevel', None)
-    talkative = kw.pop('verbose', active_verbose)
+    loglevel = kw.pop("loglevel", None)
+    talkative = kw.pop("verbose", active_verbose)
 
     with _tb_isolate(t, loglevel):
-
         if talkative:
-            nicedump('Loading algo component with description:', **kw)
+            nicedump("Loading algo component with description:", **kw)
 
         ok = proxy.component(**kw)  # @UndefinedVariable
         if ok and talkative:
@@ -606,34 +683,36 @@ def diff(*args, **kw):
     """
 
     # First, retrieve arguments of the toolbox command itself
-    fatal = kw.pop('fatal', True)
-    loglevel = kw.pop('loglevel', None)
-    talkative = kw.pop('verbose', active_verbose)
-    batch = kw.pop('batch', active_batchinputs)
+    fatal = kw.pop("fatal", True)
+    loglevel = kw.pop("loglevel", None)
+    talkative = kw.pop("verbose", active_verbose)
+    batch = kw.pop("batch", active_batchinputs)
 
     # Distinguish between section arguments, and resource loader arguments
     opts, kwclean = stripargs_section(**kw)
 
     # Show the actual set of arguments
     if talkative:
-        nicedump('Discard section options', **opts)
-        nicedump('Resource handler description', **kwclean)
+        nicedump("Discard section options", **opts)
+        nicedump("Resource handler description", **kwclean)
 
     # Fast exit in case of undefined value
     rlok = list()
-    none_skip = {k for k, v in kwclean.items()
-                 if v is None and k in ('experiment', 'namespace')}
+    none_skip = {
+        k
+        for k, v in kwclean.items()
+        if v is None and k in ("experiment", "namespace")
+    }
     if none_skip:
-        logger.warning('Skip diff because of undefined argument(s)')
+        logger.warning("Skip diff because of undefined argument(s)")
         return rlok
 
     t = sessions.current()
 
     # Swich off autorecording of the current context + deal with loggging
     with _tb_isolate(t, loglevel):
-
         # Do not track the reference files
-        kwclean['storetrack'] = False
+        kwclean["storetrack"] = False
 
         rhandlers = rload(*args, **kwclean)
         sections = list()
@@ -647,12 +726,17 @@ def diff(*args, **kw):
             for ir, rhandler in enumerate(rhandlers):
                 source_container.append(rhandler.container)
                 # Create a new container to hold the reference file
-                lazzy_container.append(footprints.proxy.container(shouldfly=True,
-                                                                  actualfmt=rhandler.container.actualfmt))
+                lazzy_container.append(
+                    footprints.proxy.container(
+                        shouldfly=True, actualfmt=rhandler.container.actualfmt
+                    )
+                )
                 # Swapp the original container with the lazzy one
                 rhandler.container = lazzy_container[-1]
                 # Create a new section
-                sec = Section(rh=rhandler, kind=ixo.INPUT, intent=intent.IN, fatal=False)
+                sec = Section(
+                    rh=rhandler, kind=ixo.INPUT, intent=intent.IN, fatal=False
+                )
                 sections.append(sec)
                 # Early-get
                 if rhandler.complete:
@@ -661,9 +745,14 @@ def diff(*args, **kw):
                     earlyget_id.append(None)
             # Finalising
             if any([r_id and r_id is not True for r_id in earlyget_id]):
-                t.sh.highlight('Finalising Early-gets')
-                t.context.delayedactions_hub.finalise(* [r_id for r_id in earlyget_id
-                                                         if r_id and r_id is not True])
+                t.sh.highlight("Finalising Early-gets")
+                t.context.delayedactions_hub.finalise(
+                    *[
+                        r_id
+                        for r_id in earlyget_id
+                        if r_id and r_id is not True
+                    ]
+                )
 
         for ir, rhandler in enumerate(rhandlers):
             if talkative:
@@ -671,9 +760,11 @@ def diff(*args, **kw):
                 rhandler.quickview(nb=ir + 1, indent=0)
                 print(t.line)
             if not rhandler.complete:
-                logger.error('Incomplete Resource Handler for diff [%s]', rhandler)
+                logger.error(
+                    "Incomplete Resource Handler for diff [%s]", rhandler
+                )
                 if fatal:
-                    raise ValueError('Incomplete Resource Handler for diff')
+                    raise ValueError("Incomplete Resource Handler for diff")
                 else:
                     rlok.append(False)
                     continue
@@ -686,52 +777,65 @@ def diff(*args, **kw):
                 rc = sections[ir].get()
             if not rc:
                 try:
-                    logger.error('Cannot get the reference resource: %s',
-                                 rhandler.locate())
+                    logger.error(
+                        "Cannot get the reference resource: %s",
+                        rhandler.locate(),
+                    )
                 except Exception:
-                    logger.error('Cannot get the reference resource: ???')
+                    logger.error("Cannot get the reference resource: ???")
                 if fatal:
-                    raise ValueError('Cannot get the reference resource')
+                    raise ValueError("Cannot get the reference resource")
             else:
-                logger.info('The reference file is stored under: %s',
-                            rhandler.container.localpath())
+                logger.info(
+                    "The reference file is stored under: %s",
+                    rhandler.container.localpath(),
+                )
 
             # What are the differences ?
             if rc:
                 # priority is given to the diff implemented in the DataContent
                 if rhandler.resource.clscontents.is_diffable():
                     source_contents = rhandler.resource.contents_handler(
-                        datafmt=source_container[ir].actualfmt)
+                        datafmt=source_container[ir].actualfmt
+                    )
                     source_contents.slurp(source_container[ir])
                     ref_contents = rhandler.contents
                     rc = source_contents.diff(ref_contents)
                 else:
-                    rc = t.sh.diff(source_container[ir].localpath(),
-                                   rhandler.container.localpath(),
-                                   fmt=rhandler.container.actualfmt)
+                    rc = t.sh.diff(
+                        source_container[ir].localpath(),
+                        rhandler.container.localpath(),
+                        fmt=rhandler.container.actualfmt,
+                    )
 
             # Delete the reference file
             lazzy_container[ir].clear()
 
             # Now proceed with the result
-            logger.info('Diff return %s', str(rc))
-            t.context.diff_history.append_record(rc, source_container[ir], rhandler)
+            logger.info("Diff return %s", str(rc))
+            t.context.diff_history.append_record(
+                rc, source_container[ir], rhandler
+            )
             try:
-                logger.info('Diff result %s', str(rc.result))
+                logger.info("Diff result %s", str(rc.result))
             except AttributeError:
                 pass
             if not rc:
                 try:
-                    logger.warning('Some diff occurred with %s', rhandler.locate())
+                    logger.warning(
+                        "Some diff occurred with %s", rhandler.locate()
+                    )
                 except Exception:
-                    logger.warning('Some diff occurred with ???')
+                    logger.warning("Some diff occurred with ???")
                 try:
                     rc.result.differences()
                 except Exception:
                     pass
                 if fatal:
-                    logger.critical('Difference in resource comparison is fatal')
-                    raise ValueError('Fatal diff')
+                    logger.critical(
+                        "Difference in resource comparison is fatal"
+                    )
+                    raise ValueError("Fatal diff")
             if t.sh.trace:
                 print()
             rlok.append(rc)
@@ -746,7 +850,7 @@ def magic(localpath, **kw):
     """
     kw.update(
         unknown=True,
-        magic='magic://localhost/' + localpath,
+        magic="magic://localhost/" + localpath,
         filename=localpath,
     )
     rhmagic = rh(**kw)
@@ -770,22 +874,24 @@ def archive_refill(*args, **kw):
     t = sessions.current()
 
     # First, retrieve arguments of the toolbox command itself
-    loglevel = kw.pop('loglevel', None)
-    talkative = kw.pop('verbose', active_verbose)
+    loglevel = kw.pop("loglevel", None)
+    talkative = kw.pop("verbose", active_verbose)
 
     with _tb_isolate(t, loglevel):
-
         # Distinguish between section arguments, and resource loader arguments
         opts, kwclean = stripargs_section(**kw)
-        fatal = opts.get('fatal', True)
+        fatal = opts.get("fatal", True)
 
         # Print the user inputs
         if talkative:
-            nicedump('Archive Refill Ressource+Provider description', **kwclean)
+            nicedump(
+                "Archive Refill Ressource+Provider description", **kwclean
+            )
 
         # Create the resource handlers
-        kwclean['container'] = footprints.proxy.container(uuid4fly=True,
-                                                          uuid4flydir="archive_refills")
+        kwclean["container"] = footprints.proxy.container(
+            uuid4fly=True, uuid4flydir="archive_refills"
+        )
         rl = rload(*args, **kwclean)
 
         @contextmanager
@@ -795,36 +901,56 @@ def archive_refill(*args, **kw):
             try:
                 yield wrap_rc
             except Exception as e:
-                logger.error('Something wrong (action %s): %s. %s',
-                             action, str(e), traceback.format_exc())
-                wrap_rc['rc'] = False
-                wrap_rc['exc'] = e
-            if fatal and not wrap_rc['rc']:
-                logger.critical('Fatal error with action %s.', action)
-                raise RuntimeError('Could not {:s} resource: {!s}'.format(action,
-                                                                          wrap_rc['rc']))
+                logger.error(
+                    "Something wrong (action %s): %s. %s",
+                    action,
+                    str(e),
+                    traceback.format_exc(),
+                )
+                wrap_rc["rc"] = False
+                wrap_rc["exc"] = e
+            if fatal and not wrap_rc["rc"]:
+                logger.critical("Fatal error with action %s.", action)
+                raise RuntimeError(
+                    "Could not {:s} resource: {!s}".format(
+                        action, wrap_rc["rc"]
+                    )
+                )
 
         with t.sh.ftppool():
             for ir, rhandler in enumerate(rl):
                 if talkative:
-                    t.sh.subtitle('Resource no {:02d}/{:02d}'.format(ir + 1, len(rl)))
+                    t.sh.subtitle(
+                        "Resource no {:02d}/{:02d}".format(ir + 1, len(rl))
+                    )
                     rhandler.quickview(nb=ir + 1, indent=0)
-                if not (rhandler.store.use_cache() and rhandler.store.use_archive()):
-                    logger.info('The requested store does not have both the cache and archive capabilities. ' +
-                                'Skipping this ressource handler.')
+                if not (
+                    rhandler.store.use_cache() and rhandler.store.use_archive()
+                ):
+                    logger.info(
+                        "The requested store does not have both the cache and archive capabilities. "
+                        + "Skipping this ressource handler."
+                    )
                     continue
-                with _fatal_wrap('get') as get_status:
-                    get_status['rc'] = rhandler.get(incache=True, intent=intent.IN,
-                                                    fmt=rhandler.resource.nativefmt)
+                with _fatal_wrap("get") as get_status:
+                    get_status["rc"] = rhandler.get(
+                        incache=True,
+                        intent=intent.IN,
+                        fmt=rhandler.resource.nativefmt,
+                    )
                 put_status = dict(rc=False)
-                if get_status['rc']:
-                    with _fatal_wrap('put') as put_status:
-                        put_status['rc'] = rhandler.put(inarchive=True,
-                                                        fmt=rhandler.resource.nativefmt)
+                if get_status["rc"]:
+                    with _fatal_wrap("put") as put_status:
+                        put_status["rc"] = rhandler.put(
+                            inarchive=True, fmt=rhandler.resource.nativefmt
+                        )
                     rhandler.container.clear()
                 if talkative:
-                    t.sh.highlight('Result from get: [{!s}], from put: [{!s}]'
-                                   .format(get_status['rc'], put_status['rc']))
+                    t.sh.highlight(
+                        "Result from get: [{!s}], from put: [{!s}]".format(
+                            get_status["rc"], put_status["rc"]
+                        )
+                    )
 
     return rl
 
@@ -842,7 +968,7 @@ def stack_archive_refill(*args, **kw):
 
     :return: A list of :class:`vortex.data.handlers.Handler` objects.
     """
-    kw['block'] = 'stacks'
+    kw["block"] = "stacks"
     return archive_refill(*args, **kw)
 
 
@@ -852,21 +978,24 @@ def namespaces(**kw):
     used. By default tracks ``stores`` and ``providers`` but one could give an
     ``only`` argument.
     """
-    rematch = re.compile('|'.join(kw.get('match', '.').split(',')),
-                         re.IGNORECASE)
-    if 'only' in kw:
-        usedcat = kw['only'].split(',')
+    rematch = re.compile(
+        "|".join(kw.get("match", ".").split(",")), re.IGNORECASE
+    )
+    if "only" in kw:
+        usedcat = kw["only"].split(",")
     else:
-        usedcat = ('provider', 'store')
+        usedcat = ("provider", "store")
     nameseen = dict()
     for cat in [footprints.collectors.get(tag=x) for x in usedcat]:
         for cls in cat():
             fp = cls.footprint_retrieve().attr
-            netattr = fp.get('namespace', None)
+            netattr = fp.get("namespace", None)
             if not netattr:
-                netattr = fp.get('netloc', None)
-            if netattr and 'values' in netattr:
-                for netname in filter(lambda x: rematch.search(x), netattr['values']):
+                netattr = fp.get("netloc", None)
+            if netattr and "values" in netattr:
+                for netname in filter(
+                    lambda x: rematch.search(x), netattr["values"]
+                ):
                     if netname not in nameseen:
                         nameseen[netname] = list()
                     nameseen[netname].append(cls.fullname())
@@ -875,17 +1004,18 @@ def namespaces(**kw):
 
 def print_namespaces(**kw):
     """Formatted print of current namespaces."""
-    prefix = kw.pop('prefix', '+ ')
+    prefix = kw.pop("prefix", "+ ")
     nd = namespaces(**kw)
     justify = max([len(x) for x in nd.keys()])
-    linesep = ",\n" + ' ' * (justify + len(prefix) + 2)
+    linesep = ",\n" + " " * (justify + len(prefix) + 2)
     for k, v in sorted(nd.items()):
         nice_v = linesep.join(v) if len(v) > 1 else v[0]
-        print(prefix + k.ljust(justify), '[' + nice_v + ']')
+        print(prefix + k.ljust(justify), "[" + nice_v + "]")
 
 
-def clear_promises(clear=None, netloc='promise.cache.fr', scheme='vortex',
-                   storeoptions=None):
+def clear_promises(
+    clear=None, netloc="promise.cache.fr", scheme="vortex", storeoptions=None
+):
     """Remove all promises that have been made in the current session.
 
     :param netloc: Netloc of the promise's cache store to clean up
@@ -913,50 +1043,49 @@ def rescue(*files, **opts):
 
     # Summarise diffs...
     if len(t.context.diff_history):
-        sh.header('Summary of automatic toolbox diffs')
+        sh.header("Summary of automatic toolbox diffs")
         t.context.diff_history.show()
 
     # Force clearing of all promises
     clear_promises(clear=True)
 
-    sh.header('Rescuing current dir')
+    sh.header("Rescuing current dir")
     sh.dir(output=False, fatal=False)
 
-    logger.info('Rescue files %s', files)
+    logger.info("Rescue files %s", files)
 
-    if 'VORTEX_RESCUE' in env and env.false('VORTEX_RESCUE'):
-        logger.warning('Skip rescue <VORTEX_RESCUE=%s>', env.VORTEX_RESCUE)
+    if "VORTEX_RESCUE" in env and env.false("VORTEX_RESCUE"):
+        logger.warning("Skip rescue <VORTEX_RESCUE=%s>", env.VORTEX_RESCUE)
         return False
 
     if files:
         items = list(files)
     else:
-        items = sh.glob('*')
+        items = sh.glob("*")
 
-    rfilter = opts.get('filter', env.VORTEX_RESCUE_FILTER)
+    rfilter = opts.get("filter", env.VORTEX_RESCUE_FILTER)
     if rfilter is not None:
-        logger.warning('Rescue filter <%s>', rfilter)
-        select = '|'.join(re.split(r'[,;:]+', rfilter))
+        logger.warning("Rescue filter <%s>", rfilter)
+        select = "|".join(re.split(r"[,;:]+", rfilter))
         items = [x for x in items if re.search(select, x, re.IGNORECASE)]
-        logger.info('Rescue filter [%s]', select)
+        logger.info("Rescue filter [%s]", select)
 
-    rdiscard = opts.get('discard', env.VORTEX_RESCUE_DISCARD)
+    rdiscard = opts.get("discard", env.VORTEX_RESCUE_DISCARD)
     if rdiscard is not None:
-        logger.warning('Rescue discard <%s>', rdiscard)
-        select = '|'.join(re.split(r'[,;:]+', rdiscard))
+        logger.warning("Rescue discard <%s>", rdiscard)
+        select = "|".join(re.split(r"[,;:]+", rdiscard))
         items = [x for x in items if not re.search(select, x, re.IGNORECASE)]
-        logger.info('Rescue discard [%s]', select)
+        logger.info("Rescue discard [%s]", select)
 
     if items:
-
-        bkupdir = opts.get('bkupdir', env.VORTEX_RESCUE_PATH)
+        bkupdir = opts.get("bkupdir", env.VORTEX_RESCUE_PATH)
 
         if bkupdir is None:
-            logger.error('No rescue directory defined.')
+            logger.error("No rescue directory defined.")
         else:
-            logger.info('Backup directory defined by user < %s >', bkupdir)
+            logger.info("Backup directory defined by user < %s >", bkupdir)
             items.sort()
-            logger.info('Rescue items %s', str(items))
+            logger.info("Rescue items %s", str(items))
             sh.mkdir(bkupdir)
             mkmove = False
             st1 = sh.stat(sh.getcwd())
@@ -977,6 +1106,6 @@ def rescue(*files, **opts):
                         thisrescue(ritem, rtarget)
 
     else:
-        logger.warning('No item to rescue.')
+        logger.warning("No item to rescue.")
 
     return bool(items)

--- a/src/vortex/tools/__init__.py
+++ b/src/vortex/tools/__init__.py
@@ -8,4 +8,6 @@ from . import storage, schedulers, services, systems, targets, date, env, names
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'VORTEX generic tools (system interfaces, format handling, ...)'
+__tocinfoline__ = (
+    "VORTEX generic tools (system interfaces, format handling, ...)"
+)

--- a/src/vortex/tools/__init__.py
+++ b/src/vortex/tools/__init__.py
@@ -3,7 +3,14 @@ This is a pure package containing several modules that could be used
 as standalone tools.
 """
 
-from . import storage, schedulers, services, systems, targets, date, env, names
+from . import storage as storage
+from . import schedulers as schedulers
+from . import services as services
+from . import systems as systems
+from . import targets as targets
+from . import date as date
+from . import env as env
+from . import names as names
 
 #: No automatic export
 __all__ = []

--- a/src/vortex/tools/addons.py
+++ b/src/vortex/tools/addons.py
@@ -23,53 +23,50 @@ class Addon(footprints.FootprintBase):
     """Root class for any :class:`Addon` system subclasses."""
 
     _abstract = True
-    _collector = ('addon',)
+    _collector = ("addon",)
     _footprint = dict(
-        info = 'Default add-on',
-        attr = dict(
-            kind = dict(),
-            sh = dict(
-                type     = OSExtended,
-                alias    = ('shell',),
-                access   = 'rwx-weak',
+        info="Default add-on",
+        attr=dict(
+            kind=dict(),
+            sh=dict(
+                type=OSExtended,
+                alias=("shell",),
+                access="rwx-weak",
             ),
-            env = dict(
-                type     = Environment,
-                optional = True,
-                default  = None,
-                access   = 'rwx',
-                doc_visibility = footprints.doc.visibility.ADVANCED
+            env=dict(
+                type=Environment,
+                optional=True,
+                default=None,
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            cfginfo = dict(
-                optional = True,
-                default  = '[kind]',
-                doc_visibility = footprints.doc.visibility.ADVANCED
+            cfginfo=dict(
+                optional=True,
+                default="[kind]",
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            cmd = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            cmd=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            path = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            path=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            cycle = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            cycle=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            toolkind = dict(
-                optional = True,
-                default  = None
-            ),
-        )
+            toolkind=dict(optional=True, default=None),
+        ),
     )
 
     def __init__(self, *args, **kw):
         """Abstract Addon initialisation."""
-        logger.debug('Abstract Addon init %s', self.__class__)
+        logger.debug("Abstract Addon init %s", self.__class__)
         super().__init__(*args, **kw)
         self.sh.extend(self)
         self._context_cache = defaultdict(dict)
@@ -81,7 +78,9 @@ class Addon(footprints.FootprintBase):
             self.env[k] = clsenv[k]
         if self.path is None:
             self.path = get_from_config_w_default(
-                section="nwp-tools", key=self.kind, default=None,
+                section="nwp-tools",
+                key=self.kind,
+                default=None,
             )
 
     @classmethod
@@ -103,36 +102,44 @@ class Addon(footprints.FootprintBase):
         if ctxtag not in self._context_cache and self.toolkind is not None:
             ltrack = contexts.current().localtracker
             # NB: 'str' is important because local might be in unicode...
-            candidates = [str(self.sh.path.realpath(local))
-                          for local, entry in ltrack.items()
-                          if (entry.latest_rhdict('get').get('resource', dict()).get('kind', '') ==
-                              self.toolkind)]
+            candidates = [
+                str(self.sh.path.realpath(local))
+                for local, entry in ltrack.items()
+                if (
+                    entry.latest_rhdict("get")
+                    .get("resource", dict())
+                    .get("kind", "")
+                    == self.toolkind
+                )
+            ]
             if candidates:
                 realpath = candidates.pop()
-                self._context_cache[ctxtag] = dict(path=self.sh.path.dirname(realpath),
-                                                   cmd=self.sh.path.basename(realpath))
+                self._context_cache[ctxtag] = dict(
+                    path=self.sh.path.dirname(realpath),
+                    cmd=self.sh.path.basename(realpath),
+                )
         return self._context_cache[ctxtag]
 
     @property
     def actual_path(self):
         """The path that should be used in the current context."""
         infos = self._query_context()
-        ctxpath = infos.get('path', None)
+        ctxpath = infos.get("path", None)
         return self.path if ctxpath is None else ctxpath
 
     @property
     def actual_cmd(self):
         """The cmd that should be used in the current context."""
         infos = self._query_context()
-        ctxcmd = infos.get('cmd', None)
+        ctxcmd = infos.get("cmd", None)
         return self.cmd if ctxcmd is None else ctxcmd
 
     def _spawn_commons(self, cmd, **kw):
         """Internal method setting local environment and calling standard shell spawn."""
 
         # Is there a need for an interpreter ?
-        if 'interpreter' in kw:
-            cmd.insert(0, kw.pop('interpreter'))
+        if "interpreter" in kw:
+            cmd.insert(0, kw.pop("interpreter"))
         else:
             # The first element of the command line needs to be executable
             if cmd[0] not in self._cmd_xperms_cache:
@@ -141,16 +148,15 @@ class Addon(footprints.FootprintBase):
 
         # Overwrite global module env values with specific ones
         with self.sh.env.clone() as localenv:
-
             localenv.verbose(True, self.sh)
             localenv.update(self.env)
 
             # Check if a pipe is requested
-            inpipe = kw.pop('inpipe', False)
+            inpipe = kw.pop("inpipe", False)
 
             # Ask the attached shell to run the addon command
             if inpipe:
-                kw.setdefault('stdout', True)
+                kw.setdefault("stdout", True)
                 rc = self.sh.popen(cmd, **kw)
             else:
                 rc = self.sh.spawn(cmd, **kw)
@@ -163,7 +169,7 @@ class Addon(footprints.FootprintBase):
         # Insert the actual tool command as first argument
         cmd.insert(0, self.actual_cmd)
         if self.actual_path is not None:
-            cmd[0] = self.actual_path + '/' + cmd[0]
+            cmd[0] = self.actual_path + "/" + cmd[0]
 
         return self._spawn_commons(cmd, **kw)
 
@@ -172,7 +178,7 @@ class Addon(footprints.FootprintBase):
 
         # Insert the tool path before the first argument
         if self.actual_path is not None:
-            cmd[0] = self.actual_path + '/' + cmd[0]
+            cmd[0] = self.actual_path + "/" + cmd[0]
 
         return self._spawn_commons(cmd, **kw)
 
@@ -182,26 +188,28 @@ class FtrawEnableAddon(Addon):
 
     _abstract = True
     _footprint = dict(
-        info = 'Default add-on with rawftput support.',
-        attr = dict(
-            rawftshell = dict(
-                info     = "Path to ftserv's concatenation shell",
-                optional = True,
-                default  = None,
-                access   = 'rwx',
-                doc_visibility = footprints.doc.visibility.GURU,
+        info="Default add-on with rawftput support.",
+        attr=dict(
+            rawftshell=dict(
+                info="Path to ftserv's concatenation shell",
+                optional=True,
+                default=None,
+                access="rwx",
+                doc_visibility=footprints.doc.visibility.GURU,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
         """Abstract Addon initialisation."""
-        logger.debug('Abstract Addon init %s', self.__class__)
+        logger.debug("Abstract Addon init %s", self.__class__)
         super().__init__(*args, **kw)
         # If needed, look in the config file for the rawftshell
         if self.rawftshell is None:
             self.rawftshell = get_from_config_w_default(
-                section="rawftshell", key=self.kind, default=None,
+                section="rawftshell",
+                key=self.kind,
+                default=None,
             )
 
 
@@ -213,52 +221,59 @@ class AddonGroup(footprints.FootprintBase):
     """
 
     _abstract = True
-    _collector = ('addon',)
+    _collector = ("addon",)
     _footprint = dict(
-        info = 'Default add-on group',
-        attr = dict(
-            kind = dict(),
-            sh = dict(
-                type     = OSExtended,
-                alias    = ('shell',),
+        info="Default add-on group",
+        attr=dict(
+            kind=dict(),
+            sh=dict(
+                type=OSExtended,
+                alias=("shell",),
             ),
-            env = dict(
-                type     = Environment,
-                optional = True,
-                default  = None,
-                doc_visibility = footprints.doc.visibility.ADVANCED,
+            env=dict(
+                type=Environment,
+                optional=True,
+                default=None,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            cycle = dict(
-                optional = True,
-                default  = None,
+            cycle=dict(
+                optional=True,
+                default=None,
             ),
-            verboseload = dict(
-                optional = True,
-                default  = True,
-                type     = bool,
+            verboseload=dict(
+                optional=True,
+                default=True,
+                type=bool,
             ),
-        )
+        ),
     )
 
     _addonslist = None
 
     def __init__(self, *args, **kw):
         """Abstract Addon initialisation."""
-        logger.debug('Abstract Addon init %s', self.__class__)
+        logger.debug("Abstract Addon init %s", self.__class__)
         super().__init__(*args, **kw)
         self._addons_load()
 
     def _addons_load(self):
         if self._addonslist is None:
-            raise RuntimeError("the _addonslist classe variable must be overriden.")
+            raise RuntimeError(
+                "the _addonslist classe variable must be overriden."
+            )
         self._load_addons_from_list(self._addonslist)
 
     def _load_addons_from_list(self, addons):
         if self.verboseload:
             logger.info("Loading the %s Addons group.", self.kind)
         for addon in addons:
-            _shadd = footprints.proxy.addon(kind=addon, sh=self.sh, env=self.env,
-                                            cycle=self.cycle, verboseload=self.verboseload)
+            _shadd = footprints.proxy.addon(
+                kind=addon,
+                sh=self.sh,
+                env=self.env,
+                cycle=self.cycle,
+                verboseload=self.verboseload,
+            )
             if self.verboseload:
                 logger.info("%s Addon is: %s", addon, repr(_shadd))
 
@@ -270,13 +285,13 @@ def require_external_addon(*addons):
 
     If not, a :class:`RuntimeError` exception will be raised.
     """
+
     @nicedeco
     def r_addon_decorator(method):
-
         def decorated(self, *kargs, **kwargs):
             # Create a cache in self... ugly but efficient !
-            if not hasattr(self, '_require_external_addon_check_cache'):
-                setattr(self, '_require_external_addon_check_cache', set())
+            if not hasattr(self, "_require_external_addon_check_cache"):
+                setattr(self, "_require_external_addon_check_cache", set())
             ko_addons = set()
             loaded_addons = None
             for addon in addons:
@@ -289,9 +304,13 @@ def require_external_addon(*addons):
                 else:
                     ko_addons.add(addon)
             if ko_addons:
-                raise RuntimeError('The following addons are needed to use the {:s} method: {:s}'
-                                   .format(method.__name__, ', '.join(ko_addons)))
+                raise RuntimeError(
+                    "The following addons are needed to use the {:s} method: {:s}".format(
+                        method.__name__, ", ".join(ko_addons)
+                    )
+                )
             return method(self, *kargs, **kwargs)
 
         return decorated
+
     return r_addon_decorator

--- a/src/vortex/tools/arm.py
+++ b/src/vortex/tools/arm.py
@@ -7,7 +7,7 @@ from bronx.fancies import loggers
 from vortex.util.config import load_template
 
 #: No automatic export
-__all__ = ['ArmForgeTool']
+__all__ = ["ArmForgeTool"]
 
 logger = loggers.getLogger(__name__)
 
@@ -21,18 +21,20 @@ class ArmForgeTool:
         """
         self._t = ticket
         self._sh = self._t.sh
-        self._config = self._sh.default_target.items('armtools')
-        self._ddtpath = self._sh.env.get('VORTEX_ARM_DDT_PATH', None)
-        self._mappath = self._sh.env.get('VORTEX_ARM_MAP_PATH', None)
-        self._forgedir = self._sh.env.get('VORTEX_ARM_FORGE_DIR',
-                                          self.config.get('forgedir', None))
-        self._forgeversion = self._sh.env.get('VORTEX_ARM_FORGE_VERSION',
-                                              self.config.get('forgeversion', 999999))
+        self._config = self._sh.default_target.items("armtools")
+        self._ddtpath = self._sh.env.get("VORTEX_ARM_DDT_PATH", None)
+        self._mappath = self._sh.env.get("VORTEX_ARM_MAP_PATH", None)
+        self._forgedir = self._sh.env.get(
+            "VORTEX_ARM_FORGE_DIR", self.config.get("forgedir", None)
+        )
+        self._forgeversion = self._sh.env.get(
+            "VORTEX_ARM_FORGE_VERSION", self.config.get("forgeversion", 999999)
+        )
         self._forgeversion = int(self._forgeversion)
         if self._forgedir and self._ddtpath is None:
-            self._ddtpath = self._sh.path.join(self._forgedir, 'bin', 'ddt')
+            self._ddtpath = self._sh.path.join(self._forgedir, "bin", "ddt")
         if self._forgedir and self._mappath is None:
-            self._mappath = self._sh.path.join(self._forgedir, 'bin', 'map')
+            self._mappath = self._sh.path.join(self._forgedir, "bin", "map")
 
     @property
     def config(self):
@@ -43,34 +45,52 @@ class ArmForgeTool:
     def ddtpath(self):
         """The path to the DDT debuger executable."""
         if self._ddtpath is None:
-            raise RuntimeError('DDT requested but the DDT path is not configured.')
+            raise RuntimeError(
+                "DDT requested but the DDT path is not configured."
+            )
         return self._ddtpath
 
     @property
     def mappath(self):
         """The path to the MAP profiler executable."""
         if self._mappath is None:
-            raise RuntimeError('MAP requested but the MAP path is not configured.')
+            raise RuntimeError(
+                "MAP requested but the MAP path is not configured."
+            )
         return self._mappath
 
     def _dump_forge_session(self, sources=(), workdir=None):
         """Create the ARM Forge's session file to list source directories."""
-        targetfile = 'armforge-vortex-session-file.ddt'
+        targetfile = "armforge-vortex-session-file.ddt"
         if workdir:
             targetfile = self._sh.path.join(workdir, targetfile)
-        tpl = load_template(self._t, '@armforge-session-conf.tpl',
-                            encoding='utf-8', version=self._forgeversion)
-        sconf = tpl.substitute(sourcedirs='\n'.join(['        <directory>{:s}</directory>'.format(d)
-                                                     for d in sources]))
-        with open(targetfile, 'w') as fhs:
+        tpl = load_template(
+            self._t,
+            "@armforge-session-conf.tpl",
+            encoding="utf-8",
+            version=self._forgeversion,
+        )
+        sconf = tpl.substitute(
+            sourcedirs="\n".join(
+                [
+                    "        <directory>{:s}</directory>".format(d)
+                    for d in sources
+                ]
+            )
+        )
+        with open(targetfile, "w") as fhs:
             fhs.write(sconf)
         return targetfile
 
     def ddt_prefix_cmd(self, sources=(), workdir=None):
         """Generate the prefix command required to start DDT."""
         if sources:
-            return [self.ddtpath,
-                    '--session={:s}'.format(self._dump_forge_session(sources, workdir=workdir)),
-                    '--connect']
+            return [
+                self.ddtpath,
+                "--session={:s}".format(
+                    self._dump_forge_session(sources, workdir=workdir)
+                ),
+                "--connect",
+            ]
         else:
-            return [self.ddtpath, '--connect']
+            return [self.ddtpath, "--connect"]

--- a/src/vortex/tools/date.py
+++ b/src/vortex/tools/date.py
@@ -11,10 +11,17 @@ import sys
 from bronx.stdtypes import date as _b_date
 
 _ALIASES = _b_date.local_date_functions.copy()
-_ALIASES.update(dict(guess=_b_date.guess, daterange=_b_date.daterange,
-                     stamp=_b_date.stamp,
-                     Period=_b_date.Period,
-                     Date=_b_date.Date, Time=_b_date.Time, Month=_b_date.Month))
+_ALIASES.update(
+    dict(
+        guess=_b_date.guess,
+        daterange=_b_date.daterange,
+        stamp=_b_date.stamp,
+        Period=_b_date.Period,
+        Date=_b_date.Date,
+        Time=_b_date.Time,
+        Month=_b_date.Month,
+    )
+)
 
 for n, obj in _ALIASES.items():
     sys.modules[__name__].__dict__.update(_ALIASES)

--- a/src/vortex/tools/env.py
+++ b/src/vortex/tools/env.py
@@ -19,10 +19,12 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 #: Pre-compiled evaluation mostly used by :class:`Environment` method (true).
-vartrue = re.compile(r'^\s*(?:[1-9]\d*|ok|on|true|yes|y)\s*$', flags=re.IGNORECASE)
+vartrue = re.compile(
+    r"^\s*(?:[1-9]\d*|ok|on|true|yes|y)\s*$", flags=re.IGNORECASE
+)
 
 #: Pre-compiled evaluation mostly used by :class:`Environment` method (false).
-varfalse = re.compile(r'^\s*(?:0|ko|off|false|no|n)\s*$', flags=re.IGNORECASE)
+varfalse = re.compile(r"^\s*(?:0|ko|off|false|no|n)\s*$", flags=re.IGNORECASE)
 
 
 def current():
@@ -51,8 +53,16 @@ class Environment:
 
     _current_active = None
 
-    def __init__(self, env=None, active=False, clear=False, verbose=False,
-                 noexport=[], contextlock=None, history=True):
+    def __init__(
+        self,
+        env=None,
+        active=False,
+        clear=False,
+        verbose=False,
+        noexport=[],
+        contextlock=None,
+        history=True,
+    ):
         """
         :param Environment env: An existing Environment used to initialise this object.
         :param bool active: Is this new environment activated when created.
@@ -69,18 +79,18 @@ class Environment:
             :class:`~bronx.stdtypes.history.PrivateHistory` object that will be
             accessible through the :attr:`history` property.
         """
-        self.__dict__['_history'] = PrivateHistory() if history else None
-        self.__dict__['_verbose'] = verbose
-        self.__dict__['_frozen'] = collections.deque()
-        self.__dict__['_pool'] = dict()
-        self.__dict__['_mods'] = set()
-        self.__dict__['_sh'] = None
-        self.__dict__['_os'] = list()
+        self.__dict__["_history"] = PrivateHistory() if history else None
+        self.__dict__["_verbose"] = verbose
+        self.__dict__["_frozen"] = collections.deque()
+        self.__dict__["_pool"] = dict()
+        self.__dict__["_mods"] = set()
+        self.__dict__["_sh"] = None
+        self.__dict__["_os"] = list()
         if env is not None and isinstance(env, Environment):
             self._env_clone_internals(env, contextlock)
             if verbose:
                 try:
-                    self.__dict__['_sh'] = env._sh
+                    self.__dict__["_sh"] = env._sh
                 except AttributeError:
                     pass
         else:
@@ -88,20 +98,22 @@ class Environment:
                 active = False
             else:
                 if self._current_active is not None:
-                    self._env_clone_internals(self._current_active, contextlock)
+                    self._env_clone_internals(
+                        self._current_active, contextlock
+                    )
                 else:
                     self._pool.update(os.environ)
-        self.__dict__['_noexport'] = [x.upper() for x in noexport]
+        self.__dict__["_noexport"] = [x.upper() for x in noexport]
         self.active(active)
 
     def _env_clone_internals(self, env, contextlock):
-        self.__dict__['_os'] = env.osstack()
-        self.__dict__['_os'].append(env)
+        self.__dict__["_os"] = env.osstack()
+        self.__dict__["_os"].append(env)
         self._pool.update(env.items())
         if contextlock is not None:
-            self.__dict__['_contextlock'] = contextlock
+            self.__dict__["_contextlock"] = contextlock
         else:
-            self.__dict__['_contextlock'] = env.contextlock
+            self.__dict__["_contextlock"] = env.contextlock
 
     @property
     def history(self):
@@ -116,7 +128,9 @@ class Environment:
             self.history.append(var, value, traceback.format_stack()[:-1])
 
     def __str__(self):
-        return '{:s} | including {:d} variables>'.format(repr(self).rstrip('>'), len(self))
+        return "{:s} | including {:d} variables>".format(
+            repr(self).rstrip(">"), len(self)
+        )
 
     @classmethod
     def current(cls):
@@ -139,11 +153,11 @@ class Environment:
         """Dump the specified ``value`` as a string (utility function)."""
         if isinstance(value, str):
             obj = str(value)
-        elif hasattr(value, 'export_dict'):
+        elif hasattr(value, "export_dict"):
             obj = value.export_dict()
-        elif hasattr(value, 'footprint_export'):
+        elif hasattr(value, "footprint_export"):
             obj = value.footprint_export()
-        elif hasattr(value, '__dict__'):
+        elif hasattr(value, "__dict__"):
             obj = vars(value)
         else:
             obj = value
@@ -169,7 +183,9 @@ class Environment:
             os.environ[upvar] = actualvalue
             if self.verbose():
                 if self.osbound() and self._sh:
-                    self._sh.stderr('export', '{:s}={:s}'.format(upvar, actualvalue))
+                    self._sh.stderr(
+                        "export", "{:s}={:s}".format(upvar, actualvalue)
+                    )
                 logger.debug('Env export %s="%s"', upvar, actualvalue)
 
     def __setitem__(self, varname, value):
@@ -195,7 +211,7 @@ class Environment:
         return self.getvar(varname)
 
     def __getattr__(self, varname):
-        if varname.startswith('_'):
+        if varname.startswith("_"):
             raise AttributeError
         else:
             return self.getvar(varname)
@@ -217,9 +233,9 @@ class Environment:
         if seen and self.osbound():
             del os.environ[varname.upper()]
             if self.verbose() and self._sh:
-                self._sh.stderr('unset', '{:s}'.format(varname.upper()))
+                self._sh.stderr("unset", "{:s}".format(varname.upper()))
         if seen:
-            self._record(varname.upper(), '!!deleted!!')
+            self._record(varname.upper(), "!!deleted!!")
 
     def __delitem__(self, varname):
         self.delvar(varname)
@@ -268,9 +284,11 @@ class Environment:
         return self._pool.items()
 
     def __eq__(self, other):
-        return (isinstance(other, type(self)) and
-                set(self.keys()) == set(other.keys) and
-                all([self[k] == other[k] for k in self.keys]))
+        return (
+            isinstance(other, type(self))
+            and set(self.keys()) == set(other.keys)
+            and all([self[k] == other[k] for k in self.keys])
+        )
 
     def __ne__(self, other):
         return not self == other
@@ -342,7 +360,9 @@ class Environment:
         try:
             eclone.verbose(self._verbose, self._sh)
         except AttributeError:
-            logger.debug('Could not find verbose attributes while cloning env...')
+            logger.debug(
+                "Could not find verbose attributes while cloning env..."
+            )
         return eclone
 
     def __enter__(self):
@@ -365,10 +385,10 @@ class Environment:
     def verbose(self, switch=None, sh=None, fromenv=None):
         """Switch on or off the verbose mode. Returns actual value."""
         if switch is not None:
-            self.__dict__['_verbose'] = bool(switch)
+            self.__dict__["_verbose"] = bool(switch)
         if sh is not None:
-            self.__dict__['_sh'] = sh
-        return self.__dict__['_verbose']
+            self.__dict__["_sh"] = sh
+        return self.__dict__["_verbose"]
 
     def active(self, *args):
         """
@@ -383,19 +403,23 @@ class Environment:
         if args and type(args[0]) is bool:
             active = args[0]
         if previous_act and not active and self._os:
-            self._record('!!OS_BINDING!!', 'Broken...')
+            self._record("!!OS_BINDING!!", "Broken...")
             self.__class__._current_active = self._os[-1]
             osrewind = self.__class__._current_active
         if not previous_act and active:
             if self.contextlock is not None and not self.contextlock.active:
-                raise RuntimeError("It's not allowed to switch to an Environment " +
-                                   "that belongs to an inactive context")
-            self._record('!!OS_BINDING!!', 'Acquiring...')
+                raise RuntimeError(
+                    "It's not allowed to switch to an Environment "
+                    + "that belongs to an inactive context"
+                )
+            self._record("!!OS_BINDING!!", "Acquiring...")
             self.__class__._current_active = self
             osrewind = self.__class__._current_active
         if osrewind:
             os.environ.clear()
-            for k in filter(lambda x: x not in osrewind._noexport, osrewind._pool.keys()):
+            for k in filter(
+                lambda x: x not in osrewind._noexport, osrewind._pool.keys()
+            ):
                 os.environ[k] = osrewind.native(k)
         return active
 
@@ -436,11 +460,15 @@ class Environment:
 
     def mkautolist(self, prefix):
         """Return a list of variable starting with the ``prefix`` string."""
-        return [var + '="' + self.get(var, '') + '"' for var in self.keys() if var.startswith(prefix)]
+        return [
+            var + '="' + self.get(var, "") + '"'
+            for var in self.keys()
+            if var.startswith(prefix)
+        ]
 
     def trueshell(self):
         """Extract the actual shell name according to env variable SHELL."""
-        return re.sub('^.*/', '', self.getvar('shell'))
+        return re.sub("^.*/", "", self.getvar("shell"))
 
     def true(self, varname):
         """Extended boolean positive test of the variable given as argument."""
@@ -461,41 +489,41 @@ class Environment:
         :param str value: The value that will be inserted in the path
         :param int pos: Where in the path, to insert ``value`` (by default, at the end)
         """
-        mypath = self.getvar(var).split(':') if self.getvar(var) else []
+        mypath = self.getvar(var).split(":") if self.getvar(var) else []
         value = str(value)
         while value in mypath:
             mypath.remove(value)
         if pos is None:
             pos = len(mypath)
         mypath.insert(pos, value)
-        self.setvar(var, ':'.join(mypath))
+        self.setvar(var, ":".join(mypath))
 
     def rmgenericpath(self, var, value):
         """Remove the specified ``value`` from a PATH like variable."""
-        mypath = self.getvar(var).split(':') if self.getvar(var) else []
+        mypath = self.getvar(var).split(":") if self.getvar(var) else []
         while value in mypath:
             mypath.remove(value)
-        self.setvar(var, ':'.join(mypath))
+        self.setvar(var, ":".join(mypath))
 
     def setbinpath(self, value, pos=None):
         """
         Insert a new path ``value`` to the bin search path (i.e. the PATH
         environment variable) at given position.
         """
-        self.setgenericpath('PATH', value, pos)
+        self.setgenericpath("PATH", value, pos)
 
     def rmbinpath(self, value):
         """
         Remove the specified ``value`` from the bin path (i.e. the PATH
         environment variable).
         """
-        self.rmgenericpath('PATH', value)
+        self.rmgenericpath("PATH", value)
 
 
 collections.abc.Mapping.register(Environment)
 
 
-class EnvironmentDeltaContext():
+class EnvironmentDeltaContext:
     """Context that will apply a delta on the Environment and rewind it on exit."""
 
     def __init__(self, env, **kw):

--- a/src/vortex/tools/folder.py
+++ b/src/vortex/tools/folder.py
@@ -19,23 +19,38 @@ __all__ = []
 
 logger = loggers.getLogger(__name__)
 
-_folder_exposed_methods = {'cp', 'mv', 'forcepack', 'forceunpack',
-                           'anyft_remote_rewrite',
-                           'ftget', 'rawftget', 'batchrawftget', 'ftput', 'rawftput',
-                           'scpget', 'scpput',
-                           'ecfsget', 'ecfsput', 'ectransget', 'ectransput'}
+_folder_exposed_methods = {
+    "cp",
+    "mv",
+    "forcepack",
+    "forceunpack",
+    "anyft_remote_rewrite",
+    "ftget",
+    "rawftget",
+    "batchrawftget",
+    "ftput",
+    "rawftput",
+    "scpget",
+    "scpput",
+    "ecfsget",
+    "ecfsput",
+    "ectransget",
+    "ectransput",
+}
 
 
 def folderize(cls):
     """Create the necessary methods in a class that inherits from :class:`FolderShell`."""
-    addon_kind = cls.footprint_retrieve().get_values('kind')
+    addon_kind = cls.footprint_retrieve().get_values("kind")
     if len(addon_kind) != 1:
-        raise SyntaxError("Authorised values for a given Addon's kind must be unique")
+        raise SyntaxError(
+            "Authorised values for a given Addon's kind must be unique"
+        )
     addon_kind = addon_kind[0]
     for basic_mtdname in _folder_exposed_methods:
-        expected_mtdname = '{:s}_{:s}'.format(addon_kind, basic_mtdname)
+        expected_mtdname = "{:s}_{:s}".format(addon_kind, basic_mtdname)
         if not hasattr(cls, expected_mtdname):
-            parent_mtd = getattr(cls, '_folder_{:s}'.format(basic_mtdname))
+            parent_mtd = getattr(cls, "_folder_{:s}".format(basic_mtdname))
             setattr(cls, expected_mtdname, parent_mtd)
     return cls
 
@@ -45,41 +60,53 @@ class FolderShell(addons.FtrawEnableAddon):
     This abstract class defines methods to manipulate folders.
     """
 
-    _COMPRESSED = 'gz'
+    _COMPRESSED = "gz"
 
     _abstract = True
     _footprint = dict(
-        info = 'Tools for manipulating folders',
-        attr = dict(
-            kind = dict(
-                values   = ['folder'],
+        info="Tools for manipulating folders",
+        attr=dict(
+            kind=dict(
+                values=["folder"],
             ),
-            tmpname = dict(
-                optional = True,
-                default  = 'folder_tmpunpack',
+            tmpname=dict(
+                optional=True,
+                default="folder_tmpunpack",
             ),
-            pipeget = dict(
-                type     = bool,
-                optional = True,
-                default  = False,
+            pipeget=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            supportedfmt = dict(
-                optional = True,
-                default  = '[kind]',
+            supportedfmt=dict(
+                optional=True,
+                default="[kind]",
             ),
-        )
+        ),
     )
 
-    def _folder_cp(self, source, destination,
-                   smartcp_threshold=0, intent='in', silent=False):
+    def _folder_cp(
+        self,
+        source,
+        destination,
+        smartcp_threshold=0,
+        intent="in",
+        silent=False,
+    ):
         """Extended copy for a folder repository."""
         rc, source, destination = self._folder_tarfix_out(source, destination)
-        rc = rc and self.sh.cp(source, destination,
-                               smartcp_threshold=smartcp_threshold, intent=intent)
+        rc = rc and self.sh.cp(
+            source,
+            destination,
+            smartcp_threshold=smartcp_threshold,
+            intent=intent,
+        )
         if rc:
-            rc, source, destination = self._folder_tarfix_in(source, destination)
-            if rc and intent == 'inout':
-                self.sh.stderr('chmod', 0o644, destination)
+            rc, source, destination = self._folder_tarfix_in(
+                source, destination
+            )
+            if rc and intent == "inout":
+                self.sh.stderr("chmod", 0o644, destination)
                 with self.sh.mute_stderr():
                     for infile in self.sh.ffind(destination):
                         self.sh.chmod(infile, 0o644)
@@ -92,18 +119,27 @@ class FolderShell(addons.FtrawEnableAddon):
             if isinstance(source, str):
                 rc = rc and self.sh.remove(source)
         else:
-            rc, source, destination = self._folder_tarfix_out(source, destination)
+            rc, source, destination = self._folder_tarfix_out(
+                source, destination
+            )
             rc = rc and self.sh.move(source, destination)
             if rc:
-                rc, source, destination = self._folder_tarfix_in(source, destination)
+                rc, source, destination = self._folder_tarfix_in(
+                    source, destination
+                )
         return rc
 
     def _folder_forcepack(self, source, destination=None):
         """Returned a path to a packed data."""
         if not self.sh.is_tarname(source):
-            destination = (destination if destination else
-                           "{:s}.{:s}".format(self.sh.safe_fileaddsuffix(source),
-                                              self._folder_tarfix_extension))
+            destination = (
+                destination
+                if destination
+                else "{:s}.{:s}".format(
+                    self.sh.safe_fileaddsuffix(source),
+                    self._folder_tarfix_extension,
+                )
+            )
             if not self.sh.path.exists(destination):
                 absdestination = self.sh.path.abspath(destination)
                 with self.sh.cdcontext(self.sh.path.dirname(source)):
@@ -114,24 +150,33 @@ class FolderShell(addons.FtrawEnableAddon):
 
     def _folder_forceunpack(self, source):
         """Unpack the data "inplace"."""
-        fakesource = '{:s}.{:s}'.format(self.sh.safe_fileaddsuffix(source),
-                                        self._folder_tarfix_extension)
+        fakesource = "{:s}.{:s}".format(
+            self.sh.safe_fileaddsuffix(source), self._folder_tarfix_extension
+        )
         rc, _, _ = self._folder_tarfix_in(fakesource, source)
         return rc
 
     def _folder_pack_stream(self, source, stdout=True):
         source_name = self.sh.path.basename(source)
         source_dirname = self.sh.path.dirname(source)
-        compression_map = {'gz': 'z', 'bz2': 'j'}
-        compression_opt = compression_map.get(self._COMPRESSED, '')
-        cmd = ['tar', '--directory', source_dirname,
-               '-c' + compression_opt, source_name]
+        compression_map = {"gz": "z", "bz2": "j"}
+        compression_opt = compression_map.get(self._COMPRESSED, "")
+        cmd = [
+            "tar",
+            "--directory",
+            source_dirname,
+            "-c" + compression_opt,
+            source_name,
+        ]
         return self.sh.popen(cmd, stdout=stdout, bufsize=8192)
 
-    def _folder_unpack_stream(self, stdin=True, options='xvf'):
+    def _folder_unpack_stream(self, stdin=True, options="xvf"):
         return self.sh.popen(
             # the z option is omitted consequently it also works if the file is not compressed
-            ['tar', options, '-'], stdin=stdin, bufsize=8192)
+            ["tar", options, "-"],
+            stdin=stdin,
+            bufsize=8192,
+        )
 
     def _packed_size(self, source):
         """Size of the final file, must be exact or be an overestimation.
@@ -150,17 +195,20 @@ class FolderShell(addons.FtrawEnableAddon):
 
     def _folder_preftget(self, source, destination):
         """Prepare source and destination"""
-        destination = self.sh.path.abspath(self.sh.path.expanduser(destination))
+        destination = self.sh.path.abspath(
+            self.sh.path.expanduser(destination)
+        )
         self.sh.rm(destination)
         return source, destination
 
     def _folder_postftget(self, destination):
         """Move the untared stuff to the destination and clean-up things."""
         try:
-            unpacked = self.sh.glob('*')
+            unpacked = self.sh.glob("*")
             if unpacked:
-                if (len(unpacked) == 1 and
-                        self.sh.path.isdir(self.sh.path.join(unpacked[-1]))):
+                if len(unpacked) == 1 and self.sh.path.isdir(
+                    self.sh.path.join(unpacked[-1])
+                ):
                     # This is the most usual case... (ODB, DDH packs produced by Vortex)
                     self.sh.wpermtree(unpacked[-1], force=True)
                     if self.sh.path.isdir(unpacked[-1]):
@@ -174,17 +222,21 @@ class FolderShell(addons.FtrawEnableAddon):
                         self.sh.mkdir(destination)
                         for item in unpacked:
                             self.sh.wpermtree(item, force=True)
-                            self.sh.mv(item, self.sh.path.join(destination, item))
+                            self.sh.mv(
+                                item, self.sh.path.join(destination, item)
+                            )
             else:
-                logger.error('Nothing to unpack')
+                logger.error("Nothing to unpack")
         except Exception as trouble:
-            logger.critical('Unable to proceed folder post-ftget step')
+            logger.critical("Unable to proceed folder post-ftget step")
             raise trouble
 
     @contextlib.contextmanager
     def _folder_postftget_context(self, destination):
         """Move the untared stuff to the destination and clean-up things."""
-        with self.sh.temporary_dir_cdcontext(prefix='folder_', dir=self.sh.getcwd()):
+        with self.sh.temporary_dir_cdcontext(
+            prefix="folder_", dir=self.sh.getcwd()
+        ):
             try:
                 yield
             finally:
@@ -209,8 +261,11 @@ class FolderShell(addons.FtrawEnableAddon):
 
     @contextlib.contextmanager
     def _folder_ftput_file_compress(self, source):
-        c_source = (self.sh.safe_fileaddsuffix(source) +
-                    '.' + self._folder_tarfix_extension)
+        c_source = (
+            self.sh.safe_fileaddsuffix(source)
+            + "."
+            + self._folder_tarfix_extension
+        )
         try:
             self.sh.tar(c_source, source)
             yield c_source
@@ -226,36 +281,54 @@ class FolderShell(addons.FtrawEnableAddon):
     def _folder_anyft_remote_rewrite(self, remote):
         """Add the folder suffix before using file transfert protocols."""
         if not self.sh.is_tarname(self.sh.path.basename(remote)):
-            return '{:s}.{:s}'.format(remote, self._folder_tarfix_extension)
+            return "{:s}.{:s}".format(remote, self._folder_tarfix_extension)
         else:
             return remote
 
-    def _folder_ftget(self, source, destination, hostname=None, logname=None,
-                      port=DEFAULT_FTP_PORT, cpipeline=None):
+    def _folder_ftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+    ):
         """Proceed direct ftp get on the specified target."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
         hostname = self.sh.fix_fthostname(hostname)
         with self.sh.ftpcontext(hostname, logname, port=port) as ftp:
             if ftp:
-                source, destination = self._folder_preftget(source, destination)
+                source, destination = self._folder_preftget(
+                    source, destination
+                )
                 with self._folder_postftget_context(destination):
                     try:
                         if self.pipeget:
                             with self._folder_ftget_pipe_extract() as p:
                                 rc = ftp.get(source, p.stdin)
                         else:
-                            with self._folder_ftget_file_extract(source) as tmp_target:
+                            with self._folder_ftget_file_extract(
+                                source
+                            ) as tmp_target:
                                 rc = ftp.get(source, tmp_target)
                     except ftplib.all_errors as e:
-                        logger.warning('An FTP error occurred: %s', str(e))
+                        logger.warning("An FTP error occurred: %s", str(e))
                         rc = False
                 return rc
             else:
                 return False
 
-    def _folder_rawftget(self, source, destination, hostname=None, logname=None,
-                         port=None, cpipeline=None):
+    def _folder_rawftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+    ):
         """Use ftserv as much as possible."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
@@ -263,17 +336,30 @@ class FolderShell(addons.FtrawEnableAddon):
             source, destination = self._folder_preftget(source, destination)
             with self._folder_postftget_context(destination):
                 with self._folder_ftget_file_extract(source) as tmp_target:
-                    rc = self.sh.ftserv_get(source, tmp_target,
-                                            hostname=hostname, logname=logname,
-                                            port=port)
+                    rc = self.sh.ftserv_get(
+                        source,
+                        tmp_target,
+                        hostname=hostname,
+                        logname=logname,
+                        port=port,
+                    )
             return rc
         else:
             if port is None:
                 port = DEFAULT_FTP_PORT
-            return self._folder_ftget(source, destination, hostname, logname, port=port)
+            return self._folder_ftget(
+                source, destination, hostname, logname, port=port
+            )
 
-    def _folder_batchrawftget(self, source, destination, hostname=None, logname=None,
-                              port=None, cpipeline=None):
+    def _folder_batchrawftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+    ):
         """Use ftserv to fetch several folder-like resources."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
@@ -288,20 +374,35 @@ class FolderShell(addons.FtrawEnableAddon):
                     actualdestinations.append(actual_d)
                     d_dirname = self.sh.path.dirname(actual_d)
                     self.sh.mkdir(d_dirname)
-                    d_tmpdir = tempfile.mkdtemp(prefix='folder_', dir=d_dirname)
+                    d_tmpdir = tempfile.mkdtemp(
+                        prefix="folder_", dir=d_dirname
+                    )
                     d_extname = self.sh.tarname_splitext(actual_s)[1]
-                    tmpdestinations.append(self.sh.path.join(d_tmpdir, self.tmpname + d_extname))
+                    tmpdestinations.append(
+                        self.sh.path.join(d_tmpdir, self.tmpname + d_extname)
+                    )
 
-                rc = self.sh.ftserv_batchget(actualsources, tmpdestinations, hostname,
-                                             logname, port=port)
+                rc = self.sh.ftserv_batchget(
+                    actualsources,
+                    tmpdestinations,
+                    hostname,
+                    logname,
+                    port=port,
+                )
 
-                for i, (d, t) in enumerate(zip(actualdestinations, tmpdestinations)):
+                for i, (d, t) in enumerate(
+                    zip(actualdestinations, tmpdestinations)
+                ):
                     if rc[i]:
                         with self.sh.cdcontext(self.sh.path.dirname(t)):
                             try:
                                 try:
-                                    rc[i] = rc[i] and bool(self.sh.untar(self.sh.path.basename(t),
-                                                                         autocompress=False))
+                                    rc[i] = rc[i] and bool(
+                                        self.sh.untar(
+                                            self.sh.path.basename(t),
+                                            autocompress=False,
+                                        )
+                                    )
                                 finally:
                                     self.sh.rm(t)
                             finally:
@@ -311,10 +412,18 @@ class FolderShell(addons.FtrawEnableAddon):
                     self.sh.rm(self.sh.path.dirname(t))
             return rc
         else:
-            raise RuntimeError('You are not supposed to land here !')
+            raise RuntimeError("You are not supposed to land here !")
 
-    def _folder_ftput(self, source, destination, hostname=None, logname=None,
-                      port=DEFAULT_FTP_PORT, cpipeline=None, sync=False):
+    def _folder_ftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+        sync=False,
+    ):
         """Proceed direct ftp put on the specified target."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
@@ -326,42 +435,64 @@ class FolderShell(addons.FtrawEnableAddon):
                 with self._folder_ftput_pipe_compress(source) as p:
                     sponge = IoSponge(p.stdout, guessed_size=packed_size)
                     try:
-                        rc = ftp.put(sponge, destination, size=sponge.size, exact=False)
+                        rc = ftp.put(
+                            sponge, destination, size=sponge.size, exact=False
+                        )
                     except ftplib.all_errors as e:
-                        logger.warning('An FTP error occurred: %s', str(e))
+                        logger.warning("An FTP error occurred: %s", str(e))
                         rc = False
                 return rc
             else:
                 return False
 
-    def _folder_rawftput(self, source, destination, hostname=None, logname=None,
-                         port=None, cpipeline=None, sync=False):
+    def _folder_rawftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Use ftserv as much as possible."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
         if self.sh.ftraw and self.rawftshell is not None:
-            newsource = self.sh.copy2ftspool(source, nest=True,
-                                             fmt=self.supportedfmt)
-            request = self.sh.path.dirname(newsource) + '.request'
-            with open(request, 'w') as request_fh:
+            newsource = self.sh.copy2ftspool(
+                source, nest=True, fmt=self.supportedfmt
+            )
+            request = self.sh.path.dirname(newsource) + ".request"
+            with open(request, "w") as request_fh:
                 request_fh.write(str(self.sh.path.dirname(newsource)))
             self.sh.readonly(request)
-            rc = self.sh.ftserv_put(request, destination,
-                                    hostname=hostname, logname=logname, port=port,
-                                    specialshell=self.rawftshell, sync=sync)
+            rc = self.sh.ftserv_put(
+                request,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                specialshell=self.rawftshell,
+                sync=sync,
+            )
             self.sh.rm(request)
             return rc
         else:
             if port is None:
                 port = DEFAULT_FTP_PORT
-            return self._folder_ftput(source, destination, hostname, logname,
-                                      port=port, sync=sync)
+            return self._folder_ftput(
+                source, destination, hostname, logname, port=port, sync=sync
+            )
 
-    def _folder_scpget(self, source, destination, hostname, logname=None, cpipeline=None):
+    def _folder_scpget(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """Retrieve a folder using scp."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
-        logname = self.sh.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
+        logname = self.sh.fix_ftuser(
+            hostname, logname, fatal=False, defaults_to_user=False
+        )
         ssh = self.sh.ssh(hostname, logname)
         rc = False
         source, destination = self._folder_preftget(source, destination)
@@ -370,18 +501,22 @@ class FolderShell(addons.FtrawEnableAddon):
                 rc = ssh.scpget_stream(source, p.stdin)
         return rc
 
-    def _folder_scpput(self, source, destination, hostname, logname=None, cpipeline=None):
+    def _folder_scpput(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """Upload a folder using scp."""
         if cpipeline is not None:
             raise OSError("It's not allowed to compress folder like data.")
         source = self.sh.path.abspath(source)
-        logname = self.sh.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
+        logname = self.sh.fix_ftuser(
+            hostname, logname, fatal=False, defaults_to_user=False
+        )
         ssh = self.sh.ssh(hostname, logname)
         with self._folder_ftput_pipe_compress(source) as p:
             rc = ssh.scpput_stream(p.stdout, destination)
         return rc
 
-    @addons.require_external_addon('ecfs')
+    @addons.require_external_addon("ecfs")
     def _folder_ecfsget(self, source, target, cpipeline=None, options=None):
         """Get a folder resource using ECfs.
 
@@ -397,10 +532,12 @@ class FolderShell(addons.FtrawEnableAddon):
         source, target = self._folder_preftget(source, target)
         with self._folder_postftget_context(target):
             with self._folder_ftget_file_extract(source) as tmp_target:
-                rc = self.sh.ecfsget(source=source, target=tmp_target, options=options)
+                rc = self.sh.ecfsget(
+                    source=source, target=tmp_target, options=options
+                )
         return rc
 
-    @addons.require_external_addon('ecfs')
+    @addons.require_external_addon("ecfs")
     def _folder_ecfsput(self, source, target, cpipeline=None, options=None):
         """Put a folder resource using ECfs.
 
@@ -414,11 +551,15 @@ class FolderShell(addons.FtrawEnableAddon):
             raise OSError("It's not allowed to compress folder like data.")
         source = self.sh.path.abspath(source)
         with self._folder_ftput_file_compress(source) as c_source:
-            rc = self.sh.ecfsput(source=c_source, target=target, options=options)
+            rc = self.sh.ecfsput(
+                source=c_source, target=target, options=options
+            )
         return rc
 
-    @addons.require_external_addon('ectrans')
-    def _folder_ectransget(self, source, target, gateway=None, remote=None, cpipeline=None):
+    @addons.require_external_addon("ectrans")
+    def _folder_ectransget(
+        self, source, target, gateway=None, remote=None, cpipeline=None
+    ):
         """Get a folder resource using ECtrans.
 
         :param source: source file
@@ -434,15 +575,24 @@ class FolderShell(addons.FtrawEnableAddon):
         source, target = self._folder_preftget(source, target)
         with self._folder_postftget_context(target):
             with self._folder_ftget_file_extract(source) as tmp_target:
-                rc = self.sh.raw_ectransget(source=source,
-                                            target=tmp_target,
-                                            gateway=gateway,
-                                            remote=remote)
+                rc = self.sh.raw_ectransget(
+                    source=source,
+                    target=tmp_target,
+                    gateway=gateway,
+                    remote=remote,
+                )
         return rc
 
-    @addons.require_external_addon('ectrans')
-    def _folder_ectransput(self, source, target, gateway=None, remote=None,
-                           cpipeline=None, sync=False):
+    @addons.require_external_addon("ectrans")
+    def _folder_ectransput(
+        self,
+        source,
+        target,
+        gateway=None,
+        remote=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Put a folder resource using ECtrans.
 
         :param source: source file
@@ -457,24 +607,29 @@ class FolderShell(addons.FtrawEnableAddon):
             raise OSError("It's not allowed to compress folder like data.")
         source = self.sh.path.abspath(source)
         with self._folder_ftput_file_compress(source) as c_source:
-            rc = self.sh.raw_ectransput(source=c_source,
-                                        target=target,
-                                        gateway=gateway,
-                                        remote=remote,
-                                        sync=sync)
+            rc = self.sh.raw_ectransput(
+                source=c_source,
+                target=target,
+                gateway=gateway,
+                remote=remote,
+                sync=sync,
+            )
         return rc
 
     @property
     def _folder_tarfix_extension(self):
         """Return the extension of tar file associated with this extension."""
         if self._COMPRESSED:
-            if self._COMPRESSED == 'gz':
+            if self._COMPRESSED == "gz":
                 return "tgz"
-            elif self._COMPRESSED == 'bz2':
+            elif self._COMPRESSED == "bz2":
                 return "tar.bz2"
             else:
-                raise ValueError("Unsupported compression type: {:s}"
-                                 .format(self._COMPRESSED))
+                raise ValueError(
+                    "Unsupported compression type: {:s}".format(
+                        self._COMPRESSED
+                    )
+                )
         else:
             return "tar"
 
@@ -487,17 +642,23 @@ class FolderShell(addons.FtrawEnableAddon):
         ok = True
         sh = self.sh
         if sh.is_tarname(source) and not sh.is_tarname(destination):
-            logger.info('tarfix_in: untar from get <%s> to <%s>', source, destination)
+            logger.info(
+                "tarfix_in: untar from get <%s> to <%s>", source, destination
+            )
             (destdir, destfile) = sh.path.split(sh.path.abspath(destination))
             tar_ext = sh.tarname_splitext(source)[1]
             desttar = sh.path.abspath(destination + tar_ext)
             sh.remove(desttar)
             ok = ok and sh.move(destination, desttar)
-            with sh.temporary_dir_cdcontext(prefix='untar_', dir=destdir):
+            with sh.temporary_dir_cdcontext(prefix="untar_", dir=destdir):
                 ok = ok and sh.untar(desttar, output=False)
-                unpacked = sh.glob('*')
-                ok = ok and len(unpacked) == 1  # Only one element allowed in this kind of tarfiles
-                ok = ok and sh.move(unpacked[0], sh.path.join(destdir, destfile))
+                unpacked = sh.glob("*")
+                ok = (
+                    ok and len(unpacked) == 1
+                )  # Only one element allowed in this kind of tarfiles
+                ok = ok and sh.move(
+                    unpacked[0], sh.path.join(destdir, destfile)
+                )
                 ok = ok and sh.remove(desttar)
         return (ok, source, destination)
 
@@ -511,7 +672,9 @@ class FolderShell(addons.FtrawEnableAddon):
         ok = True
         sh = self.sh
         if sh.is_tarname(destination) and not sh.is_tarname(source):
-            logger.info('tarfix_out: tar before put <%s> to <%s>', source, destination)
+            logger.info(
+                "tarfix_out: tar before put <%s> to <%s>", source, destination
+            )
             tar_ext = sh.tarname_splitext(destination)[1]
             sourcetar = sh.path.abspath(source + tar_ext)
             source_rel = sh.path.basename(source)
@@ -532,12 +695,12 @@ class OdbShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default ODB system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['odb'],
+        info="Default ODB system interface",
+        attr=dict(
+            kind=dict(
+                values=["odb"],
             ),
-        )
+        ),
     )
 
 
@@ -549,12 +712,12 @@ class DdhPackShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default DDHpack system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['ddhpack'],
+        info="Default DDHpack system interface",
+        attr=dict(
+            kind=dict(
+                values=["ddhpack"],
             ),
-        )
+        ),
     )
 
 
@@ -566,12 +729,12 @@ class RawFilesShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default (g)RRRRawfiles system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['rawfiles'],
+        info="Default (g)RRRRawfiles system interface",
+        attr=dict(
+            kind=dict(
+                values=["rawfiles"],
             ),
-        )
+        ),
     )
 
 
@@ -583,12 +746,12 @@ class ObsLocationPackShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default Obs Location packs system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['obslocationpack'],
+        info="Default Obs Location packs system interface",
+        attr=dict(
+            kind=dict(
+                values=["obslocationpack"],
             ),
-        )
+        ),
     )
 
 
@@ -600,12 +763,12 @@ class ObsFirePackShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default Obs Location packs system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['obsfirepack'],
+        info="Default Obs Location packs system interface",
+        attr=dict(
+            kind=dict(
+                values=["obsfirepack"],
             ),
-        )
+        ),
     )
 
 
@@ -617,12 +780,12 @@ class WavesBCShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default waves BC system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['wbcpack'],
+        info="Default waves BC system interface",
+        attr=dict(
+            kind=dict(
+                values=["wbcpack"],
             ),
-        )
+        ),
     )
 
 
@@ -634,30 +797,38 @@ class FilesPackShell(FolderShell):
     """
 
     _footprint = dict(
-        info = 'Default Files packs system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['filespack'],
+        info="Default Files packs system interface",
+        attr=dict(
+            kind=dict(
+                values=["filespack"],
             ),
-        )
+        ),
     )
 
 
-available_foldershells = [e.footprint_values('kind')[0] for e in locals().values()
-                          if (isinstance(e, type) and issubclass(e, FolderShell) and
-                              not e.footprint_abstract())]
+available_foldershells = [
+    e.footprint_values("kind")[0]
+    for e in locals().values()
+    if (
+        isinstance(e, type)
+        and issubclass(e, FolderShell)
+        and not e.footprint_abstract()
+    )
+]
 
 
 class FolderShellsGroup(addons.AddonGroup):
     """The whole bunch of folder shells."""
 
     _footprint = dict(
-        info = 'The whole bunch of folder shells',
-        attr = dict(
-            kind = dict(
-                values = ['allfolders', ],
+        info="The whole bunch of folder shells",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "allfolders",
+                ],
             ),
-        )
+        ),
     )
 
     _addonslist = available_foldershells

--- a/src/vortex/tools/grib.py
+++ b/src/vortex/tools/grib.py
@@ -19,7 +19,10 @@ import footprints
 
 from . import addons
 from vortex.config import get_from_config_w_default
-from vortex.algo.components import AlgoComponentDecoMixin, algo_component_deco_mixin_autodoc
+from vortex.algo.components import (
+    AlgoComponentDecoMixin,
+    algo_component_deco_mixin_autodoc,
+)
 from vortex.tools.net import DEFAULT_FTP_PORT
 
 #: No automatic export
@@ -30,7 +33,7 @@ logger = loggers.getLogger(__name__)
 
 def use_in_shell(sh, **kw):
     """Extend current shell with the LFI interface defined by optional arguments."""
-    kw['shell'] = sh
+    kw["shell"] = sh
     return footprints.proxy.addon(**kw)
 
 
@@ -38,13 +41,14 @@ class GRIB_Tool(addons.FtrawEnableAddon):
     """
     Handle multipart-GRIB files properly.
     """
+
     _footprint = dict(
-        info = 'Default GRIB system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['grib'],
+        info="Default GRIB system interface",
+        attr=dict(
+            kind=dict(
+                values=["grib"],
             ),
-        )
+        ),
     )
 
     def _std_grib_index_get(self, source):
@@ -55,24 +59,33 @@ class GRIB_Tool(addons.FtrawEnableAddon):
     xgrib_index_get = _std_grib_index_get
 
     def _std_grib_index_write(self, destination, gribpaths):
-        gribparts = [str(urlparse.urlunparse(('file', '', path, '', '', '')))
-                     for path in gribpaths]
+        gribparts = [
+            str(urlparse.urlunparse(("file", "", path, "", "", "")))
+            for path in gribpaths
+        ]
         tmpfile = self.sh.safe_fileaddsuffix(destination)
-        with open(tmpfile, 'w') as fd:
-            fd.write('\n'.join(gribparts))
+        with open(tmpfile, "w") as fd:
+            fd.write("\n".join(gribparts))
         return self.sh.move(tmpfile, destination)
 
     def is_xgrib(self, source):
         """Check if the given ``source`` is a multipart-GRIB file."""
         rc = False
         if source and isinstance(source, str) and self.sh.path.exists(source):
-            with open(source, 'rb') as fd:
-                rc = fd.read(7) == b'file://'
+            with open(source, "rb") as fd:
+                rc = fd.read(7) == b"file://"
         return rc
 
-    def _backend_cp(self, source, destination, smartcp_threshold=0, intent='in'):
-        return self.sh.cp(source, destination,
-                          smartcp_threshold=smartcp_threshold, intent=intent, smartcp=True)
+    def _backend_cp(
+        self, source, destination, smartcp_threshold=0, intent="in"
+    ):
+        return self.sh.cp(
+            source,
+            destination,
+            smartcp_threshold=smartcp_threshold,
+            intent=intent,
+            smartcp=True,
+        )
 
     def _backend_rm(self, *args):
         return self.sh.rm(*args)
@@ -103,8 +116,15 @@ class GRIB_Tool(addons.FtrawEnableAddon):
 
     grib_rm = grib_remove = _std_remove
 
-    def _std_copy(self, source, destination,
-                  smartcp_threshold=0, intent='in', pack=False, silent=False):
+    def _std_copy(
+        self,
+        source,
+        destination,
+        smartcp_threshold=0,
+        intent="in",
+        pack=False,
+        silent=False,
+    ):
         """Extended copy for (possibly) multi GRIB file."""
         # Might be multipart
         if self.is_xgrib(source):
@@ -112,22 +132,38 @@ class GRIB_Tool(addons.FtrawEnableAddon):
             if isinstance(destination, str) and not pack:
                 with self.sh.mute_stderr():
                     idx = self._std_grib_index_get(source)
-                    destdir = self.sh.path.abspath(self.sh.path.expanduser(destination) + ".d")
+                    destdir = self.sh.path.abspath(
+                        self.sh.path.expanduser(destination) + ".d"
+                    )
                     rc = rc and self.sh.mkdir(destdir)
                     target_idx = list()
-                    for (i, a_mpart) in enumerate(idx):
-                        target_idx.append(self.sh.path.join(destdir, 'GRIB_mpart{:06d}'.format(i)))
-                        rc = rc and self._backend_cp(a_mpart, target_idx[-1],
-                                                     smartcp_threshold=smartcp_threshold, intent=intent)
-                        rc = rc and self._std_grib_index_write(destination, target_idx)
-                    if intent == 'in':
+                    for i, a_mpart in enumerate(idx):
+                        target_idx.append(
+                            self.sh.path.join(
+                                destdir, "GRIB_mpart{:06d}".format(i)
+                            )
+                        )
+                        rc = rc and self._backend_cp(
+                            a_mpart,
+                            target_idx[-1],
+                            smartcp_threshold=smartcp_threshold,
+                            intent=intent,
+                        )
+                        rc = rc and self._std_grib_index_write(
+                            destination, target_idx
+                        )
+                    if intent == "in":
                         self.sh.chmod(destination, 0o444)
             else:
                 rc = rc and self.xgrib_pack(source, destination)
         else:
             # Usual file or file descriptor
-            rc = self._backend_cp(source, destination,
-                                  smartcp_threshold=smartcp_threshold, intent=intent)
+            rc = self._backend_cp(
+                source,
+                destination,
+                smartcp_threshold=smartcp_threshold,
+                intent=intent,
+            )
         return rc
 
     grib_cp = grib_copy = _std_copy
@@ -136,7 +172,7 @@ class GRIB_Tool(addons.FtrawEnableAddon):
         """Extended mv for (possibly) multi GRIB file."""
         # Might be multipart
         if self.is_xgrib(source):
-            intent = 'inout' if self.sh.access(source, self.sh.W_OK) else 'in'
+            intent = "inout" if self.sh.access(source, self.sh.W_OK) else "in"
             rc = self._std_copy(source, destination, intent=intent)
             rc = rc and self._std_remove(source)
         else:
@@ -146,7 +182,9 @@ class GRIB_Tool(addons.FtrawEnableAddon):
     grib_mv = grib_move = _std_move
 
     def _pack_stream(self, source, stdout=True):
-        cmd = ['cat', ]
+        cmd = [
+            "cat",
+        ]
         cmd.extend(self._std_grib_index_get(source))
         return self.sh.popen(cmd, stdout=stdout, bufsize=8192)
 
@@ -159,14 +197,14 @@ class GRIB_Tool(addons.FtrawEnableAddon):
             total += size
         return total
 
-    def xgrib_pack(self, source, destination, intent='in'):
+    def xgrib_pack(self, source, destination, intent="in"):
         """Manually pack a multi GRIB."""
         if isinstance(destination, str):
             tmpfile = self.sh.safe_fileaddsuffix(destination)
-            with open(tmpfile, 'wb') as fd:
+            with open(tmpfile, "wb") as fd:
                 p = self._pack_stream(source, stdout=fd)
             self.sh.pclose(p)
-            if intent == 'in':
+            if intent == "in":
                 self.sh.chmod(tmpfile, 0o444)
             return self.sh.move(tmpfile, destination)
         else:
@@ -177,13 +215,16 @@ class GRIB_Tool(addons.FtrawEnableAddon):
     def _std_forcepack(self, source, destination=None):
         """Returned a path to a packed data."""
         if self.is_xgrib(source):
-            destination = (destination if destination else
-                           self.sh.safe_fileaddsuffix(source))
+            destination = (
+                destination
+                if destination
+                else self.sh.safe_fileaddsuffix(source)
+            )
             if not self.sh.path.exists(destination):
                 if self.xgrib_pack(source, destination):
                     return destination
                 else:
-                    raise OSError('XGrib packing failed')
+                    raise OSError("XGrib packing failed")
             else:
                 return destination
         else:
@@ -191,8 +232,16 @@ class GRIB_Tool(addons.FtrawEnableAddon):
 
     grib_forcepack = _std_forcepack
 
-    def _std_ftput(self, source, destination, hostname=None, logname=None,
-                   port=DEFAULT_FTP_PORT, cpipeline=None, sync=False):
+    def _std_ftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+        sync=False,
+    ):
         """On the fly packing and ftp."""
         if self.is_xgrib(source):
             if cpipeline is not None:
@@ -202,19 +251,35 @@ class GRIB_Tool(addons.FtrawEnableAddon):
             if ftp:
                 packed_size = self._packed_size(source)
                 p = self._pack_stream(source)
-                rc = ftp.put(p.stdout, destination, size=packed_size, exact=True)
+                rc = ftp.put(
+                    p.stdout, destination, size=packed_size, exact=True
+                )
                 self.sh.pclose(p)
                 ftp.close()
             else:
                 rc = False
             return rc
         else:
-            return self.sh.ftput(source, destination, hostname=hostname,
-                                 logname=logname, port=port,
-                                 cpipeline=cpipeline, sync=sync)
+            return self.sh.ftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                sync=sync,
+            )
 
-    def _std_rawftput(self, source, destination, hostname=None, logname=None,
-                      port=None, cpipeline=None, sync=False):
+    def _std_rawftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Use ftserv as much as possible."""
         if self.is_xgrib(source):
             if cpipeline is not None:
@@ -222,52 +287,82 @@ class GRIB_Tool(addons.FtrawEnableAddon):
             if self.sh.ftraw and self.rawftshell is not None:
                 # Copy the GRIB pieces individually
                 pieces = self.xgrib_index_get(source)
-                newsources = [str(self.sh.copy2ftspool(piece)) for piece in pieces]
-                request = newsources[0] + '.request'
-                with open(request, 'w') as request_fh:
-                    request_fh.writelines('\n'.join(newsources))
+                newsources = [
+                    str(self.sh.copy2ftspool(piece)) for piece in pieces
+                ]
+                request = newsources[0] + ".request"
+                with open(request, "w") as request_fh:
+                    request_fh.writelines("\n".join(newsources))
                 self.sh.readonly(request)
-                rc = self.sh.ftserv_put(request, destination,
-                                        hostname=hostname, logname=logname, port=port,
-                                        specialshell=self.rawftshell, sync=sync)
+                rc = self.sh.ftserv_put(
+                    request,
+                    destination,
+                    hostname=hostname,
+                    logname=logname,
+                    port=port,
+                    specialshell=self.rawftshell,
+                    sync=sync,
+                )
                 self.sh.rm(request)
                 return rc
             else:
                 if port is None:
                     port = DEFAULT_FTP_PORT
-                return self._std_ftput(source, destination,
-                                       hostname=hostname, logname=logname,
-                                       port=port, sync=sync)
+                return self._std_ftput(
+                    source,
+                    destination,
+                    hostname=hostname,
+                    logname=logname,
+                    port=port,
+                    sync=sync,
+                )
         else:
-            return self.sh.rawftput(source, destination, hostname=hostname,
-                                    logname=logname, port=port,
-                                    cpipeline=cpipeline, sync=sync)
+            return self.sh.rawftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                sync=sync,
+            )
 
     grib_ftput = _std_ftput
     grib_rawftput = _std_rawftput
 
-    def _std_scpput(self, source, destination, hostname, logname=None, cpipeline=None):
+    def _std_scpput(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """On the fly packing and scp."""
         if self.is_xgrib(source):
             if cpipeline is not None:
                 raise OSError("It's not allowed to compress xgrib files.")
-            logname = self.sh.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
+            logname = self.sh.fix_ftuser(
+                hostname, logname, fatal=False, defaults_to_user=False
+            )
             ssh = self.sh.ssh(hostname, logname)
             permissions = ssh.get_permissions(source)
             # remove the .d companion directory (scp_stream removes the destination)
             # go on on failure : the .d lingers on, but the grib will be self-contained
-            ssh.remove(destination + '.d')
+            ssh.remove(destination + ".d")
             p = self._pack_stream(source)
-            rc = ssh.scpput_stream(p.stdout, destination, permissions=permissions)
+            rc = ssh.scpput_stream(
+                p.stdout, destination, permissions=permissions
+            )
             self.sh.pclose(p)
             return rc
         else:
-            return self.sh.scpput(source, destination, hostname,
-                                  logname=logname, cpipeline=cpipeline)
+            return self.sh.scpput(
+                source,
+                destination,
+                hostname,
+                logname=logname,
+                cpipeline=cpipeline,
+            )
 
     grib_scpput = _std_scpput
 
-    @addons.require_external_addon('ecfs')
+    @addons.require_external_addon("ecfs")
     def grib_ecfsput(self, source, target, cpipeline=None, options=None):
         """Put a grib resource using ECfs.
 
@@ -282,25 +377,33 @@ class GRIB_Tool(addons.FtrawEnableAddon):
                 raise OSError("It's not allowed to compress xgrib files.")
             psource = self.sh.safe_fileaddsuffix(source)
             try:
-                rc = self.xgrib_pack(source=source,
-                                     destination=psource)
+                rc = self.xgrib_pack(source=source, destination=psource)
                 dict_args = dict()
                 if rc:
-                    rc, dict_args = self.sh.ecfsput(source=psource,
-                                                    target=target,
-                                                    options=options)
+                    rc, dict_args = self.sh.ecfsput(
+                        source=psource, target=target, options=options
+                    )
             finally:
                 self.sh.rm(psource)
             return rc, dict_args
         else:
-            return self.sh.ecfsput(source=source,
-                                   target=target,
-                                   options=options,
-                                   cpipeline=cpipeline)
+            return self.sh.ecfsput(
+                source=source,
+                target=target,
+                options=options,
+                cpipeline=cpipeline,
+            )
 
-    @addons.require_external_addon('ectrans')
-    def grib_ectransput(self, source, target, gateway=None, remote=None,
-                        cpipeline=None, sync=False):
+    @addons.require_external_addon("ectrans")
+    def grib_ectransput(
+        self,
+        source,
+        target,
+        gateway=None,
+        remote=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Put a grib resource using ECtrans.
 
         :param source: source file
@@ -316,25 +419,28 @@ class GRIB_Tool(addons.FtrawEnableAddon):
                 raise OSError("It's not allowed to compress xgrib files.")
             psource = self.sh.safe_fileaddsuffix(source)
             try:
-                rc = self.xgrib_pack(source=source,
-                                     destination=psource)
+                rc = self.xgrib_pack(source=source, destination=psource)
                 dict_args = dict()
                 if rc:
-                    rc, dict_args = self.sh.raw_ectransput(source=psource,
-                                                           target=target,
-                                                           gateway=gateway,
-                                                           remote=remote,
-                                                           sync=sync)
+                    rc, dict_args = self.sh.raw_ectransput(
+                        source=psource,
+                        target=target,
+                        gateway=gateway,
+                        remote=remote,
+                        sync=sync,
+                    )
             finally:
                 self.sh.rm(psource)
             return rc, dict_args
         else:
-            return self.sh.ectransput(source=source,
-                                      target=target,
-                                      gateway=gateway,
-                                      remote=remote,
-                                      cpipeline=cpipeline,
-                                      sync=sync)
+            return self.sh.ectransput(
+                source=source,
+                target=target,
+                gateway=gateway,
+                remote=remote,
+                cpipeline=cpipeline,
+                sync=sync,
+            )
 
 
 @algo_component_deco_mixin_autodoc
@@ -356,23 +462,37 @@ class EcGribDecoMixin(AlgoComponentDecoMixin):
         gribapi_lib = None
         if rh is not None:
             if not isinstance(rh, (list, tuple)):
-                rh = [rh, ]
+                rh = [
+                    rh,
+                ]
             for a_rh in rh:
                 libs = self.system.ldd(a_rh.container.localpath())
                 a_eccodes_lib = None
                 a_gribapi_lib = None
                 for lib, path in libs.items():
-                    if re.match(r'^libeccodes(?:-[.0-9]+)?\.so(?:\.[.0-9]+)?$', lib):
+                    if re.match(
+                        r"^libeccodes(?:-[.0-9]+)?\.so(?:\.[.0-9]+)?$", lib
+                    ):
                         a_eccodes_lib = path
-                    if re.match(r'^libgrib_api(?:-[.0-9]+)?\.so(?:\.[.0-9]+)?$', lib):
+                    if re.match(
+                        r"^libgrib_api(?:-[.0-9]+)?\.so(?:\.[.0-9]+)?$", lib
+                    ):
                         a_gribapi_lib = path
                 if a_eccodes_lib:
-                    self.algoassert(eccodes_lib is None or (eccodes_lib == a_eccodes_lib),
-                                    "ecCodes library inconsistency (rh: {!s})".format(a_rh))
+                    self.algoassert(
+                        eccodes_lib is None or (eccodes_lib == a_eccodes_lib),
+                        "ecCodes library inconsistency (rh: {!s})".format(
+                            a_rh
+                        ),
+                    )
                     eccodes_lib = a_eccodes_lib
                 if a_gribapi_lib:
-                    self.algoassert(gribapi_lib is None or (gribapi_lib == a_gribapi_lib),
-                                    "grib_api library inconsistency (rh: {!s})".format(a_rh))
+                    self.algoassert(
+                        gribapi_lib is None or (gribapi_lib == a_gribapi_lib),
+                        "grib_api library inconsistency (rh: {!s})".format(
+                            a_rh
+                        ),
+                    )
                     gribapi_lib = a_gribapi_lib
         return eccodes_lib, gribapi_lib
 
@@ -380,71 +500,99 @@ class EcGribDecoMixin(AlgoComponentDecoMixin):
         """Add axtra definitions/samples to the library path."""
         for gdef in self.context.sequence.effective_inputs(role=a_role):
             local_path = gdef.rh.container.localpath()
-            new_path = (local_path if self.system.path.isdir(local_path)
-                        else self.system.path.dirname(local_path))
+            new_path = (
+                local_path
+                if self.system.path.isdir(local_path)
+                else self.system.path.dirname(local_path)
+            )
             # NB: Grib-API doesn't understand relative paths...
             new_path = self.system.path.abspath(new_path)
             self.env.setgenericpath(a_var, new_path, pos=0)
 
     def _gribapi_envsetup(self, gribapi_lib):
         """Setup environment variables for grib_api."""
-        defvar = 'GRIB_DEFINITION_PATH'
-        samplevar = 'GRIB_SAMPLES_PATH'
+        defvar = "GRIB_DEFINITION_PATH"
+        samplevar = "GRIB_SAMPLES_PATH"
         if gribapi_lib is not None:
             gribapi_root = self.system.path.dirname(gribapi_lib)
             gribapi_root = self.system.path.split(gribapi_root)[0]
-            gribapi_share = self.system.path.join(gribapi_root, 'share', 'grib_api')
+            gribapi_share = self.system.path.join(
+                gribapi_root, "share", "grib_api"
+            )
             if defvar not in self.env:
                 # This one is for compatibility with old versions of the gribapi !
-                self.env.setgenericpath(defvar,
-                                        self.system.path.join(gribapi_root, 'share', 'definitions'))
+                self.env.setgenericpath(
+                    defvar,
+                    self.system.path.join(
+                        gribapi_root, "share", "definitions"
+                    ),
+                )
                 # This should be the lastest one:
-                self.env.setgenericpath(defvar,
-                                        self.system.path.join(gribapi_share, 'definitions'))
+                self.env.setgenericpath(
+                    defvar, self.system.path.join(gribapi_share, "definitions")
+                )
             if samplevar not in self.env:
                 # This one is for compatibility with old versions of the gribapi !
-                self.env.setgenericpath(samplevar,
-                                        self.system.path.join(gribapi_root, 'ifs_samples', 'grib1'))
+                self.env.setgenericpath(
+                    samplevar,
+                    self.system.path.join(
+                        gribapi_root, "ifs_samples", "grib1"
+                    ),
+                )
                 # This should be the lastest one:
-                self.env.setgenericpath(samplevar,
-                                        self.system.path.join(gribapi_share, 'ifs_samples', 'grib1'))
+                self.env.setgenericpath(
+                    samplevar,
+                    self.system.path.join(
+                        gribapi_share, "ifs_samples", "grib1"
+                    ),
+                )
         else:
             # Use the default GRIB-API config if the ldd approach fails
-            self.export('gribapi')
+            self.export("gribapi")
         return defvar, samplevar
 
     def gribapi_setup(self, rh, opts):
         """Setup the grib_api related stuff."""
         _, gribapi_lib = self._ecgrib_libs_detext(rh)
         defvar, samplevar = self._gribapi_envsetup(gribapi_lib)
-        self._ecgrib_additional_config('AdditionalGribAPIDefinitions', defvar)
-        self._ecgrib_additional_config('AdditionalGribAPISamples', samplevar)
+        self._ecgrib_additional_config("AdditionalGribAPIDefinitions", defvar)
+        self._ecgrib_additional_config("AdditionalGribAPISamples", samplevar)
         # Recap
         for a_var in (defvar, samplevar):
-            logger.info('After gribapi_setup %s = %s', a_var, self.env.getvar(a_var))
+            logger.info(
+                "After gribapi_setup %s = %s", a_var, self.env.getvar(a_var)
+            )
 
     def _eccodes_envsetup(self, eccodes_lib):
         """Setup environment variables for ecCodes."""
-        dep_warn = ("%s is left unconfigured because the old grib_api's variable is defined." +
-                    "Please remove that !")
+        dep_warn = (
+            "%s is left unconfigured because the old grib_api's variable is defined."
+            + "Please remove that !"
+        )
         eccodes_root = self.system.path.dirname(eccodes_lib)
         eccodes_root = self.system.path.split(eccodes_root)[0]
-        eccodes_share = self.system.path.join(eccodes_root, 'share', 'eccodes')
-        defvar = 'ECCODES_DEFINITION_PATH'
+        eccodes_share = self.system.path.join(eccodes_root, "share", "eccodes")
+        defvar = "ECCODES_DEFINITION_PATH"
         if defvar not in self.env:
-            if 'GRIB_DEFINITION_PATH' in self.env:
+            if "GRIB_DEFINITION_PATH" in self.env:
                 logger.warning(dep_warn, defvar)
-                defvar = 'GRIB_DEFINITION_PATH'
+                defvar = "GRIB_DEFINITION_PATH"
             else:
-                self.env.setgenericpath(defvar, self.system.path.join(eccodes_share, 'definitions'))
-        samplevar = 'ECCODES_SAMPLES_PATH'
+                self.env.setgenericpath(
+                    defvar, self.system.path.join(eccodes_share, "definitions")
+                )
+        samplevar = "ECCODES_SAMPLES_PATH"
         if samplevar not in self.env:
-            if 'GRIB_SAMPLES_PATH' in self.env:
+            if "GRIB_SAMPLES_PATH" in self.env:
                 logger.warning(dep_warn, samplevar)
-                samplevar = 'GRIB_SAMPLES_PATH'
+                samplevar = "GRIB_SAMPLES_PATH"
             else:
-                self.env.setgenericpath(samplevar,
-                                        self.system.path.join(eccodes_share, 'ifs_samples', 'grib1'))
+                self.env.setgenericpath(
+                    samplevar,
+                    self.system.path.join(
+                        eccodes_share, "ifs_samples", "grib1"
+                    ),
+                )
         return defvar, samplevar
 
     def eccodes_setup(self, rh, opts, compat=False, fatal=True):
@@ -462,26 +610,38 @@ class EcGribDecoMixin(AlgoComponentDecoMixin):
             defvar, samplevar = self._gribapi_envsetup(gribapi_lib)
         else:
             if fatal:
-                raise RuntimeError('No suitable configuration found for ecCodes.')
+                raise RuntimeError(
+                    "No suitable configuration found for ecCodes."
+                )
             else:
                 logger.error("ecCodes was not found !")
                 return
         # Then, inspect the context to look for customised search paths
-        self._ecgrib_additional_config(('AdditionalGribAPIDefinitions', 'AdditionalEcCodesDefinitions'),
-                                       defvar)
-        self._ecgrib_additional_config(('AdditionalGribAPISamples', 'AdditionalEcCodesSamples'),
-                                       samplevar)
+        self._ecgrib_additional_config(
+            ("AdditionalGribAPIDefinitions", "AdditionalEcCodesDefinitions"),
+            defvar,
+        )
+        self._ecgrib_additional_config(
+            ("AdditionalGribAPISamples", "AdditionalEcCodesSamples"), samplevar
+        )
         # Recap
         for a_var in (defvar, samplevar):
-            logger.info('After eccodes_setup (compat=%s) : %s = %s', str(compat),
-                        a_var, self.env.getvar(a_var))
+            logger.info(
+                "After eccodes_setup (compat=%s) : %s = %s",
+                str(compat),
+                a_var,
+                self.env.getvar(a_var),
+            )
 
     def _ecgrib_mixin_setup(self, rh, opts):
-        self.eccodes_setup(rh, opts,
-                           compat=self._ECGRIB_SETUP_COMPAT,
-                           fatal=self._ECGRIB_SETUP_FATAL)
+        self.eccodes_setup(
+            rh,
+            opts,
+            compat=self._ECGRIB_SETUP_COMPAT,
+            fatal=self._ECGRIB_SETUP_FATAL,
+        )
 
-    _MIXIN_PREPARE_HOOKS = (_ecgrib_mixin_setup, )
+    _MIXIN_PREPARE_HOOKS = (_ecgrib_mixin_setup,)
 
 
 class GRIBAPI_Tool(addons.Addon):
@@ -490,12 +650,12 @@ class GRIBAPI_Tool(addons.Addon):
     """
 
     _footprint = dict(
-        info = 'Default GRIBAPI system interface',
-        attr = dict(
-            kind = dict(
-                values   = ['gribapi'],
+        info="Default GRIBAPI system interface",
+        attr=dict(
+            kind=dict(
+                values=["gribapi"],
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
@@ -513,17 +673,19 @@ class GRIBAPI_Tool(addons.Addon):
 
     def _spawn_wrap(self, cmd, **kw):
         """Internal method calling standard shell spawn."""
-        cmd[0] = 'bin' + self.sh.path.sep + cmd[0]
+        cmd[0] = "bin" + self.sh.path.sep + cmd[0]
         return super()._spawn_wrap(cmd, **kw)
 
     def _actual_diff(self, grib1, grib2, skipkeys, **kw):
         """Run the actual GRIBAPI command."""
-        cmd = ['grib_compare', '-r', '-b', ','.join(skipkeys), grib1, grib2]
-        kw['fatal'] = False
-        kw['output'] = False
+        cmd = ["grib_compare", "-r", "-b", ",".join(skipkeys), grib1, grib2]
+        kw["fatal"] = False
+        kw["output"] = False
         return self._spawn_wrap(cmd, **kw)
 
-    def grib_diff(self, grib1, grib2, skipkeys=('generatingProcessIdentifier',), **kw):
+    def grib_diff(
+        self, grib1, grib2, skipkeys=("generatingProcessIdentifier",), **kw
+    ):
         """
         Difference between two GRIB files (using the GRIB-API)
 
@@ -538,15 +700,15 @@ class GRIBAPI_Tool(addons.Addon):
         """
 
         # Are multipart GRIB suported ?
-        xgrib_support = 'grib' in self.sh.loaded_addons()
+        xgrib_support = "grib" in self.sh.loaded_addons()
         grib1_ori = grib1
         grib2_ori = grib2
         if xgrib_support:
             if self.sh.is_xgrib(grib1):
-                grib1 = self.sh.safe_fileaddsuffix(grib1_ori) + '_diffcat'
+                grib1 = self.sh.safe_fileaddsuffix(grib1_ori) + "_diffcat"
                 self.sh.xgrib_pack(grib1_ori, grib1)
             if self.sh.is_xgrib(grib2):
-                grib2 = self.sh.safe_fileaddsuffix(grib2_ori) + '_diffcat'
+                grib2 = self.sh.safe_fileaddsuffix(grib2_ori) + "_diffcat"
                 self.sh.xgrib_pack(grib2_ori, grib2)
 
         rc = self._actual_diff(grib1, grib2, skipkeys, **kw)

--- a/src/vortex/tools/lfi.py
+++ b/src/vortex/tools/lfi.py
@@ -29,7 +29,7 @@ logger = loggers.getLogger(__name__)
 
 def use_in_shell(sh, **kw):
     """Extend current shell with the LFI interface defined by optional arguments."""
-    kw['shell'] = sh
+    kw["shell"] = sh
     return footprints.proxy.addon(**kw)
 
 
@@ -49,7 +49,9 @@ class LFI_Status:
         self._result = result or list()
 
     def __str__(self):
-        return '{:s} | rc={:d} result={:d}>'.format(repr(self).rstrip('>'), self.rc, len(self.result))
+        return "{:s} | rc={:d} result={:d}>".format(
+            repr(self).rstrip(">"), self.rc, len(self.result)
+        )
 
     @property
     def ok(self):
@@ -107,42 +109,44 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
     Interface to LFI commands through Perl wrappers.
     """
 
-    LFI_HNDL_SPEC = ':1'
+    LFI_HNDL_SPEC = ":1"
     DR_HOOK_SILENT = 1
     DR_HOOK_NOT_MPI = 1
     DR_HOOK_ASSERT_MPI_INITIALIZED = 0
-    OMP_STACKSIZE = '32M'
-    KMP_STACKSIZE = '32M'
-    KMP_MONITOR_STACKSIZE = '32M'
+    OMP_STACKSIZE = "32M"
+    KMP_STACKSIZE = "32M"
+    KMP_MONITOR_STACKSIZE = "32M"
 
     _footprint = dict(
-        info = 'Default LFI system interface (Perl)',
-        attr = dict(
-            kind = dict(
-                values   = ['lfi'],
+        info="Default LFI system interface (Perl)",
+        attr=dict(
+            kind=dict(
+                values=["lfi"],
             ),
-            cmd = dict(
-                alias    = ('lficmd',),
-                default  = 'lfitools',
+            cmd=dict(
+                alias=("lficmd",),
+                default="lfitools",
             ),
-            path = dict(
-                alias    = ('lfipath',),
+            path=dict(
+                alias=("lfipath",),
             ),
-            warnpack = dict(
-                type     = bool,
-                optional = True,
-                default  = False,
+            warnpack=dict(
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            wraplanguage = dict(
-                values   = ['perl', ],
-                default  = 'perl',
-                optional = True,
-                doc_visibility = footprints.doc.visibility.ADVANCED,
+            wraplanguage=dict(
+                values=[
+                    "perl",
+                ],
+                default="perl",
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
             ),
-            toolkind = dict(
-                default  = 'lfitools',
+            toolkind=dict(
+                default="lfitools",
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
@@ -154,7 +158,9 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
     def lfitools_path(self):
         ctxtag = contexts.Context.tag_focus()
         if ctxtag not in self._lfitools_path:
-            self._lfitools_path[ctxtag] = self.sh.path.join(self.actual_path, self.actual_cmd)
+            self._lfitools_path[ctxtag] = self.sh.path.join(
+                self.actual_path, self.actual_cmd
+            )
             self.sh.xperm(self._lfitools_path[ctxtag], force=True)
         return self._lfitools_path[ctxtag]
 
@@ -166,14 +172,20 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
     def _spawn_wrap(self, func, cmd, **kw):
         """Tube to set LFITOOLS env variable."""
         self.env.LFITOOLS = self.lfitools_path
-        return super()._spawn_wrap(['lfi_' + func, ] + cmd, **kw)
+        return super()._spawn_wrap(
+            [
+                "lfi_" + func,
+            ]
+            + cmd,
+            **kw,
+        )
 
     def is_xlfi(self, source):
         """Check if the given ``source`` is a multipart-lfi file."""
         rc = False
         if source and isinstance(source, str) and self.sh.path.exists(source):
-            with open(source, 'rb') as fd:
-                rc = fd.read(8) == b'LFI_ALTM'
+            with open(source, "rb") as fd:
+                rc = fd.read(8) == b"LFI_ALTM"
         return rc
 
     def _std_table(self, lfifile, **kw):
@@ -184,13 +196,13 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
           * lfifile : lfi file name
 
         """
-        cmd = ['lfilist', lfifile]
-        kw['output'] = True
+        cmd = ["lfilist", lfifile]
+        kw["output"] = True
         rawout = self._spawn(cmd, **kw)
         return LFI_Status(
             rc=0,
             stdout=rawout,
-            result=[tuple(eval(x)[0]) for x in rawout if x.startswith('[')]
+            result=[tuple(eval(x)[0]) for x in rawout if x.startswith("[")],
         )
 
     fa_table = lfi_table = _std_table
@@ -208,39 +220,39 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
           * skipfields : LFI fields not to be compared
           * skiplength : Offset at which the comparison starts for each LFI fields
         """
-        cmd = ['lfidiff', '--lfi-file-1', lfi1, '--lfi-file-2', lfi2]
+        cmd = ["lfidiff", "--lfi-file-1", lfi1, "--lfi-file-2", lfi2]
 
-        maxprint = kw.pop('maxprint', 2)
+        maxprint = kw.pop("maxprint", 2)
         if maxprint:
-            cmd.extend(['--max-print-diff', str(maxprint)])
+            cmd.extend(["--max-print-diff", str(maxprint)])
 
-        skipfields = kw.pop('skipfields', 0)
+        skipfields = kw.pop("skipfields", 0)
         if skipfields:
-            cmd.extend(['--lfi-skip-fields', str(skipfields)])
+            cmd.extend(["--lfi-skip-fields", str(skipfields)])
 
-        skiplength = kw.pop('skiplength', 0)
+        skiplength = kw.pop("skiplength", 0)
         if skiplength:
-            cmd.extend(['--lfi-skip-length', str(skiplength)])
+            cmd.extend(["--lfi-skip-length", str(skiplength)])
 
-        kw['output'] = True
+        kw["output"] = True
 
         rawout = self._spawn(cmd, **kw)
-        fields = [tuple(x.split(' ', 2)[-2:]) for x in rawout if re.match(r' (?:\!=|\+\+|\-\-)', x)]
+        fields = [
+            tuple(x.split(" ", 2)[-2:])
+            for x in rawout
+            if re.match(r" (?:\!=|\+\+|\-\-)", x)
+        ]
 
         trfields = Tracker(
-            deleted=[x[1] for x in fields if x[0] == '--'],
-            created=[x[1] for x in fields if x[0] == '++'],
-            updated=[x[1] for x in fields if x[0] == '!='],
+            deleted=[x[1] for x in fields if x[0] == "--"],
+            created=[x[1] for x in fields if x[0] == "++"],
+            updated=[x[1] for x in fields if x[0] == "!="],
         )
 
         stlist = self.lfi_table(lfi1, output=True)
         trfields.unchanged = {x[0] for x in stlist.result} - set(trfields)
 
-        return LFI_Status(
-            rc=int(bool(fields)),
-            stdout=rawout,
-            result=trfields
-        )
+        return LFI_Status(rc=int(bool(fields)), stdout=rawout, result=trfields)
 
     fa_diff = lfi_diff = _std_diff
 
@@ -253,17 +265,29 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
           * fa2 : The new empty file
 
         """
-        cmd = ['faempty', fa1, fa2]
+        cmd = ["faempty", fa1, fa2]
         self._spawn(cmd, **kw)
 
     def _pack_stream(self, source):
-        return self._spawn_wrap('pack', [source, ],
-                                output=False,
-                                inpipe=True,
-                                bufsize=8192)
+        return self._spawn_wrap(
+            "pack",
+            [
+                source,
+            ],
+            output=False,
+            inpipe=True,
+            bufsize=8192,
+        )
 
     def _packed_size(self, source):
-        out = self._spawn_wrap('size', [source, ], output=True, inpipe=False)
+        out = self._spawn_wrap(
+            "size",
+            [
+                source,
+            ],
+            output=True,
+            inpipe=False,
+        )
         try:
             return int(out[0])
         except ValueError:
@@ -273,14 +297,19 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
     def _std_forcepack(self, source, destination=None):
         """Returned a path to a packed data."""
         if self.is_xlfi(source):
-            destination = (destination if destination else
-                           self.sh.safe_fileaddsuffix(source))
+            destination = (
+                destination
+                if destination
+                else self.sh.safe_fileaddsuffix(source)
+            )
             if not self.sh.path.exists(destination):
-                st = self._std_copy(source=source, destination=destination, pack=True)
+                st = self._std_copy(
+                    source=source, destination=destination, pack=True
+                )
                 if st:
                     return destination
                 else:
-                    raise OSError('XLFI packing failed')
+                    raise OSError("XLFI packing failed")
             else:
                 return destination
         else:
@@ -288,8 +317,16 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
 
     fa_forcepack = lfi_forcepack = _std_forcepack
 
-    def _std_ftput(self, source, destination, hostname=None, logname=None,
-                   port=DEFAULT_FTP_PORT, cpipeline=None, sync=False):
+    def _std_ftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+        sync=False,
+    ):
         """On the fly packing and ftp."""
         if self.is_xlfi(source):
             if cpipeline is not None:
@@ -301,64 +338,100 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
             if ftp:
                 packed_size = self._packed_size(source)
                 p = self._pack_stream(source)
-                st.rc = ftp.put(p.stdout, destination, size=packed_size, exact=True)
+                st.rc = ftp.put(
+                    p.stdout, destination, size=packed_size, exact=True
+                )
                 self.sh.pclose(p)
                 st.result = [destination]
                 st.stdout = [
-                    'Connection time   : {:f}'.format(ftp.length),
-                    'Packed source size: {:d}'.format(packed_size),
-                    'Actual target size: {:d}'.format(ftp.size(destination))
+                    "Connection time   : {:f}".format(ftp.length),
+                    "Packed source size: {:d}".format(packed_size),
+                    "Actual target size: {:d}".format(ftp.size(destination)),
                 ]
                 ftp.close()
             else:
                 st.rc = 1
-                st.result = ['Could not connect to ' + hostname + ' as user ' + logname]
+                st.result = [
+                    "Could not connect to " + hostname + " as user " + logname
+                ]
             return st
         else:
-            return self.sh.ftput(source, destination, hostname=hostname,
-                                 logname=logname, cpipeline=cpipeline,
-                                 port=port, sync=sync)
+            return self.sh.ftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                cpipeline=cpipeline,
+                port=port,
+                sync=sync,
+            )
 
-    def _std_rawftput(self, source, destination, hostname=None, logname=None,
-                      port=None, cpipeline=None, sync=False):
+    def _std_rawftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Use ftserv as much as possible."""
         if self.is_xlfi(source):
             if cpipeline is not None:
                 raise OSError("It's not allowed to compress xlfi files.")
             if self.sh.ftraw and self.rawftshell is not None:
-                newsource = self.sh.copy2ftspool(source, fmt='lfi')
-                rc = self.sh.ftserv_put(newsource, destination,
-                                        hostname=hostname, logname=logname, port=port,
-                                        specialshell=self.rawftshell, sync=sync)
+                newsource = self.sh.copy2ftspool(source, fmt="lfi")
+                rc = self.sh.ftserv_put(
+                    newsource,
+                    destination,
+                    hostname=hostname,
+                    logname=logname,
+                    port=port,
+                    specialshell=self.rawftshell,
+                    sync=sync,
+                )
                 self.sh.rm(newsource)  # Delete the request file
                 return rc
             else:
                 if port is None:
                     port = DEFAULT_FTP_PORT
-                return self._std_ftput(source, destination, hostname, logname,
-                                       port=port, sync=sync)
+                return self._std_ftput(
+                    source,
+                    destination,
+                    hostname,
+                    logname,
+                    port=port,
+                    sync=sync,
+                )
         else:
-            return self.sh.rawftput(source, destination, hostname=hostname,
-                                    logname=logname, port=port,
-                                    cpipeline=cpipeline, sync=sync)
+            return self.sh.rawftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                sync=sync,
+            )
 
     fa_ftput = lfi_ftput = _std_ftput
     fa_rawftput = lfi_rawftput = _std_rawftput
 
-    def _std_prepare(self, source, destination, intent='in'):
+    def _std_prepare(self, source, destination, intent="in"):
         """Check for the source and prepare the destination."""
-        if intent not in ('in', 'inout'):
-            raise ValueError('Incorrect value for intent ({})'.format(intent))
+        if intent not in ("in", "inout"):
+            raise ValueError("Incorrect value for intent ({})".format(intent))
         st = LFI_Status()
         if not self.sh.path.exists(source):
-            logger.error('Missing source %s', source)
+            logger.error("Missing source %s", source)
             st.rc = 2
-            st.stderr = 'No such source file or directory : [' + source + ']'
+            st.stderr = "No such source file or directory : [" + source + "]"
             return st
         if not self.sh.filecocoon(destination):
-            raise OSError('Could not cocoon [' + destination + ']')
+            raise OSError("Could not cocoon [" + destination + "]")
         if not self.lfi_rm(destination):
-            raise OSError('Could not clean destination [' + destination + ']')
+            raise OSError("Could not clean destination [" + destination + "]")
         return st
 
     def _std_remove(self, *args):
@@ -366,16 +439,30 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
         st = LFI_Status(result=list())
         for pname in args:
             for objpath in self.sh.glob(pname):
-                rc = self._spawn_wrap('remove', [objpath, ], output=False)
-                st.result.append(dict(path=objpath,
-                                      multi=self.is_xlfi(objpath), rc=rc))
+                rc = self._spawn_wrap(
+                    "remove",
+                    [
+                        objpath,
+                    ],
+                    output=False,
+                )
+                st.result.append(
+                    dict(path=objpath, multi=self.is_xlfi(objpath), rc=rc)
+                )
                 st.rc = rc
         return st
 
     lfi_rm = lfi_remove = fa_rm = fa_remove = _std_remove
 
-    def _std_copy(self, source, destination,
-                  smartcp_threshold=0, intent='in', pack=False, silent=False):
+    def _std_copy(
+        self,
+        source,
+        destination,
+        smartcp_threshold=0,
+        intent="in",
+        pack=False,
+        silent=False,
+    ):
         """Extended copy for (possibly) multi lfi file."""
         st = self._std_prepare(source, destination, intent)
         if st.rc == 0:
@@ -385,23 +472,48 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
             actual_intent = intent
             if ln_cross_users and not self.sh.allow_cross_users_links:
                 actual_pack = True
-                actual_intent = 'inout'
+                actual_intent = "inout"
             try:
-                st.rc = self._spawn_wrap('copy', (['-pack', ] if actual_pack else []) +
-                                         ['-intent={}'.format(actual_intent), source, destination],
-                                         output=False)
+                st.rc = self._spawn_wrap(
+                    "copy",
+                    (
+                        [
+                            "-pack",
+                        ]
+                        if actual_pack
+                        else []
+                    )
+                    + [
+                        "-intent={}".format(actual_intent),
+                        source,
+                        destination,
+                    ],
+                    output=False,
+                )
             except systems.ExecutionError:
                 if self.sh.allow_cross_users_links and ln_cross_users:
                     # This is expected to fail if the fs.protected_hardlinks
                     # Linux kernel setting is 1.
-                    logger.info("Force System's allow_cross_users_links to False")
+                    logger.info(
+                        "Force System's allow_cross_users_links to False"
+                    )
                     self.sh.allow_cross_users_links = False
                     logger.info("Re-running the cp command on this LFI file")
-                    st = self._std_copy(source, destination, intent=intent, pack=pack, silent=silent)
+                    st = self._std_copy(
+                        source,
+                        destination,
+                        intent=intent,
+                        pack=pack,
+                        silent=silent,
+                    )
                 else:
                     raise
             else:
-                if ln_cross_users and not self.sh.allow_cross_users_links and intent == 'in':
+                if (
+                    ln_cross_users
+                    and not self.sh.allow_cross_users_links
+                    and intent == "in"
+                ):
                     self.sh.readonly(destination)
         return st
 
@@ -411,12 +523,23 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
         """Extended mv for (possibly) multi lfi file."""
         if self.is_xlfi(source):
             if intent is None:
-                intent = 'inout' if self.sh.access(source, self.sh.W_OK) else 'in'
+                intent = (
+                    "inout" if self.sh.access(source, self.sh.W_OK) else "in"
+                )
             st = self._std_prepare(source, destination, intent)
             if st.rc == 0:
-                st.rc = self._spawn_wrap('move', (['-pack', ] if pack else []) +
-                                         ['-intent={}'.format(intent), source, destination],
-                                         output=False)
+                st.rc = self._spawn_wrap(
+                    "move",
+                    (
+                        [
+                            "-pack",
+                        ]
+                        if pack
+                        else []
+                    )
+                    + ["-intent={}".format(intent), source, destination],
+                    output=False,
+                )
         else:
             st = LFI_Status()
             st.rc = self.sh.mv(source, destination)
@@ -424,27 +547,35 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
 
     lfi_mv = lfi_move = fa_mv = fa_move = _std_move
 
-    def _std_scpput(self, source, destination, hostname, logname=None, cpipeline=None):
+    def _std_scpput(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """On the fly packing and scp."""
         if not self.is_xlfi(source):
-            rc = self.sh.scpput(source, destination, hostname, logname, cpipeline)
+            rc = self.sh.scpput(
+                source, destination, hostname, logname, cpipeline
+            )
         else:
             if cpipeline is not None:
                 raise OSError("It's not allowed to compress xlfi files.")
-            logname = self.sh.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
+            logname = self.sh.fix_ftuser(
+                hostname, logname, fatal=False, defaults_to_user=False
+            )
             ssh = self.sh.ssh(hostname, logname)
             permissions = ssh.get_permissions(source)
             # remove the .d companion directory (scp_stream removes the destination)
             # go on on failure : the .d lingers on, but the lfi will be self-contained
-            ssh.remove(destination + '.d')
+            ssh.remove(destination + ".d")
             p = self._pack_stream(source)
-            rc = ssh.scpput_stream(p.stdout, destination, permissions=permissions)
+            rc = ssh.scpput_stream(
+                p.stdout, destination, permissions=permissions
+            )
             self.sh.pclose(p)
         return rc
 
     fa_scpput = lfi_scpput = _std_scpput
 
-    @addons.require_external_addon('ecfs')
+    @addons.require_external_addon("ecfs")
     def _std_ecfsput(self, source, target, cpipeline=None, options=None):
         """
         :param source: source file
@@ -459,29 +590,38 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
             psource = self.sh.safe_fileaddsuffix(source)
             rc = LFI_Status()
             try:
-                st = self._std_copy(source=source,
-                                    destination=psource,
-                                    pack=True)
+                st = self._std_copy(
+                    source=source, destination=psource, pack=True
+                )
                 rc = rc and st.rc
                 dict_args = dict()
                 if rc:
-                    rc, dict_args = self.sh.ecfsput(source=psource,
-                                                    target=target,
-                                                    options=options)
+                    rc, dict_args = self.sh.ecfsput(
+                        source=psource, target=target, options=options
+                    )
             finally:
                 self.sh.rm(psource)
             return rc, dict_args
         else:
-            return self.sh.ecfsput(source=source,
-                                   target=target,
-                                   options=options,
-                                   cpipeline=cpipeline)
+            return self.sh.ecfsput(
+                source=source,
+                target=target,
+                options=options,
+                cpipeline=cpipeline,
+            )
 
     fa_ecfsput = lfi_ecfsput = _std_ecfsput
 
-    @addons.require_external_addon('ectrans')
-    def _std_ectransput(self, source, target, gateway=None, remote=None,
-                        cpipeline=None, sync=False):
+    @addons.require_external_addon("ectrans")
+    def _std_ectransput(
+        self,
+        source,
+        target,
+        gateway=None,
+        remote=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """
         :param source: source file
         :param target: target file
@@ -497,27 +637,31 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
             psource = self.sh.safe_fileaddsuffix(source)
             rc = LFI_Status()
             try:
-                st = self._std_copy(source=source,
-                                    destination=psource,
-                                    pack=True)
+                st = self._std_copy(
+                    source=source, destination=psource, pack=True
+                )
                 rc = rc and st.rc
                 dict_args = dict()
                 if rc:
-                    rc, dict_args = self.sh.raw_ectransput(source=psource,
-                                                           target=target,
-                                                           gateway=gateway,
-                                                           remote=remote,
-                                                           sync=sync)
+                    rc, dict_args = self.sh.raw_ectransput(
+                        source=psource,
+                        target=target,
+                        gateway=gateway,
+                        remote=remote,
+                        sync=sync,
+                    )
             finally:
                 self.sh.rm(psource)
             return rc, dict_args
         else:
-            return self.sh.ectransput(source=source,
-                                      target=target,
-                                      gateway=gateway,
-                                      remote=remote,
-                                      cpipeline=cpipeline,
-                                      sync=sync)
+            return self.sh.ectransput(
+                source=source,
+                target=target,
+                gateway=gateway,
+                remote=remote,
+                cpipeline=cpipeline,
+                sync=sync,
+            )
 
     fa_ectransput = lfi_ectransput = _std_ectransput
 
@@ -530,20 +674,23 @@ class LFI_Tool_Py(LFI_Tool_Raw):
     """
 
     _footprint = dict(
-        info = 'Default LFI system interface (Python)',
-        attr = dict(
-            wraplanguage = dict(
-                values   = ['python', ],
+        info="Default LFI system interface (Python)",
+        attr=dict(
+            wraplanguage=dict(
+                values=[
+                    "python",
+                ],
             ),
-        )
+        ),
     )
 
     def _pack_stream(self, source):
-        return self._spawn(['lfi_alt_pack', '--lfi-file-in', source,
-                            '--lfi-file-out', '-'],
-                           output=False,
-                           inpipe=True,
-                           bufsize=8192)
+        return self._spawn(
+            ["lfi_alt_pack", "--lfi-file-in", source, "--lfi-file-out", "-"],
+            output=False,
+            inpipe=True,
+            bufsize=8192,
+        )
 
     def _std_remove(self, *args):
         """Remove (possibly) multi lfi files."""
@@ -552,12 +699,14 @@ class LFI_Tool_Py(LFI_Tool_Raw):
             for objpath in self.sh.glob(pname):
                 xlfi = self.is_xlfi(objpath)
                 if xlfi:
-                    rc = self._spawn(['lfi_alt_remv', '--lfi-file', objpath], output=False)
+                    rc = self._spawn(
+                        ["lfi_alt_remv", "--lfi-file", objpath], output=False
+                    )
                 else:
                     rc = self.sh.remove(objpath)
                 st.result.append(dict(path=objpath, multi=xlfi, rc=rc))
                 st.rc = rc
-            for dirpath in self.sh.glob(pname + '.d'):
+            for dirpath in self.sh.glob(pname + ".d"):
                 if self.sh.path.exists(dirpath):
                     rc = self.sh.remove(dirpath)
                     st.result.append(dict(path=dirpath, multi=True, rc=rc))
@@ -568,29 +717,61 @@ class LFI_Tool_Py(LFI_Tool_Raw):
 
     def _cp_pack_read(self, source, destination):
         if self.warnpack:
-            logger.warning('Suspicious packing <%s>', source)
-        rc = self._spawn(['lfi_alt_pack', '--lfi-file-in', source, '--lfi-file-out', destination],
-                         output=False)
+            logger.warning("Suspicious packing <%s>", source)
+        rc = self._spawn(
+            [
+                "lfi_alt_pack",
+                "--lfi-file-in",
+                source,
+                "--lfi-file-out",
+                destination,
+            ],
+            output=False,
+        )
         self.sh.chmod(destination, 0o444)
         return rc
 
     def _cp_pack_write(self, source, destination):
         if self.warnpack:
-            logger.warning('Suspicious packing <%s>', source)
-        rc = self._spawn(['lfi_alt_pack', '--lfi-file-in', source, '--lfi-file-out', destination],
-                         output=False)
+            logger.warning("Suspicious packing <%s>", source)
+        rc = self._spawn(
+            [
+                "lfi_alt_pack",
+                "--lfi-file-in",
+                source,
+                "--lfi-file-out",
+                destination,
+            ],
+            output=False,
+        )
         self.sh.chmod(destination, 0o644)
         return rc
 
     def _cp_copy_read(self, source, destination):
-        rc = self._spawn(['lfi_alt_copy', '--lfi-file-in', source, '--lfi-file-out', destination],
-                         output=False)
+        rc = self._spawn(
+            [
+                "lfi_alt_copy",
+                "--lfi-file-in",
+                source,
+                "--lfi-file-out",
+                destination,
+            ],
+            output=False,
+        )
         self.sh.chmod(destination, 0o444)
         return rc
 
     def _cp_copy_write(self, source, destination):
-        rc = self._spawn(['lfi_alt_copy', '--lfi-file-in', source, '--lfi-file-out', destination],
-                         output=False)
+        rc = self._spawn(
+            [
+                "lfi_alt_copy",
+                "--lfi-file-in",
+                source,
+                "--lfi-file-out",
+                destination,
+            ],
+            output=False,
+        )
         self.sh.chmod(destination, 0o644)
         return rc
 
@@ -604,38 +785,55 @@ class LFI_Tool_Py(LFI_Tool_Raw):
     _cp_nopack_fsko_read = _cp_pack_read
     _cp_nopack_fsko_write = _cp_pack_write
 
-    def _multicpmethod(self, pack=False, intent='in', samefs=False):
-        return '_cp_{:s}_{:s}_{:s}'.format(
-            'aspack' if pack else 'nopack',
-            'fsok' if samefs else 'fsko',
-            'read' if intent == 'in' else 'write',
+    def _multicpmethod(self, pack=False, intent="in", samefs=False):
+        return "_cp_{:s}_{:s}_{:s}".format(
+            "aspack" if pack else "nopack",
+            "fsok" if samefs else "fsko",
+            "read" if intent == "in" else "write",
         )
 
-    def _std_copy(self, source, destination,
-                  smartcp_threshold=0, intent='in', pack=False, silent=False):
+    def _std_copy(
+        self,
+        source,
+        destination,
+        smartcp_threshold=0,
+        intent="in",
+        pack=False,
+        silent=False,
+    ):
         """Extended copy for (possibly) multi lfi file."""
         st = LFI_Status()
         if not self.sh.path.exists(source):
-            logger.error('Missing source %s', source)
+            logger.error("Missing source %s", source)
             st.rc = 2
-            st.stderr = 'No such source file or directory : [' + source + ']'
+            st.stderr = "No such source file or directory : [" + source + "]"
             return st
         if self.is_xlfi(source):
             if not self.sh.filecocoon(destination):
-                raise OSError('Could not cocoon [' + destination + ']')
+                raise OSError("Could not cocoon [" + destination + "]")
             if not self.lfi_rm(destination):
-                raise OSError('Could not clean destination [' + destination + ']')
-            xcp = self._multicpmethod(pack=pack, intent=intent, samefs=self.sh.is_samefs(source, destination))
+                raise OSError(
+                    "Could not clean destination [" + destination + "]"
+                )
+            xcp = self._multicpmethod(
+                pack=pack,
+                intent=intent,
+                samefs=self.sh.is_samefs(source, destination),
+            )
             actualcp = getattr(self, xcp, None)
             if actualcp is None:
-                raise AttributeError('No actual LFI cp command ' + xcp)
+                raise AttributeError("No actual LFI cp command " + xcp)
             else:
                 st.rc = actualcp(source, self.sh.path.realpath(destination))
         else:
-            if intent == 'in':
-                st.rc = self.sh.smartcp(source, destination, smartcp_threshold=smartcp_threshold)
+            if intent == "in":
+                st.rc = self.sh.smartcp(
+                    source, destination, smartcp_threshold=smartcp_threshold
+                )
             else:
-                st.rc = self.sh.cp(source, destination, smartcp_threshold=smartcp_threshold)
+                st.rc = self.sh.cp(
+                    source, destination, smartcp_threshold=smartcp_threshold
+                )
         return st
 
     lfi_cp = lfi_copy = fa_cp = fa_copy = _std_copy
@@ -644,7 +842,9 @@ class LFI_Tool_Py(LFI_Tool_Raw):
         """Extended mv for (possibly) multi lfi file."""
         if self.is_xlfi(source):
             if intent is None:
-                intent = 'inout' if self.sh.access(source, self.sh.W_OK) else 'in'
+                intent = (
+                    "inout" if self.sh.access(source, self.sh.W_OK) else "in"
+                )
             st = self.lfi_cp(source, destination, intent=intent, pack=pack)
             if st:
                 st = self.lfi_rm(source)
@@ -662,72 +862,79 @@ class IO_Poll(addons.Addon):
     This addon is in charge of multi-file reshaping after IFS-ARPEGE execution.
     """
 
-    LFI_HNDL_SPEC = ':1'
+    LFI_HNDL_SPEC = ":1"
     DR_HOOK_SILENT = 1
     DR_HOOK_NOT_MPI = 1
     DR_HOOK_ASSERT_MPI_INITIALIZED = 0
-    OMP_STACKSIZE = '32M'
-    KMP_STACKSIZE = '32M'
-    KMP_MONITOR_STACKSIZE = '32M'
+    OMP_STACKSIZE = "32M"
+    KMP_STACKSIZE = "32M"
+    KMP_MONITOR_STACKSIZE = "32M"
 
     _footprint = dict(
-        info = 'Default io_poll system interface',
-        attr = dict(
-            kind = dict(
-                values  = ['iopoll', 'io_poll'],
-                remap   = dict(
-                    io_poll = 'iopoll',
-                )
+        info="Default io_poll system interface",
+        attr=dict(
+            kind=dict(
+                values=["iopoll", "io_poll"],
+                remap=dict(
+                    io_poll="iopoll",
+                ),
             ),
-            cfginfo = dict(
-                default = 'lfi',
+            cfginfo=dict(
+                default="lfi",
             ),
-            cmd = dict(
-                alias   = ('iopollcmd', 'io_pollcmd', 'io_poll_cmd'),
-                default = 'io_poll',
+            cmd=dict(
+                alias=("iopollcmd", "io_pollcmd", "io_poll_cmd"),
+                default="io_poll",
             ),
-            path = dict(
-                alias   = ('iopollpath', 'io_pollpath', 'io_poll_path', 'iopath'),
+            path=dict(
+                alias=("iopollpath", "io_pollpath", "io_poll_path", "iopath"),
             ),
-            interpreter = dict(
-                values  = ['perl', 'none', 'None'],
-                remap   = dict({'None': 'none', }),
-                default = 'perl',
-                optional = True,
+            interpreter=dict(
+                values=["perl", "none", "None"],
+                remap=dict(
+                    {
+                        "None": "none",
+                    }
+                ),
+                default="perl",
+                optional=True,
             ),
-            toolkind = dict(
-                default = 'iopoll'
-            )
-        )
+            toolkind=dict(default="iopoll"),
+        ),
     )
 
     def __init__(self, *args, **kw):
         """Abstract Addon initialisation."""
-        logger.debug('IO_Poll init %s', self.__class__)
+        logger.debug("IO_Poll init %s", self.__class__)
         super().__init__(*args, **kw)
         self._polled = set()
 
     def _spawn(self, cmd, **kw):
         """Tube to set LFITOOLS env variable."""
-        if 'LFITOOLS' not in self.env:
-            active_lfi = (LFI_Tool_Raw.in_shell(self.sh) or
-                          LFI_Tool_Py.in_shell(self.sh))
+        if "LFITOOLS" not in self.env:
+            active_lfi = LFI_Tool_Raw.in_shell(
+                self.sh
+            ) or LFI_Tool_Py.in_shell(self.sh)
             if active_lfi is None:
-                raise RuntimeError('Could not find any active LFI Tool')
-            self.env.LFITOOLS = active_lfi.actual_path + '/' + active_lfi.actual_cmd
+                raise RuntimeError("Could not find any active LFI Tool")
+            self.env.LFITOOLS = (
+                active_lfi.actual_path + "/" + active_lfi.actual_cmd
+            )
         # Is there a need for an interpreter ?
-        if self.interpreter != 'none':
-            kw['interpreter'] = self.interpreter
+        if self.interpreter != "none":
+            kw["interpreter"] = self.interpreter
         return super()._spawn(cmd, **kw)
 
     def io_poll(self, prefix, nproc_io=None):
         """Do the actual job of polling files prefixed by ``prefix``."""
-        cmd = ['--prefix', prefix]
+        cmd = ["--prefix", prefix]
         if nproc_io is None:
-            if not self.sh.path.exists('fort.4'):
-                raise OSError('The proc_io option or a fort.4 file should be provided.')
+            if not self.sh.path.exists("fort.4"):
+                raise OSError(
+                    "The proc_io option or a fort.4 file should be provided."
+                )
         else:
-            cmd.extend(['--nproc_io', str(nproc_io)])
+            cmd.extend(["--nproc_io", str(nproc_io)])
 
         # Catch the file processed
         rawout = self._spawn(cmd)

--- a/src/vortex/tools/listings.py
+++ b/src/vortex/tools/listings.py
@@ -17,7 +17,7 @@ __all__ = []
 
 def use_in_shell(sh, **kw):
     """Extend current shell with the arpifs_listings interface defined by optional arguments."""
-    kw['shell'] = sh
+    kw["shell"] = sh
     return footprints.proxy.addon(**kw)
 
 
@@ -30,10 +30,10 @@ class ArpIfsListingDiff_Result:
         self._jos_diff = jos_diff
 
     def __str__(self):
-        return '{:s} | NormsOk={:b} JoTablesOk={:b}>'.format(
-            repr(self).rstrip('>'),
+        return "{:s} | NormsOk={:b} JoTablesOk={:b}>".format(
+            repr(self).rstrip(">"),
             all(self._norms_eq.values()),
-            all(self._jos_eq.values())
+            all(self._jos_eq.values()),
         )
 
     def differences(self):
@@ -43,10 +43,24 @@ class ArpIfsListingDiff_Result:
             if all(self._norms_eq.values()):
                 print("Norms   check succeeded for all steps.")
             else:
-                print("Norms   check succeeded for steps:\n  {:s}".format(
-                    "\n  ".join([str(k) for k, v in self._norms_eq.items() if v])))
-                print("Norms   check FAILED    for steps:\n  {:s}".format(
-                    "\n  ".join([str(k) for k, v in self._norms_eq.items() if not v])))
+                print(
+                    "Norms   check succeeded for steps:\n  {:s}".format(
+                        "\n  ".join(
+                            [str(k) for k, v in self._norms_eq.items() if v]
+                        )
+                    )
+                )
+                print(
+                    "Norms   check FAILED    for steps:\n  {:s}".format(
+                        "\n  ".join(
+                            [
+                                str(k)
+                                for k, v in self._norms_eq.items()
+                                if not v
+                            ]
+                        )
+                    )
+                )
         else:
             print("No norms found in the new listing or no matching norms.")
         # print()  # activation breaks test_arpifs_listings_integration.py
@@ -62,14 +76,22 @@ class ArpIfsListingDiff_Result:
                         for otype_k, otype_v in todo.items():
                             for sensor_k, sensor_v in otype_v.items():
                                 for var_k, var_v in sensor_v.items():
-                                    if var_k == 'GLOBAL':
+                                    if var_k == "GLOBAL":
                                         continue
-                                    print("  > {:s} > {:s} > {:4s} : d_n={:<9d}  d_jo={:f}".format(
-                                        otype_k, sensor_k, var_k,
-                                        var_v['n']['diff'], var_v['jo']['diff']))
+                                    print(
+                                        "  > {:s} > {:s} > {:4s} : d_n={:<9d}  d_jo={:f}".format(
+                                            otype_k,
+                                            sensor_k,
+                                            var_k,
+                                            var_v["n"]["diff"],
+                                            var_v["jo"]["diff"],
+                                        )
+                                    )
                         diffprinted = True
         else:
-            print("No Jo-Tables were found or the number of Jo-Tables do not match.")
+            print(
+                "No Jo-Tables were found or the number of Jo-Tables do not match."
+            )
 
 
 class ArpIfsListingDiff_Status:
@@ -81,7 +103,7 @@ class ArpIfsListingDiff_Status:
         self._result = ArpIfsListingDiff_Result(norms_eq, jos_eq, jos_diff)
 
     def __str__(self):
-        return '{:s} | rc={:b}>'.format(repr(self).rstrip('>'), bool(self))
+        return "{:s} | rc={:b}>".format(repr(self).rstrip(">"), bool(self))
 
     @property
     def result(self):
@@ -96,12 +118,12 @@ class ArpIfsListingsTool(addons.Addon):
     """Interface to arpifs_listings (designed as a shell Addon)."""
 
     _footprint = dict(
-        info='Default arpifs_listings interface',
+        info="Default arpifs_listings interface",
         attr=dict(
             kind=dict(
-                values=['arpifs_listings'],
+                values=["arpifs_listings"],
             ),
-        )
+        ),
     )
 
     def arpifslist_diff(self, listing1, listing2):
@@ -147,17 +169,24 @@ class ArpIfsListingsTool(addons.Addon):
             if not l1_jos == l2_jos:
                 # If the JoTables list is not consistent: do nothing
                 if list(l1_jos.keys()) == list(l2_jos.keys()):
-                    for table1, table2 in zip(l1_jos.values(), l2_jos.values()):
+                    for table1, table2 in zip(
+                        l1_jos.values(), l2_jos.values()
+                    ):
                         jos_eq[table1.name] = table1 == table2
                         if not jos_eq[table1.name]:
                             jos_diff[table1.name] = OrderedDict()
                             # We only save differences when deltaN or deltaJo != 0
-                            for otype_k, otype_v in table2.compute_diff(table1).items():
+                            for otype_k, otype_v in table2.compute_diff(
+                                table1
+                            ).items():
                                 otype_tmp = OrderedDict()
                                 for sensor_k, sensor_v in otype_v.items():
                                     sensor_tmp = OrderedDict()
                                     for k, v in sensor_v.items():
-                                        if v['n']['diff'] != 0 or v['jo']['diff'] != 0:
+                                        if (
+                                            v["n"]["diff"] != 0
+                                            or v["jo"]["diff"] != 0
+                                        ):
                                             sensor_tmp[k] = v
                                     if len(sensor_tmp):
                                         otype_tmp[sensor_k] = sensor_tmp
@@ -174,7 +203,9 @@ class ArpifsListingsFormatAdapter(FormatAdapterAbstractImplementation):
     _footprint = dict(
         attr=dict(
             format=dict(
-                values=['ARPIFSLIST', ],
+                values=[
+                    "ARPIFSLIST",
+                ],
             ),
         )
     )
@@ -196,8 +227,15 @@ class ArpifsListingsFormatAdapter(FormatAdapterAbstractImplementation):
     def lines(self):
         """Return an array populated with the listing file lines."""
         if self._lines is None:
-            with open(self.filename, self.openmode, encoding='utf-8', errors='replace') as f:
-                self._lines = [l.rstrip("\n") for l in f]  # to remove trailing '\n'
+            with open(
+                self.filename,
+                self.openmode,
+                encoding="utf-8",
+                errors="replace",
+            ) as f:
+                self._lines = [
+                    l.rstrip("\n") for l in f
+                ]  # to remove trailing '\n'
         return self._lines
 
     def flush_lines(self):
@@ -210,7 +248,14 @@ class ArpifsListingsFormatAdapter(FormatAdapterAbstractImplementation):
         if self._end_is_reached is None:
             self._end_is_reached = False
             for line in self.lines:
-                if any([p in line for p in listings.OutputListing.patterns['end_is_reached']]):
+                if any(
+                    [
+                        p in line
+                        for p in listings.OutputListing.patterns[
+                            "end_is_reached"
+                        ]
+                    ]
+                ):
                     self._end_is_reached = True
                     break
         return self._end_is_reached
@@ -237,7 +282,9 @@ class ArpifsListingsFormatAdapter(FormatAdapterAbstractImplementation):
     def cost_functions(self):
         """Return a :class:`arpifs_listings.jo_tables.JoTables` object."""
         if self._costs is None:
-            self._costs = cost_functions.CostFunctions(self.filename, self.lines)
+            self._costs = cost_functions.CostFunctions(
+                self.filename, self.lines
+            )
             if not self.fmtdelayedopen:
                 self.flush_lines()
         return self._costs
@@ -266,12 +313,15 @@ class ListBasedCutoffDispenser:
             if f_dates:
                 f_cutoffs[k] = f_dates
         if f_cutoffs:
-            self._max_cutoff = max([max(dates) for dates in f_cutoffs.values()])
+            self._max_cutoff = max(
+                [max(dates) for dates in f_cutoffs.values()]
+            )
         else:
             self._max_cutoff = None
         self._default_cutoffs = defaultdict(lambda: self._max_cutoff)
-        self._default_cutoffs.update({k: max(dates)
-                                      for k, dates in f_cutoffs.items()})
+        self._default_cutoffs.update(
+            {k: max(dates) for k, dates in f_cutoffs.items()}
+        )
         self._fuse_per_obstype = fuse_per_obstype
 
     @property
@@ -300,15 +350,21 @@ class BdmBufrListingsFormatAdapter(FormatAdapterAbstractImplementation):
     _footprint = dict(
         attr=dict(
             format=dict(
-                values=['BDMBUFR_LISTING', ],
+                values=[
+                    "BDMBUFR_LISTING",
+                ],
             ),
         )
     )
 
-    _RE_OBSTYPE_GRP = re.compile(r"^.*tentative\s+(?:d')?extraction\s+pour\s+'?(?P<obstype>\w+)'?\b",
-                                 re.IGNORECASE)
-    _RE_OBSTYPE_CUT = re.compile(r"^.*cutoff\s+pour\s+'?(?P<obstype>\w+)'?\s*:\s*(?P<datetime>\d+)\b",
-                                 re.IGNORECASE)
+    _RE_OBSTYPE_GRP = re.compile(
+        r"^.*tentative\s+(?:d')?extraction\s+pour\s+'?(?P<obstype>\w+)'?\b",
+        re.IGNORECASE,
+    )
+    _RE_OBSTYPE_CUT = re.compile(
+        r"^.*cutoff\s+pour\s+'?(?P<obstype>\w+)'?\s*:\s*(?P<datetime>\d+)\b",
+        re.IGNORECASE,
+    )
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
@@ -321,8 +377,15 @@ class BdmBufrListingsFormatAdapter(FormatAdapterAbstractImplementation):
     def lines(self):
         """Return an array populated with the listing file lines."""
         if self._lines is None:
-            with open(self.filename, self.openmode, encoding='utf-8', errors='replace') as f:
-                self._lines = [l.rstrip("\n") for l in f]  # to remove trailing '\n'
+            with open(
+                self.filename,
+                self.openmode,
+                encoding="utf-8",
+                errors="replace",
+            ) as f:
+                self._lines = [
+                    l.rstrip("\n") for l in f
+                ]  # to remove trailing '\n'
         return self._lines
 
     @property
@@ -338,11 +401,16 @@ class BdmBufrListingsFormatAdapter(FormatAdapterAbstractImplementation):
                 if l_match:
                     if cur_obstype is not None:
                         self._cutoffs[cur_obstype].append(None)
-                    cur_obstype = l_match.group('obstype').lower()
+                    cur_obstype = l_match.group("obstype").lower()
                 if cur_obstype:
                     l_match = self._RE_OBSTYPE_CUT.match(line)
-                    if l_match and l_match.group('obstype').lower() == cur_obstype:
-                        self._cutoffs[cur_obstype].append(Date(l_match.group('datetime')))
+                    if (
+                        l_match
+                        and l_match.group("obstype").lower() == cur_obstype
+                    ):
+                        self._cutoffs[cur_obstype].append(
+                            Date(l_match.group("datetime"))
+                        )
                         cur_obstype = None
             if cur_obstype is not None:
                 self._cutoffs[cur_obstype].append(None)
@@ -350,5 +418,6 @@ class BdmBufrListingsFormatAdapter(FormatAdapterAbstractImplementation):
 
     def cutoffs_dispenser(self, fuse_per_obstype=False):
         """Return a new :class:`CutoffDispenser` object."""
-        return ListBasedCutoffDispenser(copy.deepcopy(self.cutoffs),
-                                        fuse_per_obstype=fuse_per_obstype)
+        return ListBasedCutoffDispenser(
+            copy.deepcopy(self.cutoffs), fuse_per_obstype=fuse_per_obstype
+        )

--- a/src/vortex/tools/names.py
+++ b/src/vortex/tools/names.py
@@ -17,6 +17,7 @@ logger = loggers.getLogger(__name__)
 
 class VortexNameBuilderError(ValueError):
     """Raised whenever the name building process fails."""
+
     pass
 
 
@@ -24,26 +25,39 @@ class AbstractVortexNameBuilder(footprints.FootprintBase):
     """Abstract class for any name building class."""
 
     _abstract = True
-    _collector = ('vortexnamebuilder',)
+    _collector = ("vortexnamebuilder",)
     _footprint = dict(
-        info = 'Abstract Vortex NameBuilder',
-        attr = dict(
-            name = dict(
-                info        = "The NameBuilder's name.",
+        info="Abstract Vortex NameBuilder",
+        attr=dict(
+            name=dict(
+                info="The NameBuilder's name.",
             ),
         ),
-        fastkeys = {'name'}
+        fastkeys={"name"},
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Init VortexNameBuilder %s', self.__class__)
+        logger.debug("Init VortexNameBuilder %s", self.__class__)
         super().__init__(*args, **kw)
         self._default = dict(
-            radical='vortexdata',
+            radical="vortexdata",
         )
         # List of known defaults
-        for k in ['flow', 'src', 'term', 'period', 'cen_period', 'geo', 'suffix',
-                  'stage', 'fmt', 'part', 'compute', 'number', 'filtername']:
+        for k in [
+            "flow",
+            "src",
+            "term",
+            "period",
+            "cen_period",
+            "geo",
+            "suffix",
+            "stage",
+            "fmt",
+            "part",
+            "compute",
+            "number",
+            "filtername",
+        ]:
             self._default[k] = None
         self.setdefault(**kw)
 
@@ -66,16 +80,16 @@ class AbstractVortexNameBuilder(footprints.FootprintBase):
 
     def pack_basename(self, d):
         """Returns a basename given the **d** info dictionary."""
-        raise NotImplementedError('This is an abstract method !')
+        raise NotImplementedError("This is an abstract method !")
 
     def pack_pathname(self, d):
         """Returns a pathname given the **d** info dictionary."""
-        raise NotImplementedError('This is an abstract method !')
+        raise NotImplementedError("This is an abstract method !")
 
 
 # Activate the footprint's fasttrack on the resources collector
-vbcollect = footprints.collectors.get(tag='vortexnamebuilder')
-vbcollect.fasttrack = ('name', )
+vbcollect = footprints.collectors.get(tag="vortexnamebuilder")
+vbcollect.fasttrack = ("name",)
 del vbcollect
 
 
@@ -113,7 +127,7 @@ class AbstractVortexNameBuilderProxy(AbstractVortexNameBuilder):
 
     def _pick_actual_builder(self, d):
         """Given the input dictionary, returns the appropriate builder object."""
-        raise NotImplementedError('This is an abstract method !')
+        raise NotImplementedError("This is an abstract method !")
 
     def pack_basename(self, d):
         """Returns a basename given the **d** info dictionary."""
@@ -135,7 +149,7 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
 
     _abstract = True
 
-    def _pack_generic(self, d, what, default='std'):
+    def _pack_generic(self, d, what, default="std"):
         """
         Build the resource vortex basename/pathname or whatever according to
         ``style`` value.
@@ -144,60 +158,68 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         components.update(self._default)
         components.update(d)
 
-        packstyle = getattr(self, '_pack_{!s}_{!s}'.format(what,
-                                                           components.get('style', default)))
+        packstyle = getattr(
+            self,
+            "_pack_{!s}_{!s}".format(what, components.get("style", default)),
+        )
         return packstyle(components)
 
     def pack_basename(self, d):
         """Build the resource vortex basename according to ``style`` value."""
-        return self._pack_generic(d, 'basename')
+        return self._pack_generic(d, "basename")
 
     def pack_pathname(self, d):
         """Build the resource vortex pathname according to ``style`` value."""
-        return '/'.join(self._pack_generic(d, 'pathname'))
+        return "/".join(self._pack_generic(d, "pathname"))
 
     # A Vortex pathname may include the following bits
 
     def _pack_pathname_init(self, d):
         """Mandatory things to be packed into the pathname."""
         pathbits = []
-        for k in ['vapp', 'vconf', 'experiment']:
+        for k in ["vapp", "vconf", "experiment"]:
             if k not in d:
-                raise VortexNameBuilderError('The {!r} info key is mandatory'.format(k))
+                raise VortexNameBuilderError(
+                    "The {!r} info key is mandatory".format(k)
+                )
             pathbits.append(str(d[k]))
         return pathbits
 
     def _pack_pathname_append_flowdate(self, pathbits, d):
         """Pack the date/cutoff that characterise the resource's flow."""
-        if 'flow' in d and d['flow'] is not None:
-            pathbits.append(self._pack_std_items_datestuff(d['flow'], fatal=True))
+        if "flow" in d and d["flow"] is not None:
+            pathbits.append(
+                self._pack_std_items_datestuff(d["flow"], fatal=True)
+            )
         else:
-            raise VortexNameBuilderError('The flow info key is mandatory')
+            raise VortexNameBuilderError("The flow info key is mandatory")
 
     def _pack_pathname_append_flowperiod(self, pathbits, d):
         """Pack the period/cutoff that characterise the resource's flow."""
-        if 'flow' in d and d['flow'] is not None:
-            pathbits.append(self._pack_std_items_periodstuff(d['flow'], fatal=True))
+        if "flow" in d and d["flow"] is not None:
+            pathbits.append(
+                self._pack_std_items_periodstuff(d["flow"], fatal=True)
+            )
         else:
-            raise VortexNameBuilderError('The flow info key is mandatory')
+            raise VortexNameBuilderError("The flow info key is mandatory")
 
     def _pack_pathname_append_member(self, pathbits, d):
         """Pack the provider's member number (optional)."""
-        if 'member' in d and d['member'] is not None:
-            pathbits.append(self._pack_std_item_member(d['member']))
+        if "member" in d and d["member"] is not None:
+            pathbits.append(self._pack_std_item_member(d["member"]))
 
     def _pack_pathname_append_scenario(self, pathbits, d):
         """Pack the provider's scenario identifier (optional)."""
-        if 'scenario' in d and d['scenario'] is not None:
-            pathbits.append(self._pack_std_item_scenario(d['scenario']))
+        if "scenario" in d and d["scenario"] is not None:
+            pathbits.append(self._pack_std_item_scenario(d["scenario"]))
 
     def _pack_pathname_append_block(self, pathbits, d):
         """Pack the provider's block name."""
-        if 'block' in d:
-            if d['block']:
-                pathbits.append('_'.join(self._pack_std_items(d['block'])))
+        if "block" in d:
+            if d["block"]:
+                pathbits.append("_".join(self._pack_std_items(d["block"])))
         else:
-            raise VortexNameBuilderError('The block info key is mandatory')
+            raise VortexNameBuilderError("The block info key is mandatory")
 
     # A bunch of utility methods that prepares values
 
@@ -207,67 +229,67 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
 
     def _pack_std_item_seta(self, value):
         """Packing of a MPI-task number in first direction."""
-        return 'a{:04d}'.format(int(value))
+        return "a{:04d}".format(int(value))
 
     def _pack_std_item_setb(self, value):
         """Packing of a MPI-task number in second direction."""
-        return 'b{:04d}'.format(int(value))
+        return "b{:04d}".format(int(value))
 
     def _pack_std_item_mpi(self, value):
         """Packing of a MPI-task number."""
-        return 'n{:04d}'.format(int(value))
+        return "n{:04d}".format(int(value))
 
     def _pack_std_item_openmp(self, value):
         """Packing of an OpenMP id number."""
-        return 'omp{:02d}'.format(int(value))
+        return "omp{:02d}".format(int(value))
 
     def _pack_std_item_month(self, value):
         """Packing of a month-number value."""
-        return 'm{!s}'.format(value)
+        return "m{!s}".format(value)
 
     def _pack_std_item_stretching(self, value):
         """Packing of the stretching factor in spectral geometry."""
-        return 'c{!s}'.format(int(value * 10))
+        return "c{!s}".format(int(value * 10))
 
     def _pack_std_item_truncation(self, value):
         """Packing of the geometry's truncation value."""
         if isinstance(value, tuple):
-            return 't{1:s}{2:s}{0!s}'.format(* value)
+            return "t{1:s}{2:s}{0!s}".format(*value)
         else:
-            return 'tl{!s}'.format(value)
+            return "tl{!s}".format(value)
 
     def _pack_std_item_filtering(self, value):
         """Packing of the geometry's filtering value."""
-        return 'f{!s}'.format(value)
+        return "f{!s}".format(value)
 
     def _pack_std_item_time(self, value):
         """Packing of a Time object."""
-        return value.fmthm if hasattr(value, 'fmthm') else str(value)
+        return value.fmthm if hasattr(value, "fmthm") else str(value)
 
     _pack_std_item_begintime = _pack_std_item_time
     _pack_std_item_endtime = _pack_std_item_time
 
     def _pack_std_item_date(self, value):
         """Packing of a Time object."""
-        return value.stdvortex if hasattr(value, 'stdvortex') else str(value)
+        return value.stdvortex if hasattr(value, "stdvortex") else str(value)
 
     _pack_std_item_begindate = _pack_std_item_date
     _pack_std_item_enddate = _pack_std_item_date
 
     def _pack_std_item_cutoff(self, value):
         """Abbreviate the cutoff name."""
-        cutoff_map = dict(production='prod')
+        cutoff_map = dict(production="prod")
         return cutoff_map.get(value, value)
 
-    def _pack_std_item_shortcutoff(self, value, default='X'):
+    def _pack_std_item_shortcutoff(self, value, default="X"):
         """Abbreviate the cutoff name."""
         return value[0].upper() if value is not None else default
 
     def _pack_std_item_member(self, value):
-        return 'mb{:03d}'.format(value)
+        return "mb{:03d}".format(value)
 
     def _pack_std_item_scenario(self, value):
-        return 's{:s}'.format(value)
+        return "s{:s}".format(value)
 
     def _pack_std_items(self, items):
         """
@@ -280,15 +302,19 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         for i in items:
             if isinstance(i, dict):
                 for k, v in i.items():
-                    packmtd = getattr(self, '_pack_std_item_' + k, self._pack_void_item)
+                    packmtd = getattr(
+                        self, "_pack_std_item_" + k, self._pack_void_item
+                    )
                     packed.append(packmtd(v))
             else:
                 packed.append(self._pack_void_item(i))
         return packed
 
     def _pack_std_items_negativetimes(self, items):
-        return [(t[1:] + 'ago' if t[0] == '-' else t)
-                for t in self._pack_std_items(items)]
+        return [
+            (t[1:] + "ago" if t[0] == "-" else t)
+            for t in self._pack_std_items(items)
+        ]
 
     def _pack_std_items_datestuff(self, d, fatal=False):
         """Specialised version of _pack_std_items that deals with date/cutoff pairs."""
@@ -296,16 +322,18 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         flowcut = None
         if isinstance(d, (tuple, list)):
             for flowitem in [x for x in d if isinstance(x, dict)]:
-                if 'date' in flowitem:
-                    flowdate = flowitem['date']
-                if 'shortcutoff' in flowitem:
-                    flowcut = flowitem['shortcutoff']
+                if "date" in flowitem:
+                    flowdate = flowitem["date"]
+                if "shortcutoff" in flowitem:
+                    flowcut = flowitem["shortcutoff"]
         if flowdate is None:
             if fatal:
-                raise VortexNameBuilderError('A date is mandatory here...')
+                raise VortexNameBuilderError("A date is mandatory here...")
             else:
-                return ''
-        return self._pack_std_item_date(flowdate) + self._pack_std_item_shortcutoff(flowcut)
+                return ""
+        return self._pack_std_item_date(
+            flowdate
+        ) + self._pack_std_item_shortcutoff(flowcut)
 
     def _pack_std_items_periodstuff(self, d, fatal=False):
         """Specialised version of _pack_std_items that deals with begindate/enddate/cutoff pairs."""
@@ -314,67 +342,88 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         flowcut = None
         if isinstance(d, (tuple, list)):
             for flowitem in [x for x in d if isinstance(x, dict)]:
-                if 'begindate' in flowitem:
-                    flowbegin = flowitem['begindate']
-                if 'enddate' in flowitem:
-                    flowend = flowitem['enddate']
-                if 'shortcutoff' in flowitem:
-                    flowcut = flowitem['shortcutoff']
+                if "begindate" in flowitem:
+                    flowbegin = flowitem["begindate"]
+                if "enddate" in flowitem:
+                    flowend = flowitem["enddate"]
+                if "shortcutoff" in flowitem:
+                    flowcut = flowitem["shortcutoff"]
         if flowbegin is None or flowend is None:
             if fatal:
-                raise VortexNameBuilderError('A begindate/enddate pair is mandatory here...')
+                raise VortexNameBuilderError(
+                    "A begindate/enddate pair is mandatory here..."
+                )
             else:
-                return ''
-        return '-'.join([self._pack_std_item_date(flowbegin) +
-                         self._pack_std_item_shortcutoff(flowcut, default=''),
-                         self._pack_std_item_date(flowend)])
+                return ""
+        return "-".join(
+            [
+                self._pack_std_item_date(flowbegin)
+                + self._pack_std_item_shortcutoff(flowcut, default=""),
+                self._pack_std_item_date(flowend),
+            ]
+        )
 
     # A Vortex basename may include the following bits
 
     def _pack_std_basename_prefixstuff(self, d):  # @UnusedVariable
         """Adds any info about date, cutoff ..."""
-        name0 = d['radical']
-        name0 += self._join_basename_bit(d, 'src', prefix='.', sep='-')
-        name0 += self._join_basename_bit(d, 'filtername', prefix='.', sep='-')
-        name0 += self._join_basename_bit(d, 'geo', prefix='.', sep='-')
-        name0 += self._join_basename_bit(d, 'compute', prefix='.', sep='-')
+        name0 = d["radical"]
+        name0 += self._join_basename_bit(d, "src", prefix=".", sep="-")
+        name0 += self._join_basename_bit(d, "filtername", prefix=".", sep="-")
+        name0 += self._join_basename_bit(d, "geo", prefix=".", sep="-")
+        name0 += self._join_basename_bit(d, "compute", prefix=".", sep="-")
         return name0
 
     def _pack_std_basename_flowstuff(self, d):  # @UnusedVariable
         """Adds any info about date, cutoff ..."""
-        return ''
+        return ""
 
     def _pack_std_basename_timestuff(self, d):  # @UnusedVariable
         """Adds any info about term, period, ..."""
-        name = ''
-        if d['term'] is not None:
-            name += self._join_basename_bit(d, 'term', prefix='+', sep='.',
-                                            packcb=self._pack_std_items_negativetimes)
+        name = ""
+        if d["term"] is not None:
+            name += self._join_basename_bit(
+                d,
+                "term",
+                prefix="+",
+                sep=".",
+                packcb=self._pack_std_items_negativetimes,
+            )
         else:
-            if d['period'] is not None:
-                name += self._join_basename_bit(d, 'period', prefix='+', sep='-',
-                                                packcb=self._pack_std_items_negativetimes)
-            elif d['cen_period'] is not None:
-                name += self._join_basename_bit(d, 'cen_period', prefix='_', sep='_',
-                                                packcb=self._pack_std_items_negativetimes)
+            if d["period"] is not None:
+                name += self._join_basename_bit(
+                    d,
+                    "period",
+                    prefix="+",
+                    sep="-",
+                    packcb=self._pack_std_items_negativetimes,
+                )
+            elif d["cen_period"] is not None:
+                name += self._join_basename_bit(
+                    d,
+                    "cen_period",
+                    prefix="_",
+                    sep="_",
+                    packcb=self._pack_std_items_negativetimes,
+                )
         return name
 
     def _pack_std_basename_suffixstuff(self, d):  # @UnusedVariable
         """Adds any info about date, cutoff ..."""
-        name1 = ''
-        name1 += self._join_basename_bit(d, 'number', prefix='.', sep='-')
-        name1 += self._join_basename_bit(d, 'fmt', prefix='.', sep='.')
-        name1 += self._join_basename_bit(d, 'suffix', prefix='.', sep='.')
+        name1 = ""
+        name1 += self._join_basename_bit(d, "number", prefix=".", sep="-")
+        name1 += self._join_basename_bit(d, "fmt", prefix=".", sep=".")
+        name1 += self._join_basename_bit(d, "suffix", prefix=".", sep=".")
         return name1
 
-    def _join_basename_bit(self, d, entry, prefix='.', sep='-', packcb=None):
+    def _join_basename_bit(self, d, entry, prefix=".", sep="-", packcb=None):
         if d[entry] is not None:
             if packcb is None:
                 return prefix + sep.join(self._pack_std_items(d[entry]))
             else:
                 return prefix + sep.join(packcb(d[entry]))
         else:
-            return ''
+            return ""
 
     # Methods that generates basenames
 
@@ -383,10 +432,12 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         Main entry point to convert a description into a file name
         according to the so-called standard style.
         """
-        return (self._pack_std_basename_prefixstuff(d).lower() +
-                self._pack_std_basename_flowstuff(d) +
-                self._pack_std_basename_timestuff(d) +
-                self._pack_std_basename_suffixstuff(d).lower())
+        return (
+            self._pack_std_basename_prefixstuff(d).lower()
+            + self._pack_std_basename_flowstuff(d)
+            + self._pack_std_basename_timestuff(d)
+            + self._pack_std_basename_suffixstuff(d).lower()
+        )
 
     # Methods that generates pathnames
 
@@ -395,30 +446,32 @@ class AbstractActualVortexNameBuilder(AbstractVortexNameBuilder):
         Main entry point to convert a description into a path name
         according to the so-called standard style.
         """
-        raise NotImplementedError('This is an abstract method !')
+        raise NotImplementedError("This is an abstract method !")
 
 
 class VortexDateNameBuilder(AbstractActualVortexNameBuilder):
     """A Standard Vortex NameBuilder (with date and cutoff)."""
 
     _footprint = dict(
-        info = 'A Standard Vortex NameBuilder (with date and cutoff)',
-        attr = dict(
-            name = dict(
-                values = ['date@std', ],
+        info="A Standard Vortex NameBuilder (with date and cutoff)",
+        attr=dict(
+            name=dict(
+                values=[
+                    "date@std",
+                ],
             ),
-        )
+        ),
     )
 
     # A Vortex basename may include the following bits
 
     def _pack_std_basename_flowstuff(self, d):
         """Adds any info about term and period, ..."""
-        name = ''
-        if d['flow'] is not None:
-            pstuff = self._pack_std_items_periodstuff(d['flow'])
+        name = ""
+        if d["flow"] is not None:
+            pstuff = self._pack_std_items_periodstuff(d["flow"])
             if pstuff:
-                name += '.' + pstuff
+                name += "." + pstuff
         return name
 
     # Methods that generates basenames
@@ -428,16 +481,18 @@ class VortexDateNameBuilder(AbstractActualVortexNameBuilder):
         Main entry point to convert a description into a file name
         according to the so-called observation style.
         """
-        obsfmt = d.get('nativefmt', d.get('fmt', None))
+        obsfmt = d.get("nativefmt", d.get("fmt", None))
         if obsfmt is None:
             raise VortexNameBuilderError()
-        name = '.'.join([
-            obsfmt + '-' + d.get('layout', 'std'),
-            'void' if d['stage'] is None else d['stage'],
-            'all' if d['part'] is None else d['part'],
-        ])
-        if d['suffix'] is not None:
-            name = name + '.' + d['suffix']
+        name = ".".join(
+            [
+                obsfmt + "-" + d.get("layout", "std"),
+                "void" if d["stage"] is None else d["stage"],
+                "all" if d["part"] is None else d["part"],
+            ]
+        )
+        if d["suffix"] is not None:
+            name = name + "." + d["suffix"]
 
         return name.lower()
 
@@ -446,11 +501,13 @@ class VortexDateNameBuilder(AbstractActualVortexNameBuilder):
         Main entry point to convert a description into a file name
         according to the so-called observation-map style.
         """
-        name = '.'.join((
-            d['radical'],
-            '-'.join(self._pack_std_items(d['stage'])),
-            'txt' if d['fmt'] is None else d['fmt'],
-        ))
+        name = ".".join(
+            (
+                d["radical"],
+                "-".join(self._pack_std_items(d["stage"])),
+                "txt" if d["fmt"] is None else d["fmt"],
+            )
+        )
         return name.lower()
 
     # Methods that generates pathnames
@@ -475,22 +532,24 @@ class VortexPeriodNameBuilder(AbstractActualVortexNameBuilder):
     """A Standard Vortex NameBuilder (with period and cutoff)."""
 
     _footprint = dict(
-        info = 'A Standard Vortex NameBuilder (with period and cutoff)',
-        attr = dict(
-            name = dict(
-                values = ['period@std', ],
+        info="A Standard Vortex NameBuilder (with period and cutoff)",
+        attr=dict(
+            name=dict(
+                values=[
+                    "period@std",
+                ],
             ),
-        )
+        ),
     )
 
     # A Vortex basename may include the following bits
 
     def _pack_std_basename_flowstuff(self, d):
-        name = ''
-        if d['flow'] is not None:
-            dstuff = self._pack_std_items_datestuff(d['flow'])
+        name = ""
+        if d["flow"] is not None:
+            dstuff = self._pack_std_items_datestuff(d["flow"])
             if dstuff:
-                name += '.' + dstuff
+                name += "." + dstuff
         return name
 
     # Methods that generates pathnames
@@ -512,25 +571,27 @@ class VortexFlatNameBuilder(AbstractActualVortexNameBuilder):
     """'A Standard Vortex NameBuilder (without date or period)."""
 
     _footprint = dict(
-        info = 'A Standard Vortex NameBuilder (without date or period)',
-        attr = dict(
-            name = dict(
-                values = ['flat@std', ],
+        info="A Standard Vortex NameBuilder (without date or period)",
+        attr=dict(
+            name=dict(
+                values=[
+                    "flat@std",
+                ],
             ),
-        )
+        ),
     )
 
     # A Vortex basename may include the following bits
 
     def _pack_std_basename_flowstuff(self, d):
-        name = ''
-        if d['flow'] is not None:
-            dstuff = self._pack_std_items_datestuff(d['flow'])
+        name = ""
+        if d["flow"] is not None:
+            dstuff = self._pack_std_items_datestuff(d["flow"])
             if dstuff:
-                name += '.' + dstuff
-            pstuff = self._pack_std_items_periodstuff(d['flow'])
+                name += "." + dstuff
+            pstuff = self._pack_std_items_periodstuff(d["flow"])
             if pstuff:
-                name += '.' + pstuff
+                name += "." + pstuff
         return name
 
     # Methods that generates pathnames
@@ -548,28 +609,29 @@ class VortexFlatNameBuilder(AbstractActualVortexNameBuilder):
 
 
 class VortexNameBuilder(AbstractVortexNameBuilderProxy):
-
     _explicit = False
     _footprint = dict(
-        info = 'Standard Vortex NameBuilder Proxy',
-        attr = dict(
-            name = dict(
-                values = ['std', ],
-                optional = True,
-                default = 'std',
+        info="Standard Vortex NameBuilder Proxy",
+        attr=dict(
+            name=dict(
+                values=[
+                    "std",
+                ],
+                optional=True,
+                default="std",
             ),
-        )
+        ),
     )
 
     def _pick_actual_builder(self, d):
         """Given the input dictionary, returns the appropriate builder object."""
-        actual_builder_name = 'flat@std'
-        if 'flow' in d and isinstance(d['flow'], (tuple, list)):
+        actual_builder_name = "flat@std"
+        if "flow" in d and isinstance(d["flow"], (tuple, list)):
             flowkeys = set()
-            for item in [item for item in d['flow'] if isinstance(item, dict)]:
+            for item in [item for item in d["flow"] if isinstance(item, dict)]:
                 flowkeys.update(item.keys())
-            if 'date' in flowkeys:
-                actual_builder_name = 'date@std'
-            elif 'begindate' in flowkeys and 'enddate' in flowkeys:
-                actual_builder_name = 'period@std'
+            if "date" in flowkeys:
+                actual_builder_name = "date@std"
+            elif "begindate" in flowkeys and "enddate" in flowkeys:
+                actual_builder_name = "period@std"
         return self._get_builder(actual_builder_name)

--- a/src/vortex/tools/prestaging.py
+++ b/src/vortex/tools/prestaging.py
@@ -20,7 +20,9 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 #: Definition of a named tuple PrestagingPriorityTuple
-PrestagingPriorityTuple = namedtuple('PrestagingPriorityTuple', ['urgent', 'normal', 'low'])
+PrestagingPriorityTuple = namedtuple(
+    "PrestagingPriorityTuple", ["urgent", "normal", "low"]
+)
 
 #: Predefined PrestagingPriorities values for urgent, normal and low
 prestaging_p = PrestagingPriorityTuple(urgent=99, normal=50, low=0)
@@ -36,23 +38,20 @@ class PrestagingTool(footprints.FootprintBase, Catalog):
     """Abstract class that deal with pre-staging for a given storage target."""
 
     _abstract = True
-    _collector = ('prestagingtool',)
+    _collector = ("prestagingtool",)
     _footprint = dict(
-        info = "Abstract class that deal with pre-staging for a given storage target.",
-        attr = dict(
-            system = dict(
-                info = "The current system object",
-                type = OSExtended
+        info="Abstract class that deal with pre-staging for a given storage target.",
+        attr=dict(
+            system=dict(info="The current system object", type=OSExtended),
+            issuerkind=dict(
+                info="The kind of store issuing the prestaging request"
             ),
-            issuerkind = dict(
-                info = 'The kind of store issuing the prestaging request'
+            priority=dict(
+                info="The prestaging request priority",
+                type=int,
+                values=list(prestaging_p),
             ),
-            priority = dict(
-                info = 'The prestaging request priority',
-                type = int,
-                values = list(prestaging_p)
-            )
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -66,12 +65,14 @@ class PrestagingTool(footprints.FootprintBase, Catalog):
 
     def describe(self, fulldump=False):
         """Print the object's characteristics and content."""
-        res = 'PrestagingTool object of class: {!s}\n'.format(self.__class__)
+        res = "PrestagingTool object of class: {!s}\n".format(self.__class__)
         for k, v in self.footprint_as_shallow_dict().items():
-            res += '  * {:s}: {!s}\n'.format(k, v)
+            res += "  * {:s}: {!s}\n".format(k, v)
         if fulldump:
-            res += '\n  * Todo list:\n'
-            res += '\n'.join(['    - {:s}'.format(item) for item in sorted(self.items())])
+            res += "\n  * Todo list:\n"
+            res += "\n".join(
+                ["    - {:s}".format(item) for item in sorted(self.items())]
+            )
         return res
 
     def flush(self, email=None):
@@ -113,24 +114,35 @@ class PrivatePrestagingHub:
         # Prestaging tool descriptions
         myptool_desc = self.prestagingtools_default_opts.copy()
         myptool_desc.update(kwargs)
-        myptool_desc['priority'] = priority
-        myptool_desc['system'] = self._sh
+        myptool_desc["priority"] = priority
+        myptool_desc["system"] = self._sh
         myptool = None
         # Scan pre-existing prestaging tools to find a suitable one
         for ptool in self._prestagingtools:
-            if ptool.footprint_reusable() and ptool.footprint_compatible(myptool_desc):
-                logger.debug("Re-usable prestaging tool found: %s", lightdump(myptool_desc))
+            if ptool.footprint_reusable() and ptool.footprint_compatible(
+                myptool_desc
+            ):
+                logger.debug(
+                    "Re-usable prestaging tool found: %s",
+                    lightdump(myptool_desc),
+                )
                 myptool = ptool
                 break
         # If necessary, create a new one
         if myptool is None:
             myptool = fpx.prestagingtool(_emptywarning=False, **myptool_desc)
             if myptool is not None:
-                logger.debug("Fresh prestaging tool created: %s", lightdump(myptool_desc))
+                logger.debug(
+                    "Fresh prestaging tool created: %s",
+                    lightdump(myptool_desc),
+                )
                 self._prestagingtools.add(myptool)
         # Let's role
         if myptool is None:
-            logger.debug("Unable to perform prestaging with: %s", lightdump(myptool_desc))
+            logger.debug(
+                "Unable to perform prestaging with: %s",
+                lightdump(myptool_desc),
+            )
         else:
             logger.debug("Prestaging requested accepted for: %s", location)
             myptool.add(location)
@@ -143,13 +155,21 @@ class PrivatePrestagingHub:
         return todo
 
     def __repr__(self, *args, **kwargs):
-        return ('{:s} | n_prestagingtools={:d}>'
-                .format(super().__repr__().rstrip('>'),
-                        len(self._prestagingtools)))
+        return "{:s} | n_prestagingtools={:d}>".format(
+            super().__repr__().rstrip(">"), len(self._prestagingtools)
+        )
 
     def __str__(self):
-        return (repr(self) + "\n\n" +
-                "\n\n".join([ptool.describe(fulldump=True) for ptool in self._prestagingtools]))
+        return (
+            repr(self)
+            + "\n\n"
+            + "\n\n".join(
+                [
+                    ptool.describe(fulldump=True)
+                    for ptool in self._prestagingtools
+                ]
+            )
+        )
 
     def flush(self, priority_threshold=prestaging_p.low):
         """Actually send the pre-staging request to the appropriate location.
@@ -163,7 +183,10 @@ class PrivatePrestagingHub:
             if rc:
                 self._prestagingtools.discard(ptool)
             else:
-                logger.error("Something went wrong when flushing the %s prestaging tool", ptool)
+                logger.error(
+                    "Something went wrong when flushing the %s prestaging tool",
+                    ptool,
+                )
 
     def clear(self, priority_threshold=prestaging_p.low):
         """Erase the pre-staging requests list.
@@ -183,4 +206,5 @@ class PrestagingHub(PrivatePrestagingHub, getbytag.GetByTag):
     Therefore, a *tag* attribute needs to be specified when building/retrieving
     an object of this class.
     """
+
     pass

--- a/src/vortex/tools/schedulers.py
+++ b/src/vortex/tools/schedulers.py
@@ -8,6 +8,7 @@ import functools
 from bronx.fancies import loggers
 import footprints
 
+from vortex import config
 from .services import Service
 
 __all__ = []
@@ -240,14 +241,10 @@ class SMS(EcmwfLikeScheduler):
         super().__init__(*args, **kw)
         self._actual_rootdir = self.rootdir
         if self._actual_rootdir is None:
-            self._actual_rootdir = self.env.SMS_INSTALL_ROOT or from_config(
-                section="sms", key="rootdir"
+            self._actual_rootdir = (
+                self.env.SMS_INSTALL_ROOT
+                or config.from_config(section="sms", key="rootdir")
             )
-            if self._actual_rootdir is None:
-                logger.warning(
-                    "SMS service could not guess install location [%s]",
-                    str(guesspath),
-                )
         if self.sh.path.exists(self.cmdpath("init")):
             self.env.setbinpath(self._actual_rootdir)
         else:

--- a/src/vortex/tools/services.py
+++ b/src/vortex/tools/services.py
@@ -19,7 +19,11 @@ from bronx.stdtypes import date
 from bronx.stdtypes.dictionaries import UpperCaseDict
 from bronx.syntax.pretty import EncodedPrettyPrinter
 from vortex import sessions
-from vortex.util.config import GenericConfigParser, load_template, LegacyTemplatingAdapter
+from vortex.util.config import (
+    GenericConfigParser,
+    load_template,
+    LegacyTemplatingAdapter,
+)
 
 #: No automatic export
 __all__ = []
@@ -27,7 +31,7 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 # See logging.handlers.SysLogHandler.priority_map
-criticals = ['debug', 'info', 'error', 'warning', 'critical']
+criticals = ["debug", "info", "error", "warning", "critical"]
 
 
 class Service(footprints.FootprintBase):
@@ -36,31 +40,31 @@ class Service(footprints.FootprintBase):
     """
 
     _abstract = True
-    _collector = ('service',)
+    _collector = ("service",)
     _footprint = dict(
-        info = 'Abstract services class',
-        attr = dict(
-            kind = dict(),
-            level = dict(
-                optional = True,
-                default  = 'info',
-                values   = criticals,
+        info="Abstract services class",
+        attr=dict(
+            kind=dict(),
+            level=dict(
+                optional=True,
+                default="info",
+                values=criticals,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract service init %s', self.__class__)
+        logger.debug("Abstract service init %s", self.__class__)
         t = sessions.current()
-        glove = kw.pop('glove', t.glove)
-        sh = kw.pop('sh', t.system())
+        glove = kw.pop("glove", t.glove)
+        sh = kw.pop("sh", t.system())
         super().__init__(*args, **kw)
         self._glove = glove
         self._sh = sh
 
     @property
     def realkind(self):
-        return 'service'
+        return "service"
 
     @property
     def sh(self):
@@ -89,7 +93,7 @@ class Service(footprints.FootprintBase):
             value = self.env.get(as_var, None)
         if not value:
             if as_conf is None:
-                as_conf = 'services:' + key.lower()
+                as_conf = "services:" + key.lower()
             value = self.sh.default_target.get(as_conf, default)
         return value
 
@@ -104,69 +108,66 @@ class MailService(Service):
     """
 
     _footprint = dict(
-        info = 'Mail services class',
-        attr = dict(
-            kind = dict(
-                values   = ['sendmail'],
+        info="Mail services class",
+        attr=dict(
+            kind=dict(
+                values=["sendmail"],
             ),
-            sender = dict(
-                optional = True,
-                default  = '[glove::xmail]',
+            sender=dict(
+                optional=True,
+                default="[glove::xmail]",
             ),
-            to = dict(
-                alias    = ('receiver', 'recipients'),
+            to=dict(
+                alias=("receiver", "recipients"),
             ),
-            replyto = dict(
-                optional = True,
-                alias    = ('reply', 'reply_to'),
-                default  = None,
+            replyto=dict(
+                optional=True,
+                alias=("reply", "reply_to"),
+                default=None,
             ),
-            message = dict(
-                optional = True,
-                default  = '',
-                alias    = ('contents', 'body'),
-                type     = str,
+            message=dict(
+                optional=True,
+                default="",
+                alias=("contents", "body"),
+                type=str,
             ),
-            filename = dict(
-                optional = True,
-                default  = None,
+            filename=dict(
+                optional=True,
+                default=None,
             ),
-            attachments = dict(
-                type     = footprints.FPList,
-                optional = True,
-                default  = footprints.FPList(),
-                alias    = ('files', 'attach'),
+            attachments=dict(
+                type=footprints.FPList,
+                optional=True,
+                default=footprints.FPList(),
+                alias=("files", "attach"),
             ),
-            subject = dict(
-                type     = str,
+            subject=dict(
+                type=str,
             ),
-            smtpserver = dict(
-                optional = True,
+            smtpserver=dict(
+                optional=True,
             ),
-            smtpport = dict(
-                type     = int,
-                optional = True,
+            smtpport=dict(
+                type=int,
+                optional=True,
             ),
-            smtpuser = dict(
-                optional = True,
+            smtpuser=dict(
+                optional=True,
             ),
-            smtppass = dict(
-                optional = True,
+            smtppass=dict(
+                optional=True,
             ),
-            charset = dict(
-                info     = 'The encoding that should be used when sending the email',
-                optional = True,
-                default  = 'utf-8',
+            charset=dict(
+                info="The encoding that should be used when sending the email",
+                optional=True,
+                default="utf-8",
             ),
-            inputs_charset = dict(
-                info     = 'The encoding that should be used when reading input files',
-                optional = True,
+            inputs_charset=dict(
+                info="The encoding that should be used when reading input files",
+                optional=True,
             ),
-            commaspace = dict(
-                optional = True,
-                default  = ', '
-            )
-        )
+            commaspace=dict(optional=True, default=", "),
+        ),
     )
 
     def attach(self, *args):
@@ -186,28 +187,41 @@ class MailService(Service):
             with open(self.filename, encoding=self.inputs_charset) as tmp:
                 body += tmp.read()
         from email.message import EmailMessage
+
         msg = EmailMessage()
-        msg.set_content(body, subtype="plain",
-                        charset=(self.charset if self.is_not_plain_ascii(body) else 'us-ascii'))
+        msg.set_content(
+            body,
+            subtype="plain",
+            charset=(
+                self.charset if self.is_not_plain_ascii(body) else "us-ascii"
+            ),
+        )
         return msg
 
     def as_multipart(self, msg):
         """Build a new multipart mail with default text contents and attachments."""
         from email.message import MIMEPart
+
         for xtra in self.attachments:
             if isinstance(xtra, MIMEPart):
                 msg.add_attachment(xtra)
             elif self.sh.path.isfile(xtra):
                 import mimetypes
+
                 ctype, encoding = mimetypes.guess_type(xtra)
                 if ctype is None or encoding is not None:
                     # No guess could be made, or the file is encoded
                     # (compressed), so use a generic bag-of-bits type.
-                    ctype = 'application/octet-stream'
-                maintype, subtype = ctype.split('/', 1)
-                with open(xtra, 'rb') as fp:
-                    msg.add_attachment(fp.read(), maintype, subtype,
-                                       cte="base64", filename=xtra)
+                    ctype = "application/octet-stream"
+                maintype, subtype = ctype.split("/", 1)
+                with open(xtra, "rb") as fp:
+                    msg.add_attachment(
+                        fp.read(),
+                        maintype,
+                        subtype,
+                        cte="base64",
+                        filename=xtra,
+                    )
         return msg
 
     def _set_header(self, msg, header, value):
@@ -215,25 +229,30 @@ class MailService(Service):
 
     def set_headers(self, msg):
         """Put on the current message the header items associated to footprint attributes."""
-        self._set_header(msg, 'From', self.sender)
-        self._set_header(msg, 'To', self.commaspace.join(self.to.split()))
-        self._set_header(msg, 'Subject', self.subject)
+        self._set_header(msg, "From", self.sender)
+        self._set_header(msg, "To", self.commaspace.join(self.to.split()))
+        self._set_header(msg, "Subject", self.subject)
         if self.replyto is not None:
-            self._set_header(msg, 'Reply-To', self.commaspace.join(self.replyto.split()))
+            self._set_header(
+                msg, "Reply-To", self.commaspace.join(self.replyto.split())
+            )
 
     @contextlib.contextmanager
     def smtp_entrypoints(self):
         import smtplib
-        my_smtpserver = self.actual_value('smtpserver',
-                                          as_var='VORTEX_SMTPSERVER',
-                                          default='localhost')
-        my_smtpport = self.actual_value('smtpport',
-                                        as_var='VORTEX_SMTPPORT',
-                                        default=smtplib.SMTP_PORT)
+
+        my_smtpserver = self.actual_value(
+            "smtpserver", as_var="VORTEX_SMTPSERVER", default="localhost"
+        )
+        my_smtpport = self.actual_value(
+            "smtpport", as_var="VORTEX_SMTPPORT", default=smtplib.SMTP_PORT
+        )
         if not self.sh.default_target.isnetworknode:
-            sshobj = self.sh.ssh('network', virtualnode=True, mandatory_hostcheck=False)
+            sshobj = self.sh.ssh(
+                "network", virtualnode=True, mandatory_hostcheck=False
+            )
             with sshobj.tunnel(my_smtpserver, my_smtpport) as tun:
-                yield 'localhost', tun.entranceport
+                yield "localhost", tun.entranceport
         else:
             yield my_smtpserver, my_smtpport
 
@@ -246,9 +265,10 @@ class MailService(Service):
         msgcorpus = msg.as_string()
         with self.smtp_entrypoints() as (smtpserver, smtpport):
             import smtplib
+
             extras = dict()
             if smtpport:
-                extras['port'] = smtpport
+                extras["port"] = smtpport
             smtp = smtplib.SMTP(smtpserver, **extras)
             if self.smtpuser and self.smtppass:
                 smtp.login(self.smtpuser, self.smtppass)
@@ -265,20 +285,15 @@ class ReportService(Service):
 
     _abstract = True
     _footprint = dict(
-        info = 'Report services class',
-        attr = dict(
-            kind = dict(
-                values   = ['sendreport']
+        info="Report services class",
+        attr=dict(
+            kind=dict(values=["sendreport"]),
+            sender=dict(
+                optional=True,
+                default="[glove::user]",
             ),
-            sender = dict(
-                optional = True,
-                default  = '[glove::user]',
-            ),
-            subject = dict(
-                optional = True,
-                default  = 'Test'
-            ),
-        )
+            subject=dict(optional=True, default="Test"),
+        ),
     )
 
     def __call__(self, *args):
@@ -291,14 +306,14 @@ class FileReportService(ReportService):
 
     _abstract = True
     _footprint = dict(
-        info = 'File Report services class',
-        attr = dict(
-            kind = dict(
-                values = ['sendreport', 'sendfilereport'],
-                remap  = dict(sendfilereport = 'sendreport'),
+        info="File Report services class",
+        attr=dict(
+            kind=dict(
+                values=["sendreport", "sendfilereport"],
+                remap=dict(sendfilereport="sendreport"),
             ),
-            filename = dict(),
-        )
+            filename=dict(),
+        ),
     )
 
 
@@ -318,57 +333,74 @@ class SSHProxy(Service):
     """
 
     _footprint = dict(
-        info = 'Remote command proxy',
-        attr = dict(
-            kind = dict(
-                values   = ['ssh', 'ssh_proxy'],
-                remap    = dict(autoremap = 'first'),
+        info="Remote command proxy",
+        attr=dict(
+            kind=dict(
+                values=["ssh", "ssh_proxy"],
+                remap=dict(autoremap="first"),
             ),
-            hostname = dict(),
-            genericnode = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            hostname=dict(),
+            genericnode=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            nodetype = dict(
-                optional = True,
-                values   = ['login', 'transfer', 'transfert', 'network', 'agt', 'syslog'],
-                default  = 'network',
-                remap    = dict(transfer = 'transfert'),
+            nodetype=dict(
+                optional=True,
+                values=[
+                    "login",
+                    "transfer",
+                    "transfert",
+                    "network",
+                    "agt",
+                    "syslog",
+                ],
+                default="network",
+                remap=dict(transfer="transfert"),
             ),
-            permut = dict(
-                type     = bool,
-                optional = True,
-                default  = True,
+            permut=dict(
+                type=bool,
+                optional=True,
+                default=True,
             ),
-            maxtries = dict(
-                type     = int,
-                optional = True,
-                default  = 2,
+            maxtries=dict(
+                type=int,
+                optional=True,
+                default=2,
             ),
-            sshopts = dict(
-                optional = True,
-                type     = footprints.FPList,
-                default  = None,
+            sshopts=dict(
+                optional=True,
+                type=footprints.FPList,
+                default=None,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Remote command proxy init %s', self.__class__)
+        logger.debug("Remote command proxy init %s", self.__class__)
         super().__init__(*args, **kw)
         hostname, virtualnode = self._actual_hostname()
-        extra_sshopts = None if self.sshopts is None else ' '.join(self.sshopts)
-        self._sshobj = self.sh.ssh(hostname, sshopts=extra_sshopts,
-                                   maxtries=self.maxtries, virtualnode=virtualnode,
-                                   permut=self.permut, mandatory_hostcheck=False)
+        extra_sshopts = (
+            None if self.sshopts is None else " ".join(self.sshopts)
+        )
+        self._sshobj = self.sh.ssh(
+            hostname,
+            sshopts=extra_sshopts,
+            maxtries=self.maxtries,
+            virtualnode=virtualnode,
+            permut=self.permut,
+            mandatory_hostcheck=False,
+        )
 
     def _actual_hostname(self):
         """Build a list of candidate target hostnames."""
         myhostname = self.hostname.strip().lower()
         virtualnode = False
-        if myhostname == 'node':
-            if self.genericnode is not None and self.genericnode != 'no_generic':
+        if myhostname == "node":
+            if (
+                self.genericnode is not None
+                and self.genericnode != "no_generic"
+            ):
                 myhostname = self.genericnode
             else:
                 myhostname = self.nodetype
@@ -381,7 +413,7 @@ class SSHProxy(Service):
 
     def __call__(self, *args):
         """Remote execution."""
-        return self._sshobj.execute(' '.join(args))
+        return self._sshobj.execute(" ".join(args))
 
 
 class JeevesService(Service):
@@ -390,38 +422,39 @@ class JeevesService(Service):
     """
 
     _footprint = dict(
-        info = 'Jeeves services class',
-        attr = dict(
-            kind = dict(
-                values   = ['askjeeves']
+        info="Jeeves services class",
+        attr=dict(
+            kind=dict(values=["askjeeves"]),
+            todo=dict(),
+            jname=dict(
+                optional=True,
+                default="test",
             ),
-            todo = dict(),
-            jname = dict(
-                optional = True,
-                default  = 'test',
+            juser=dict(
+                optional=True,
+                default="[glove::user]",
             ),
-            juser = dict(
-                optional = True,
-                default  = '[glove::user]',
+            jpath=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            jpath = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            jfile=dict(
+                optional=True,
+                default="vortex",
             ),
-            jfile = dict(
-                optional = True,
-                default  = 'vortex',
-            ),
-        )
+        ),
     )
 
     def __call__(self, *args):
         """Main action: ..."""
         if self.jpath is None:
-            self.jpath = self.sh.path.join(self.env.HOME, 'jeeves', self.jname, 'depot')
+            self.jpath = self.sh.path.join(
+                self.env.HOME, "jeeves", self.jname, "depot"
+            )
         if self.sh.path.isdir(self.jpath):
             from jeeves import bertie
+
             data = dict()
             for arg in args:
                 data.update(arg)
@@ -429,10 +462,11 @@ class JeevesService(Service):
                 user=self.juser,
                 jtag=self.sh.path.join(self.jpath, self.jfile),
                 todo=self.todo,
-                mail=data.pop('mail', self.glove.xmail),
-                apps=data.pop('apps', (self.glove.vapp,)),
-                conf=data.pop('conf', (self.glove.vconf,)),
-                task=self.env.get('JOBNAME') or self.env.get('SMSNAME', 'interactif'),
+                mail=data.pop("mail", self.glove.xmail),
+                apps=data.pop("apps", (self.glove.vapp,)),
+                conf=data.pop("conf", (self.glove.vconf,)),
+                task=self.env.get("JOBNAME")
+                or self.env.get("SMSNAME", "interactif"),
             )
             fulltalk.update(
                 data=data,
@@ -440,7 +474,7 @@ class JeevesService(Service):
             jr = bertie.ask(**fulltalk)
             return jr.todo, jr.last
         else:
-            logger.error('No valid path to jeeves <%s>', self.jpath)
+            logger.error("No valid path to jeeves <%s>", self.jpath)
             return None
 
 
@@ -453,37 +487,41 @@ class HideService(Service):
     """
 
     _footprint = dict(
-        info = 'Hide a given object on current filesystem',
-        attr = dict(
-            kind = dict(
-                values   = ['hidden', 'hide', 'hiddencache'],
-                remap    = dict(autoremap = 'first'),
+        info="Hide a given object on current filesystem",
+        attr=dict(
+            kind=dict(
+                values=["hidden", "hide", "hiddencache"],
+                remap=dict(autoremap="first"),
             ),
-            rootdir = dict(
-                optional = True,
-                default  = None,
+            rootdir=dict(
+                optional=True,
+                default=None,
             ),
-            headdir = dict(
-                optional = True,
-                default  = 'hidden',
+            headdir=dict(
+                optional=True,
+                default="hidden",
             ),
-            asfmt = dict(
-                optional = True,
-                default  = None,
+            asfmt=dict(
+                optional=True,
+                default=None,
             ),
-        )
+        ),
     )
 
     def find_rootdir(self, filename):
         """Find a path for hiding files on the same filesystem."""
         username = self.sh.getlogname()
-        work_dir = self.sh.path.join(self.sh.find_mount_point(filename), 'work')
+        work_dir = self.sh.path.join(
+            self.sh.find_mount_point(filename), "work"
+        )
         if not self.sh.path.exists(work_dir):
             logger.warning("path <%s> doesn't exist", work_dir)
             fullpath = self.sh.path.realpath(filename)
             if username not in fullpath:
-                logger.error('No login <%s> in path <%s>', username, fullpath)
-                raise ValueError('Login name not in actual path for hiding data')
+                logger.error("No login <%s> in path <%s>", username, fullpath)
+                raise ValueError(
+                    "Login name not in actual path for hiding data"
+                )
             work_dir = fullpath.partition(username)[0]
             logger.warning("using work_dir = <%s>", work_dir)
         hidden_path = self.sh.path.join(work_dir, username, self.headdir)
@@ -494,21 +532,25 @@ class HideService(Service):
 
         rootdir = self.rootdir
         if rootdir is None:
-            rootdir = self.sh.default_target.get('hidden_rootdir', None)
+            rootdir = self.sh.default_target.get("hidden_rootdir", None)
         if rootdir is not None:
             rootdir = self.sh.path.expanduser(rootdir)
 
         actual_rootdir = rootdir or self.find_rootdir(filename)
         destination = self.sh.path.join(
             actual_rootdir,
-            '.'.join((
-                'HIDDEN',
-                date.now().strftime('%Y%m%d%H%M%S.%f'),
-                'P{:06d}'.format(self.sh.getpid()),
-                hashlib.md5(self.sh.path.abspath(filename).encode(encoding='utf-8')).hexdigest()
-            ))
+            ".".join(
+                (
+                    "HIDDEN",
+                    date.now().strftime("%Y%m%d%H%M%S.%f"),
+                    "P{:06d}".format(self.sh.getpid()),
+                    hashlib.md5(
+                        self.sh.path.abspath(filename).encode(encoding="utf-8")
+                    ).hexdigest(),
+                )
+            ),
         )
-        self.sh.cp(filename, destination, intent='in', fmt=self.asfmt)
+        self.sh.cp(filename, destination, intent="in", fmt=self.asfmt)
         return destination
 
 
@@ -519,20 +561,21 @@ class Directory:
     Directory (en) means Annuaire (fr).
     """
 
-    def __init__(self, inifile, domain='meteo.fr', encoding=None):
+    def __init__(self, inifile, domain="meteo.fr", encoding=None):
         """Keep aliases in memory, as a dict of sets."""
         config = GenericConfigParser(inifile, encoding=encoding)
         try:
-            self.domain = config.get('general', 'default_domain')
+            self.domain = config.get("general", "default_domain")
         except NoOptionError:
             self.domain = domain
         self.aliases = {
-            k.lower(): set(v.lower().replace(',', ' ').split())
-            for (k, v) in config.items('aliases')
+            k.lower(): set(v.lower().replace(",", " ").split())
+            for (k, v) in config.items("aliases")
         }
         count = self._flatten()
-        logger.debug('opmail aliases flattened in %d iterations:\n%s',
-                     count, str(self))
+        logger.debug(
+            "opmail aliases flattened in %d iterations:\n%s", count, str(self)
+        )
 
     def get_addresses(self, definition, add_domain=True):
         """
@@ -540,20 +583,24 @@ class Directory:
         may reference aliases.
         """
         addresses = set()
-        for item in definition.lower().replace(',', ' ').split():
+        for item in definition.lower().replace(",", " ").split():
             if item in self.aliases:
                 addresses |= self.aliases[item]
             else:
                 addresses |= {item}
         if add_domain:
-            return ' '.join(self._add_domain(addresses))
-        return ' '.join(addresses)
+            return " ".join(self._add_domain(addresses))
+        return " ".join(addresses)
 
     def __str__(self):
-        return '\n'.join(sorted(
-            ['{}: {}'.format(k, ' '.join(sorted(v)))
-             for (k, v) in self.aliases.items()]
-        ))
+        return "\n".join(
+            sorted(
+                [
+                    "{}: {}".format(k, " ".join(sorted(v)))
+                    for (k, v) in self.aliases.items()
+                ]
+            )
+        )
 
     def _flatten(self):
         """Resolve recursive definitions from the dict of sets."""
@@ -564,11 +611,18 @@ class Directory:
             count += 1
             for kref, vref in self.aliases.items():
                 if kref in vref:
-                    logger.error('Cycle detected in the aliases directory.\n'
-                                 'offending key: %s.\n'
-                                 'directory being flattened:\n%s',
-                                 str(kref), str(self))
-                    raise ValueError('Cycle for key <{}> in directory definition'.format(kref))
+                    logger.error(
+                        "Cycle detected in the aliases directory.\n"
+                        "offending key: %s.\n"
+                        "directory being flattened:\n%s",
+                        str(kref),
+                        str(self),
+                    )
+                    raise ValueError(
+                        "Cycle for key <{}> in directory definition".format(
+                            kref
+                        )
+                    )
                 for k, v in self.aliases.items():
                     if kref in v:
                         v -= {kref}
@@ -579,11 +633,7 @@ class Directory:
 
     def _add_domain(self, aset):
         """Add domain where missing in a set of addresses."""
-        return {
-            v if '@' in v
-            else v + '@' + self.domain
-            for v in aset
-        }
+        return {v if "@" in v else v + "@" + self.domain for v in aset}
 
 
 class PromptService(Service):
@@ -593,16 +643,16 @@ class PromptService(Service):
     """
 
     _footprint = dict(
-        info = 'Simulate a call to a Service.',
-        attr = dict(
-            kind = dict(
-                values   = ('prompt',),
+        info="Simulate a call to a Service.",
+        attr=dict(
+            kind=dict(
+                values=("prompt",),
             ),
-            comment = dict(
-                optional = True,
-                default  = None,
+            comment=dict(
+                optional=True,
+                default=None,
             ),
-        )
+        ),
     )
 
     def __call__(self, options):
@@ -610,8 +660,8 @@ class PromptService(Service):
 
         pf = EncodedPrettyPrinter().pformat
         logger_action = getattr(logger, self.level, logger.warning)
-        msg = (self.comment or 'PromptService was called.') + '\noptions = {}'
-        logger_action(msg.format(pf(options)).replace('\n', '\n<prompt>'))
+        msg = (self.comment or "PromptService was called.") + "\noptions = {}"
+        logger_action(msg.format(pf(options)).replace("\n", "\n<prompt>"))
         return True
 
 
@@ -622,51 +672,51 @@ class TemplatedMailService(MailService):
     """
 
     _footprint = dict(
-        info = 'Templated mail services class',
-        attr = dict(
-            kind = dict(
-                values   = ['templatedmail'],
+        info="Templated mail services class",
+        attr=dict(
+            kind=dict(
+                values=["templatedmail"],
             ),
-            id = dict(
-                alias    = ('template',),
+            id=dict(
+                alias=("template",),
             ),
-            subject = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            subject=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            to = dict(
-                optional = True,
-                default  = None,
-                access   = 'rwx',
+            to=dict(
+                optional=True,
+                default=None,
+                access="rwx",
             ),
-            message = dict(
-                access   = 'rwx',
+            message=dict(
+                access="rwx",
             ),
-            directory = dict(
-                type     = Directory,
-                optional = True,
-                default  = None,
+            directory=dict(
+                type=Directory,
+                optional=True,
+                default=None,
             ),
-            catalog = dict(
-                type     = GenericConfigParser,
+            catalog=dict(
+                type=GenericConfigParser,
             ),
-            dryrun = dict(
-                info     = "Do not actually send the email. Just render the template.",
-                type     = bool,
-                optional = True,
-                default  = False,
+            dryrun=dict(
+                info="Do not actually send the email. Just render the template.",
+                type=bool,
+                optional=True,
+                default=False,
             ),
-        )
+        ),
     )
 
     _TEMPLATES_SUBDIR = None
 
     def __init__(self, *args, **kw):
-        ticket = kw.pop('ticket', sessions.get())
+        ticket = kw.pop("ticket", sessions.get())
         super().__init__(*args, **kw)
         self._ticket = ticket
-        logger.debug('TemplatedMail init for id <%s>', self.id)
+        logger.debug("TemplatedMail init for id <%s>", self.id)
 
     @property
     def ticket(self):
@@ -674,19 +724,22 @@ class TemplatedMailService(MailService):
 
     def header(self):
         """String prepended to the message body."""
-        return ''
+        return ""
 
     def trailer(self):
         """String appended to the message body."""
-        return ''
+        return ""
 
     def get_catalog_section(self):
         """Read section <id> (a dict-like) from the catalog."""
         try:
             section = dict(self.catalog.items(self.id))
         except NoSectionError:
-            logger.error('Section <%s> is missing in catalog <%s>',
-                         self.id, self.catalog.file)
+            logger.error(
+                "Section <%s> is missing in catalog <%s>",
+                self.id,
+                self.catalog.file,
+            )
             section = None
         return section
 
@@ -707,28 +760,31 @@ class TemplatedMailService(MailService):
         """
         if not isinstance(tpl, (Template, LegacyTemplatingAdapter)):
             tpl = Template(tpl)
-        result = ''
+        result = ""
         for level in range(depth):
             try:
                 result = tpl.substitute(tpldict)
             except KeyError as exc:
-                logger.error('Undefined key <%s> in template substitution level %d',
-                             str(exc), level + 1)
+                logger.error(
+                    "Undefined key <%s> in template substitution level %d",
+                    str(exc),
+                    level + 1,
+                )
                 result = tpl.safe_substitute(tpldict)
             except ValueError as exc:
-                logger.error('Illegal syntax in template: %s', exc)
+                logger.error("Illegal syntax in template: %s", exc)
                 result = tpl.safe_substitute(tpldict)
             tpl = Template(result)
         return result
 
     def _template_name_rewrite(self, tplguess):
-        base = '@'
+        base = "@"
         if self._TEMPLATES_SUBDIR is not None:
-            base = '@{!s}/'.format(self._TEMPLATES_SUBDIR)
+            base = "@{!s}/".format(self._TEMPLATES_SUBDIR)
         if not tplguess.startswith(base):
             tplguess = base + tplguess
-        if not tplguess.endswith('.tpl'):
-            tplguess += '.tpl'
+        if not tplguess.endswith(".tpl"):
+            tplguess += ".tpl"
         return tplguess
 
     def get_message(self, tpldict):
@@ -739,13 +795,15 @@ class TemplatedMailService(MailService):
         * header and trailer are added.
         """
         tpl = self.message
-        if tpl == '':
-            tplfile = self.section.get('template', self.id)
+        if tpl == "":
+            tplfile = self.section.get("template", self.id)
             tplfile = self._template_name_rewrite(tplfile)
             try:
-                tpl = load_template(self.ticket, tplfile, encoding=self.inputs_charset)
+                tpl = load_template(
+                    self.ticket, tplfile, encoding=self.inputs_charset
+                )
             except ValueError as exc:
-                logger.error('%s', exc.message)
+                logger.error("%s", exc.message)
                 return None
         message = self.substitute(tpl, tpldict)
         return self.header() + message + self.trailer()
@@ -758,9 +816,11 @@ class TemplatedMailService(MailService):
         """
         tpl = self.subject
         if tpl is None:
-            tpl = self.section.get('subject', None)
+            tpl = self.section.get("subject", None)
             if tpl is None:
-                logger.error('Missing <subject> definition for id <%s>.', self.id)
+                logger.error(
+                    "Missing <subject> definition for id <%s>.", self.id
+                )
                 return None
         subject = self.substitute(tpl, tpldict)
         return subject
@@ -776,9 +836,9 @@ class TemplatedMailService(MailService):
         """
         tpl = self.to
         if tpl is None:
-            tpl = self.section.get('to', None)
+            tpl = self.section.get("to", None)
             if tpl is None:
-                logger.error('Missing <to> definition for id <%s>.', self.id)
+                logger.error("Missing <to> definition for id <%s>.", self.id)
                 return None
         to = self.substitute(tpl, tpldict)
         if self.directory:
@@ -834,38 +894,48 @@ class TemplatedMailService(MailService):
 
 
 class AbstractRdTemplatedMailService(TemplatedMailService):
-
     _abstract = True
 
     def header(self):
         """String prepended to the message body."""
         now = date.now()
-        stamp1 = now.strftime('%A %d %B %Y')
-        stamp2 = now.strftime('%X')
-        return 'Email sent on {} at {} (from: {}).\n--\n\n'.format(stamp1, stamp2,
-                                                                   self.sh.default_target.hostname)
+        stamp1 = now.strftime("%A %d %B %Y")
+        stamp2 = now.strftime("%X")
+        return "Email sent on {} at {} (from: {}).\n--\n\n".format(
+            stamp1, stamp2, self.sh.default_target.hostname
+        )
 
     def substitution_dictionary(self, add_ons=None):
         sdict = super().substitution_dictionary(add_ons=add_ons)
-        sdict['jobid'] = self.sh.guess_job_identifier()
+        sdict["jobid"] = self.sh.guess_job_identifier()
         # Try to detect MTOOL data (this may be empty if MTOOL is not used):
         if self.env.MTOOL_STEP:
-            mt_stack = ['\nMTOOL details:', ]
-            mt_items = ['mtool_step_{:s}'.format(i)
-                        for i in ('abort', 'depot', 'spool', 'idnum')
-                        if 'mtool_step_{:s}'.format(i) in self.env]
-            print_tablelike('{:s} = {!s}', mt_items, [self.env[i] for i in mt_items],
-                            output_callback=mt_stack.append)
-            sdict['mtool_info'] = '\n'.join(mt_stack) + '\n'
+            mt_stack = [
+                "\nMTOOL details:",
+            ]
+            mt_items = [
+                "mtool_step_{:s}".format(i)
+                for i in ("abort", "depot", "spool", "idnum")
+                if "mtool_step_{:s}".format(i) in self.env
+            ]
+            print_tablelike(
+                "{:s} = {!s}",
+                mt_items,
+                [self.env[i] for i in mt_items],
+                output_callback=mt_stack.append,
+            )
+            sdict["mtool_info"] = "\n".join(mt_stack) + "\n"
         else:
-            sdict['mtool_info'] = ''
+            sdict["mtool_info"] = ""
         # The list of footprints' defaults
         fpdefaults = footprints.setup.defaults
-        sdict['fpdefaults'] = pprint.pformat(fpdefaults, indent=2)
+        sdict["fpdefaults"] = pprint.pformat(fpdefaults, indent=2)
         # A condensed indication on date/cutoff
-        sdict['timeid'] = fpdefaults.get('date', None)
-        if sdict['timeid']:
-            sdict['timeid'] = sdict['timeid'].vortex(cutoff=fpdefaults.get('cutoff', 'X'))
+        sdict["timeid"] = fpdefaults.get("date", None)
+        if sdict["timeid"]:
+            sdict["timeid"] = sdict["timeid"].vortex(
+                cutoff=fpdefaults.get("cutoff", "X")
+            )
         # The generic host/cluster name
-        sdict['host'] = self.sh.default_target.inetname
+        sdict["host"] = self.sh.default_target.inetname
         return sdict

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -32,7 +32,6 @@ import contextlib
 import ftplib
 import re
 import time
-from collections import defaultdict
 from datetime import datetime
 import os
 
@@ -43,10 +42,7 @@ from bronx.syntax.decorators import nicedeco
 from vortex import sessions
 from vortex.tools.actions import actiond as ad
 from vortex.tools.delayedactions import d_action_status
-from vortex.tools.systems import istruedef
 
-# TODO clean instances of GenericConfigParser
-from vortex.util.config import GenericConfigParser
 from vortex import config
 
 #: No automatic export

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -27,6 +27,7 @@ aspects. Using the :mod:`footprints` package, for a given execution target, it
 allows to customise the way data are accessed leaving the :class:`Store` objects
 unchanged.
 """
+
 import contextlib
 import ftplib
 import re
@@ -43,6 +44,7 @@ from vortex import sessions
 from vortex.tools.actions import actiond as ad
 from vortex.tools.delayedactions import d_action_status
 from vortex.tools.systems import istruedef
+
 # TODO clean instances of GenericConfigParser
 from vortex.util.config import GenericConfigParser
 from vortex import config
@@ -59,6 +61,7 @@ HARDLINK_THRESHOLD = 1048576
 
 # Decorators: for internal use in the Storage class
 # -------------------------------------------------
+
 
 def do_recording(flag):
     """Add a record line in the History object (if sensible)."""
@@ -92,6 +95,7 @@ def enforce_readonly(f):
 # Main Storage abstract class
 # ---------------------------
 
+
 class Storage(footprints.FootprintBase):
     """Root class for any Storage class, ex: Cache, Archive, ...
 
@@ -111,13 +115,13 @@ class Storage(footprints.FootprintBase):
     dictionary whose items will be written in the object's record.
     """
 
-    _abstract = True,
+    _abstract = (True,)
     _footprint = dict(
-        info = 'Default/Abstract storage place description.',
-        attr = dict(
+        info="Default/Abstract storage place description.",
+        attr=dict(
             kind=dict(
                 info="The storage place's kind.",
-                values=['std'],
+                values=["std"],
             ),
             storage=dict(
                 info="The storage target.",
@@ -127,7 +131,7 @@ class Storage(footprints.FootprintBase):
                 type=bool,
                 optional=True,
                 default=False,
-                access='rwx',
+                access="rwx",
             ),
             readonly=dict(
                 info="Disallow insert and delete action for this storage place.",
@@ -135,11 +139,11 @@ class Storage(footprints.FootprintBase):
                 optional=True,
                 default=False,
             ),
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract storage init %s', self.__class__)
+        logger.debug("Abstract storage init %s", self.__class__)
         super().__init__(*args, **kw)
         self._history = History(tag=self.tag)
 
@@ -150,10 +154,10 @@ class Storage(footprints.FootprintBase):
 
     @property
     def realkind(self):
-        return 'storage'
+        return "storage"
 
     def _str_more(self):
-        return 'tag={:s}'.format(self.tag)
+        return "tag={:s}".format(self.tag)
 
     @property
     def context(self):
@@ -239,7 +243,7 @@ class Storage(footprints.FootprintBase):
         return rc
 
     @enforce_readonly
-    @do_recording('INSERT')
+    @do_recording("INSERT")
     def insert(self, item, local, **kwargs):
         """Insert an **item** in the current storage place.
 
@@ -247,7 +251,7 @@ class Storage(footprints.FootprintBase):
         """
         return self._actual_insert(item, local, **kwargs)
 
-    @do_recording('RETRIEVE')
+    @do_recording("RETRIEVE")
     def retrieve(self, item, local, **kwargs):
         """Retrieve an **item** from the current storage place.
 
@@ -271,19 +275,23 @@ class Storage(footprints.FootprintBase):
 
         :note: **local** may be a path to a file or any kind of file like objects.
         """
-        rc, idict = self._actual_finaliseretrieve(retrieve_id, item, local, **kwargs)
+        rc, idict = self._actual_finaliseretrieve(
+            retrieve_id, item, local, **kwargs
+        )
         if rc is not None:
             infos = self._findout_record_infos(kwargs)
             infos.update(idict)
-            self.addrecord('RETRIEVE', item, status=rc, **infos)
+            self.addrecord("RETRIEVE", item, status=rc, **infos)
         return rc
 
-    def _actual_finaliseretrieve(self, retrieve_id, item, local, **kwargs):  # @UnusedVariable
+    def _actual_finaliseretrieve(
+        self, retrieve_id, item, local, **kwargs
+    ):  # @UnusedVariable
         """No delayedretrieve implemented by default."""
         return None, dict()
 
     @enforce_readonly
-    @do_recording('DELETE')
+    @do_recording("DELETE")
     def delete(self, item, **kwargs):
         """Delete an **item** from the current storage place."""
         return self._actual_delete(item, **kwargs)
@@ -292,44 +300,47 @@ class Storage(footprints.FootprintBase):
 # Defining the two main flavours of storage places
 # -----------------------------------------------
 
+
 class Cache(Storage):
     """Root class for any :class:Cache subclasses."""
 
     _abstract = True
-    _collector = ('cache',)
+    _collector = ("cache",)
     _footprint = dict(
-        info = 'Default cache description',
-        attr = dict(
-            headdir = dict(
-                info     = "The cache's subdirectory (within **rootdir**).",
-                optional = True,
-                default  = 'cache',
+        info="Default cache description",
+        attr=dict(
+            headdir=dict(
+                info="The cache's subdirectory (within **rootdir**).",
+                optional=True,
+                default="cache",
             ),
             # TODO is 'storage' used in any way?
-            storage = dict(
-                optional = True,
-                default  = 'localhost',
+            storage=dict(
+                optional=True,
+                default="localhost",
             ),
-            rtouch = dict(
-                info     = "Perform the recursive touch command on the directory structure.",
-                type     = bool,
-                optional = True,
-                default  = False,
+            rtouch=dict(
+                info="Perform the recursive touch command on the directory structure.",
+                type=bool,
+                optional=True,
+                default=False,
             ),
-            rtouchskip = dict(
-                info     = "Do not 'touch' the first **rtouchskip** directories.",
-                type     = int,
-                optional = True,
-                default  = 0,
+            rtouchskip=dict(
+                info="Do not 'touch' the first **rtouchskip** directories.",
+                type=int,
+                optional=True,
+                default=0,
             ),
-            rtouchdelay = dict(
-                info     = ("Do not perfom a touch if it has already been done in " +
-                            "the last X seconds."),
-                type     = float,
-                optional = True,
-                default  = 600.,  # 10 minutes
+            rtouchdelay=dict(
+                info=(
+                    "Do not perfom a touch if it has already been done in "
+                    + "the last X seconds."
+                ),
+                type=float,
+                optional=True,
+                default=600.0,  # 10 minutes
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
@@ -338,12 +349,12 @@ class Cache(Storage):
 
     @property
     def realkind(self):
-        return 'cache'
+        return "cache"
 
     @property
     def tag(self):
         """The identifier of this cache place."""
-        return '{:s}_{:s}_{:s}'.format(self.realkind, self.kind, self.headdir)
+        return "{:s}_{:s}_{:s}".format(self.realkind, self.kind, self.headdir)
 
     def _formatted_path(self, subpath, **kwargs):  # @UnusedVariable
         raise NotImplementedError()
@@ -363,11 +374,11 @@ class Cache(Storage):
         ts = time.time()
         ts_delay = ts - self._touch_tracker.get(path, 0)
         if ts_delay > self.rtouchdelay:
-            logger.debug('Touching: %s (delay was %.2f)', path, ts_delay)
+            logger.debug("Touching: %s (delay was %.2f)", path, ts_delay)
             self.sh.touch(path)
             self._touch_tracker[path] = ts
         else:
-            logger.debug('Skipping touch: %s (delay was %.2f)', path, ts_delay)
+            logger.debug("Skipping touch: %s (delay was %.2f)", path, ts_delay)
 
     def _recursive_touch(self, rc, item, writing=False):
         """Make recursive touches on parent directories.
@@ -375,13 +386,15 @@ class Cache(Storage):
         It might be useful for cleaning scripts.
         """
         if self.rtouch and (not self.readonly) and rc:
-            items = item.lstrip('/').split('/')
+            items = item.lstrip("/").split("/")
             items = items[:-1]
             if writing:
                 # It's useless to touch the rightmost directory
                 items = items[:-1] if len(items) > 1 else []
             for index in range(len(items), self.rtouchskip, -1):
-                self._xtouch(self._formatted_path(self.sh.path.join(*items[:index])))
+                self._xtouch(
+                    self._formatted_path(self.sh.path.join(*items[:index]))
+                )
 
     def _actual_fullpath(self, item, **kwargs):
         """Return the path/URI to the **item**'s storage location."""
@@ -389,8 +402,9 @@ class Cache(Storage):
 
     def _actual_prestageinfo(self, item, **kwargs):
         """Returns pre-staging informations."""
-        return dict(strategy=self.kind,
-                    location=self.fullpath(item, **kwargs)), dict()
+        return dict(
+            strategy=self.kind, location=self.fullpath(item, **kwargs)
+        ), dict()
 
     def _actual_check(self, item, **kwargs):
         """Check/Stat an **item** from the current storage place."""
@@ -422,10 +436,15 @@ class Cache(Storage):
         # Insert the element
         tpath = self._formatted_path(item)
         if tpath is not None:
-            rc = self.sh.cp(local, tpath, intent=intent, fmt=fmt,
-                            smartcp_threshold=HARDLINK_THRESHOLD)
+            rc = self.sh.cp(
+                local,
+                tpath,
+                intent=intent,
+                fmt=fmt,
+                smartcp_threshold=HARDLINK_THRESHOLD,
+            )
         else:
-            logger.warning('No target location for < %s >', item)
+            logger.warning("No target location for < %s >", item)
             rc = False
         self._recursive_touch(rc, item, writing=True)
         return rc, dict(intent=intent, fmt=fmt)
@@ -442,30 +461,55 @@ class Cache(Storage):
         source = self._formatted_path(item)
         if source is not None:
             # If auto_dirextract, copy recursively each file contained in source
-            if dirextract and self.sh.path.isdir(source) and self.sh.is_tarname(local):
+            if (
+                dirextract
+                and self.sh.path.isdir(source)
+                and self.sh.is_tarname(local)
+            ):
                 rc = True
                 destdir = self.sh.path.dirname(self.sh.path.realpath(local))
-                logger.info('Automatic directory extract to: %s', destdir)
-                for subpath in self.sh.glob(source + '/*'):
-                    rc = rc and self.sh.cp(subpath,
-                                           self.sh.path.join(destdir, self.sh.path.basename(subpath)),
-                                           intent=intent, fmt=fmt,
-                                           smartcp_threshold=HARDLINK_THRESHOLD)
+                logger.info("Automatic directory extract to: %s", destdir)
+                for subpath in self.sh.glob(source + "/*"):
+                    rc = rc and self.sh.cp(
+                        subpath,
+                        self.sh.path.join(
+                            destdir, self.sh.path.basename(subpath)
+                        ),
+                        intent=intent,
+                        fmt=fmt,
+                        smartcp_threshold=HARDLINK_THRESHOLD,
+                    )
                     # For the insitu feature to work...
                     rc = rc and self.sh.touch(local)
             # The usual case: just copy source
             else:
-                rc = self.sh.cp(source, local, intent=intent, fmt=fmt, silent=silent,
-                                smartcp_threshold=HARDLINK_THRESHOLD)
+                rc = self.sh.cp(
+                    source,
+                    local,
+                    intent=intent,
+                    fmt=fmt,
+                    silent=silent,
+                    smartcp_threshold=HARDLINK_THRESHOLD,
+                )
                 # If auto_tarextract, a potential tar file is extracted
-                if (rc and tarextract and not self.sh.path.isdir(local) and
-                        self.sh.is_tarname(local) and self.sh.is_tarfile(local)):
-                    destdir = self.sh.path.dirname(self.sh.path.realpath(local))
-                    logger.info('Automatic Tar extract to: %s', destdir)
-                    rc = rc and self.sh.smartuntar(local, destdir,
-                                                   uniquelevel_ignore=uniquelevel_ignore)
+                if (
+                    rc
+                    and tarextract
+                    and not self.sh.path.isdir(local)
+                    and self.sh.is_tarname(local)
+                    and self.sh.is_tarfile(local)
+                ):
+                    destdir = self.sh.path.dirname(
+                        self.sh.path.realpath(local)
+                    )
+                    logger.info("Automatic Tar extract to: %s", destdir)
+                    rc = rc and self.sh.smartuntar(
+                        local, destdir, uniquelevel_ignore=uniquelevel_ignore
+                    )
         else:
-            getattr(logger, 'info' if silent else 'warning')('No readable source for < %s >', item)
+            getattr(logger, "info" if silent else "warning")(
+                "No readable source for < %s >", item
+            )
             rc = False
         self._recursive_touch(rc, item)
         return rc, dict(intent=intent, fmt=fmt)
@@ -479,7 +523,7 @@ class Cache(Storage):
         if tpath is not None:
             rc = self.sh.remove(tpath, fmt=fmt)
         else:
-            logger.warning('No target location for < %s >', item)
+            logger.warning("No target location for < %s >", item)
             rc = False
         return rc, dict(fmt=fmt)
 
@@ -488,34 +532,36 @@ class AbstractArchive(Storage):
     """The default class to handle storage to some kind if Archive."""
 
     _abstract = True
-    _collector = ('archive',)
+    _collector = ("archive",)
     _footprint = dict(
-        info = 'Default archive description',
-        attr = dict(
-            tube = dict(
-                info     = "How to communicate with the archive ?",
+        info="Default archive description",
+        attr=dict(
+            tube=dict(
+                info="How to communicate with the archive ?",
             ),
-        )
+        ),
     )
 
     @property
     def tag(self):
         """The identifier of this cache place."""
-        return '{:s}_{:s}_{:s}'.format(self.realkind, self.storage, self.kind)
+        return "{:s}_{:s}_{:s}".format(self.realkind, self.storage, self.kind)
 
     @property
     def realkind(self):
-        return 'archive'
+        return "archive"
 
     def _formatted_path(self, rawpath, **kwargs):
-        root = kwargs.get('root', None)
+        root = kwargs.get("root", None)
         if root is not None:
-            rawpath = self.sh.path.join(root, rawpath.lstrip('/'))
+            rawpath = self.sh.path.join(root, rawpath.lstrip("/"))
         # Deal with compression
-        compressionpipeline = kwargs.get('compressionpipeline', None)
+        compressionpipeline = kwargs.get("compressionpipeline", None)
         if compressionpipeline is not None:
             rawpath += compressionpipeline.suffix
-        return self.sh.anyft_remote_rewrite(rawpath, fmt=kwargs.get('fmt', 'foo'))
+        return self.sh.anyft_remote_rewrite(
+            rawpath, fmt=kwargs.get("fmt", "foo")
+        )
 
     def _actual_proxy_method(self, pmethod):
         """Create a proxy method based on the **pmethod** actual method."""
@@ -532,18 +578,23 @@ class AbstractArchive(Storage):
 
     def __getattr__(self, attr):
         """Provides proxy methods for _actual_* methods."""
-        methods = r'fullpath|prestageinfo|check|list|insert|retrieve|delete'
-        mattr = re.match(r'_actual_(?P<action>' + methods + r')', attr)
+        methods = r"fullpath|prestageinfo|check|list|insert|retrieve|delete"
+        mattr = re.match(r"_actual_(?P<action>" + methods + r")", attr)
         if mattr:
-            pmethod = getattr(self, '_{:s}{:s}'.format(self.tube, mattr.group('action')))
+            pmethod = getattr(
+                self, "_{:s}{:s}".format(self.tube, mattr.group("action"))
+            )
             return self._actual_proxy_method(pmethod)
         else:
-            raise AttributeError("The {:s} attribute was not found in this object"
-                                 .format(attr))
+            raise AttributeError(
+                "The {:s} attribute was not found in this object".format(attr)
+            )
 
     def _actual_earlyretrieve(self, item, local, **kwargs):
         """Proxy to the appropriate tube dependent earlyretrieve method (if available)."""
-        pmethod = getattr(self, '_{:s}{:s}'.format(self.tube, 'earlyretrieve'), None)
+        pmethod = getattr(
+            self, "_{:s}{:s}".format(self.tube, "earlyretrieve"), None
+        )
         if pmethod:
             return self._actual_proxy_method(pmethod)(item, local, **kwargs)
         else:
@@ -551,9 +602,13 @@ class AbstractArchive(Storage):
 
     def _actual_finaliseretrieve(self, retrieve_id, item, local, **kwargs):
         """Proxy to the appropriate tube dependent finaliseretrieve method (if available)."""
-        pmethod = getattr(self, '_{:s}{:s}'.format(self.tube, 'finaliseretrieve'), None)
+        pmethod = getattr(
+            self, "_{:s}{:s}".format(self.tube, "finaliseretrieve"), None
+        )
         if pmethod:
-            return self._actual_proxy_method(pmethod)(item, local, retrieve_id, **kwargs)
+            return self._actual_proxy_method(pmethod)(
+                item, local, retrieve_id, **kwargs
+            )
         else:
             return None, dict()
 
@@ -562,41 +617,46 @@ class Archive(AbstractArchive):
     """The default class to handle storage to a remote location."""
 
     _footprint = dict(
-        info = 'Default archive description',
-        attr = dict(
-            tube = dict(
-                values   = ['ftp'],
+        info="Default archive description",
+        attr=dict(
+            tube=dict(
+                values=["ftp"],
             ),
-        )
+        ),
     )
 
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
         self.default_usejeeves = config.from_config(
-            section="storage", key="usejeeves",
+            section="storage",
+            key="usejeeves",
         )
 
     @property
     def _ftp_hostinfos(self):
         """Return the FTP hostname end port number."""
-        s_storage = self.storage.split(':', 1)
+        s_storage = self.storage.split(":", 1)
         hostname = s_storage[0]
         port = None
         if len(s_storage) > 1:
             try:
                 port = int(s_storage[1])
             except ValueError:
-                logger.error('Invalid port number < %s >. Ignoring it', s_storage[1])
+                logger.error(
+                    "Invalid port number < %s >. Ignoring it", s_storage[1]
+                )
         return hostname, port
 
     def _ftp_client(self, logname=None, delayed=False):
         """Return a FTP client object."""
         hostname, port = self._ftp_hostinfos
-        return self.sh.ftp(hostname, logname=logname, delayed=delayed, port=port)
+        return self.sh.ftp(
+            hostname, logname=logname, delayed=delayed, port=port
+        )
 
     def _ftpfullpath(self, item, **kwargs):
         """Actual _fullpath using ftp."""
-        username = kwargs.get('username', None)
+        username = kwargs.get("username", None)
         rc = None
         ftp = self._ftp_client(logname=username, delayed=True)
         if ftp:
@@ -608,7 +668,7 @@ class Archive(AbstractArchive):
 
     def _ftpprestageinfo(self, item, **kwargs):
         """Actual _prestageinfo using ftp."""
-        username = kwargs.get('username', None)
+        username = kwargs.get("username", None)
         if username is None:
             ftp = self._ftp_client(logname=username, delayed=True)
             if ftp:
@@ -616,15 +676,17 @@ class Archive(AbstractArchive):
                     username = ftp.logname
                 finally:
                     ftp.close()
-        baseinfo = dict(storage=self.storage,
-                        logname=username,
-                        location=item, )
+        baseinfo = dict(
+            storage=self.storage,
+            logname=username,
+            location=item,
+        )
         return baseinfo, dict()
 
     def _ftpcheck(self, item, **kwargs):
         """Actual _check using ftp."""
         rc = None
-        ftp = self._ftp_client(logname=kwargs.get('username', None))
+        ftp = self._ftp_client(logname=kwargs.get("username", None))
         if ftp:
             try:
                 rc = ftp.size(item)
@@ -638,7 +700,7 @@ class Archive(AbstractArchive):
 
     def _ftplist(self, item, **kwargs):
         """Actual _list using ftp."""
-        ftp = self._ftp_client(logname=kwargs.get('username', None))
+        ftp = self._ftp_client(logname=kwargs.get("username", None))
         rc = None
         if ftp:
             try:
@@ -657,26 +719,30 @@ class Archive(AbstractArchive):
             else:
                 # Content of the directory...
                 if rc:
-                    rc = ftp.nlst('.')
+                    rc = ftp.nlst(".")
             finally:
                 ftp.close()
         return rc, dict()
 
     def _ftpretrieve(self, item, local, **kwargs):
         """Actual _retrieve using ftp."""
-        logger.info('ftpget on ftp://%s/%s (to: %s)', self.storage, item, local)
-        extras = dict(fmt=kwargs.get('fmt', 'foo'),
-                      cpipeline=kwargs.get('compressionpipeline', None))
+        logger.info(
+            "ftpget on ftp://%s/%s (to: %s)", self.storage, item, local
+        )
+        extras = dict(
+            fmt=kwargs.get("fmt", "foo"),
+            cpipeline=kwargs.get("compressionpipeline", None),
+        )
         hostname, port = self._ftp_hostinfos
         if port is not None:
-            extras['port'] = port
+            extras["port"] = port
         rc = self.sh.smartftget(
             item,
             local,
             # Ftp control
             hostname=hostname,
-            logname=kwargs.get('username', None),
-            **extras
+            logname=kwargs.get("username", None),
+            **extras,
         )
         return rc, extras
 
@@ -685,32 +751,42 @@ class Archive(AbstractArchive):
         If FtServ/ftraw is used, trigger a delayed action in order to fetch
         several files at once.
         """
-        cpipeline = kwargs.get('compressionpipeline', None)
+        cpipeline = kwargs.get("compressionpipeline", None)
         if self.sh.rawftget_worthy(item, local, cpipeline):
-            return self.context.delayedactions_hub.register((item, kwargs.get('fmt', 'foo')),
-                                                            kind='archive',
-                                                            storage=self.storage,
-                                                            goal='get',
-                                                            tube='ftp',
-                                                            raw=True,
-                                                            logname=kwargs.get('username', None))
+            return self.context.delayedactions_hub.register(
+                (item, kwargs.get("fmt", "foo")),
+                kind="archive",
+                storage=self.storage,
+                goal="get",
+                tube="ftp",
+                raw=True,
+                logname=kwargs.get("username", None),
+            )
         else:
             return None
 
-    def _ftpfinaliseretrieve(self, item, local, retrieve_id, **kwargs):  # @UnusedVariable
+    def _ftpfinaliseretrieve(
+        self, item, local, retrieve_id, **kwargs
+    ):  # @UnusedVariable
         """
         Get the resource given the **retrieve_id** identifier returned by the
         :meth:`_ftpearlyretrieve` method.
         """
-        extras = dict(fmt=kwargs.get('fmt', 'foo'), )
-        d_action = self.context.delayedactions_hub.retrieve(retrieve_id, bareobject=True)
+        extras = dict(
+            fmt=kwargs.get("fmt", "foo"),
+        )
+        d_action = self.context.delayedactions_hub.retrieve(
+            retrieve_id, bareobject=True
+        )
         if d_action.status == d_action_status.done:
             if self.sh.filecocoon(local):
                 rc = self.sh.mv(d_action.result, local, **extras)
             else:
-                raise OSError('Could not cocoon: {!s}'.format(local))
+                raise OSError("Could not cocoon: {!s}".format(local))
         elif d_action.status == d_action_status.failed:
-            logger.info('The earlyretrieve failed (retrieve_id=%s)', retrieve_id)
+            logger.info(
+                "The earlyretrieve failed (retrieve_id=%s)", retrieve_id
+            )
             rc = False
         else:
             rc = None
@@ -718,64 +794,78 @@ class Archive(AbstractArchive):
 
     def _ftpinsert(self, item, local, **kwargs):
         """Actual _insert using ftp."""
-        usejeeves = kwargs.get('usejeeves', None)
+        usejeeves = kwargs.get("usejeeves", None)
         if usejeeves is None:
             usejeeves = self.default_usejeeves
         hostname, port = self._ftp_hostinfos
         if not usejeeves:
-            logger.info('ftpput to ftp://%s/%s (from: %s)', self.storage, item, local)
-            extras = dict(fmt=kwargs.get('fmt', 'foo'),
-                          cpipeline=kwargs.get('compressionpipeline', None))
+            logger.info(
+                "ftpput to ftp://%s/%s (from: %s)", self.storage, item, local
+            )
+            extras = dict(
+                fmt=kwargs.get("fmt", "foo"),
+                cpipeline=kwargs.get("compressionpipeline", None),
+            )
             if port is not None:
-                extras['port'] = port
+                extras["port"] = port
             rc = self.sh.smartftput(
                 local,
                 item,
                 # Ftp control
                 hostname=hostname,
-                logname=kwargs.get('username', None),
-                sync=kwargs.get('enforcesync', False),
-                **extras
+                logname=kwargs.get("username", None),
+                sync=kwargs.get("enforcesync", False),
+                **extras,
             )
         else:
-            logger.info('delayed ftpput to ftp://%s/%s (from: %s)', self.storage, item, local)
-            tempo = footprints.proxy.service(kind='hiddencache',
-                                             asfmt=kwargs.get('fmt'))
-            compressionpipeline = kwargs.get('compressionpipeline', '')
+            logger.info(
+                "delayed ftpput to ftp://%s/%s (from: %s)",
+                self.storage,
+                item,
+                local,
+            )
+            tempo = footprints.proxy.service(
+                kind="hiddencache", asfmt=kwargs.get("fmt")
+            )
+            compressionpipeline = kwargs.get("compressionpipeline", "")
             if compressionpipeline:
                 compressionpipeline = compressionpipeline.description_string
-            extras = dict(fmt=kwargs.get('fmt', 'foo'),
-                          cpipeline=compressionpipeline)
+            extras = dict(
+                fmt=kwargs.get("fmt", "foo"), cpipeline=compressionpipeline
+            )
             if port is not None:
-                extras['port'] = port
+                extras["port"] = port
 
             rc = ad.jeeves(
                 hostname=hostname,
                 # Explicitly resolve the logname (because jeeves FTP client is not
                 # running with the same glove (i.e. Jeeves ftuser configuration may
                 # be different).
-                logname=self.sh.fix_ftuser(hostname,
-                                           kwargs.get('username', None)),
-                todo='ftput',
-                rhandler=kwargs.get('info', None),
+                logname=self.sh.fix_ftuser(
+                    hostname, kwargs.get("username", None)
+                ),
+                todo="ftput",
+                rhandler=kwargs.get("info", None),
                 source=tempo(local),
                 destination=item,
                 original=self.sh.path.abspath(local),
-                **extras
+                **extras,
             )
         return rc, extras
 
     def _ftpdelete(self, item, **kwargs):
         """Actual _delete using ftp."""
         rc = None
-        ftp = self._ftp_client(logname=kwargs.get('username', None))
+        ftp = self._ftp_client(logname=kwargs.get("username", None))
         if ftp:
             if self._ftpcheck(item, **kwargs)[0]:
-                logger.info('ftpdelete on ftp://%s/%s', self.storage, item)
+                logger.info("ftpdelete on ftp://%s/%s", self.storage, item)
                 rc = ftp.delete(item)
                 ftp.close()
             else:
-                logger.error('Try to remove a non-existing resource <%s>', item)
+                logger.error(
+                    "Try to remove a non-existing resource <%s>", item
+                )
         return rc, dict()
 
 
@@ -784,12 +874,14 @@ class AbstractLocalArchive(AbstractArchive):
 
     _abstract = True
     _footprint = dict(
-        info = 'Generic local archive description',
-        attr = dict(
-            tube = dict(
-                values   = ['inplace', ],
+        info="Generic local archive description",
+        attr=dict(
+            tube=dict(
+                values=[
+                    "inplace",
+                ],
             ),
-        )
+        ),
     )
 
     def _inplacefullpath(self, item, **kwargs):
@@ -818,14 +910,14 @@ class AbstractLocalArchive(AbstractArchive):
 
     def _inplaceretrieve(self, item, local, **kwargs):
         """Actual _retrieve using ftp."""
-        logger.info('inplaceget on file:///%s (to: %s)', item, local)
-        fmt = kwargs.get('fmt', 'foo')
-        cpipeline = kwargs.get('compressionpipeline', None)
+        logger.info("inplaceget on file:///%s (to: %s)", item, local)
+        fmt = kwargs.get("fmt", "foo")
+        cpipeline = kwargs.get("compressionpipeline", None)
         if cpipeline:
             rc = cpipeline.file2uncompress(item, local)
         else:
             # Do not use fmt=... on purpose (otherwise "forceunpack" may be called twice)
-            rc = self.sh.cp(item, local, intent='in')
+            rc = self.sh.cp(item, local, intent="in")
         rc = rc and self.sh.forceunpack(local, fmt=fmt)
         return rc, dict(fmt=fmt, cpipeline=cpipeline)
 
@@ -842,20 +934,20 @@ class AbstractLocalArchive(AbstractArchive):
 
     def _inplaceinsert(self, item, local, **kwargs):
         """Actual _insert using ftp."""
-        logger.info('inplaceput to file:///%s (from: %s)', item, local)
-        cpipeline = kwargs.get('compressionpipeline', None)
-        fmt = kwargs.get('fmt', 'foo')
+        logger.info("inplaceput to file:///%s (from: %s)", item, local)
+        cpipeline = kwargs.get("compressionpipeline", None)
+        fmt = kwargs.get("fmt", "foo")
         with self._inplaceinsert_pack(local, fmt) as local_packed:
             if cpipeline:
                 rc = cpipeline.compress2file(local_packed, item)
             else:
                 # Do not use fmt=... on purpose (otherwise "forcepack" may be called twice)
-                rc = self.sh.cp(local_packed, item, intent='in')
+                rc = self.sh.cp(local_packed, item, intent="in")
         return rc, dict(fmt=fmt, cpipeline=cpipeline)
 
     def _inplacedelete(self, item, **kwargs):
         """Actual _delete using ftp."""
-        fmt = kwargs.get('fmt', 'foo')
+        fmt = kwargs.get("fmt", "foo")
         rc = None
         if self._inplacecheck(item, **kwargs)[0]:
             rc = self.sh.rm(item, fmt=fmt)
@@ -866,28 +958,32 @@ class LocalArchive(AbstractLocalArchive):
     """The default class to handle storage to the same host."""
 
     _footprint = dict(
-        info = 'Default local archive description',
-        attr = dict(
-            storage = dict(
-                values   = ['localhost', ],
+        info="Default local archive description",
+        attr=dict(
+            storage=dict(
+                values=[
+                    "localhost",
+                ],
             ),
-            auto_self_expand = dict(
-                info     = ('Automatically expand the current user home if ' +
-                            'a relative path is given (should always be True ' +
-                            'except during unit-testing)'),
-                type     = bool,
-                default  = True,
-                optional = True,
+            auto_self_expand=dict(
+                info=(
+                    "Automatically expand the current user home if "
+                    + "a relative path is given (should always be True "
+                    + "except during unit-testing)"
+                ),
+                type=bool,
+                default=True,
+                optional=True,
             ),
-        )
+        ),
     )
 
     def _formatted_path(self, rawpath, **kwargs):
         rawpath = self.sh.path.expanduser(rawpath)
-        if '~' in rawpath:
+        if "~" in rawpath:
             raise OSError('User expansion failed for "{:s}"'.format(rawpath))
         if self.auto_self_expand and not self.sh.path.isabs(rawpath):
-            rawpath = self.sh.path.expanduser(self.sh.path.join('~', rawpath))
+            rawpath = self.sh.path.expanduser(self.sh.path.join("~", rawpath))
         return super()._formatted_path(rawpath, **kwargs)
 
 
@@ -898,14 +994,14 @@ class LocalArchive(AbstractLocalArchive):
 class FixedEntryCache(Cache):
     _abstract = True
     _footprint = dict(
-        info = 'Default cache description (with a fixed entry point)',
-        attr = dict(
-            rootdir = dict(
-                info     = "The cache's location (usually on a filesystem).",
-                optional = True,
-                default  = None,
+        info="Default cache description (with a fixed entry point)",
+        attr=dict(
+            rootdir=dict(
+                info="The cache's location (usually on a filesystem).",
+                optional=True,
+                default=None,
             ),
-        )
+        ),
     )
 
     @property
@@ -918,10 +1014,10 @@ class FixedEntryCache(Cache):
     @property
     def tag(self):
         """The identifier of this cache place."""
-        return '{:s}_{:s}'.format(self.realkind, self.entry)
+        return "{:s}_{:s}".format(self.realkind, self.entry)
 
     def _formatted_path(self, subpath, **kwargs):  # @UnusedVariable
-        return self.sh.path.join(self.entry, subpath.lstrip('/'))
+        return self.sh.path.join(self.entry, subpath.lstrip("/"))
 
     def catalog(self):
         """List all files present in this cache.
@@ -930,18 +1026,20 @@ class FixedEntryCache(Cache):
         """
         entry = self.sh.path.expanduser(self.entry)
         files = self.sh.ffind(entry)
-        return [f[len(entry):] for f in files]
+        return [f[len(entry) :] for f in files]
 
     def flush(self, dumpfile=None):
         """Flush actual history to the specified ``dumpfile`` if record is on."""
         if dumpfile is None:
-            logfile = '.'.join((
-                'HISTORY',
-                datetime.now().strftime('%Y%m%d%H%M%S.%f'),
-                'P{:06d}'.format(self.sh.getpid()),
-                self.sh.getlogname()
-            ))
-            dumpfile = self.sh.path.join(self.entry, '.history', logfile)
+            logfile = ".".join(
+                (
+                    "HISTORY",
+                    datetime.now().strftime("%Y%m%d%H%M%S.%f"),
+                    "P{:06d}".format(self.sh.getpid()),
+                    self.sh.getlogname(),
+                )
+            )
+            dumpfile = self.sh.path.join(self.entry, ".history", logfile)
         if self.record:
             self.sh.pickle_dump(self.history, dumpfile)
 
@@ -950,17 +1048,17 @@ class MtoolCache(FixedEntryCache):
     """Cache items for the MTOOL jobs (or any job that acts like it)."""
 
     _footprint = dict(
-        info = 'MTOOL like Cache',
-        attr = dict(
-            kind = dict(
-                values   = ['mtool', 'swapp'],
-                remap    = dict(swapp = 'mtool'),
+        info="MTOOL like Cache",
+        attr=dict(
+            kind=dict(
+                values=["mtool", "swapp"],
+                remap=dict(swapp="mtool"),
             ),
-            headdir = dict(
-                optional = True,
-                default  = "",
+            headdir=dict(
+                optional=True,
+                default="",
             ),
-        )
+        ),
     )
 
     @property
@@ -974,7 +1072,8 @@ class MtoolCache(FixedEntryCache):
 
         if config.is_defined(section="data-tree", key="rootdir"):
             rootdir = config.from_config(
-                section="data-tree", key="rootdir",
+                section="data-tree",
+                key="rootdir",
             )
         else:
             rootdir = self.sh.path.join(os.environ["HOME"], ".vortex.d")
@@ -986,16 +1085,18 @@ class FtStashCache(MtoolCache):
     """A place to store file to be sent with ftserv."""
 
     _footprint = dict(
-        info = 'A place to store file to be sent with ftserv',
-        attr = dict(
-            kind = dict(
-                values   = ['ftstash', ],
+        info="A place to store file to be sent with ftserv",
+        attr=dict(
+            kind=dict(
+                values=[
+                    "ftstash",
+                ],
             ),
-            headdir = dict(
-                optional = True,
-                default  = 'ftspool',
+            headdir=dict(
+                optional=True,
+                default="ftspool",
             ),
-        )
+        ),
     )
 
 
@@ -1003,27 +1104,28 @@ class Op2ResearchCache(FixedEntryCache):
     """Cache of the operational suite (read-only)."""
 
     _footprint = dict(
-        info = 'MTOOL like Operations Cache (read-only)',
-        attr = dict(
-            kind = dict(
-                values   = ['op2r'],
+        info="MTOOL like Operations Cache (read-only)",
+        attr=dict(
+            kind=dict(
+                values=["op2r"],
             ),
-            headdir = dict(
-                optional = True,
-                default  = 'vortex',
+            headdir=dict(
+                optional=True,
+                default="vortex",
             ),
-            readonly = dict(
-                values  = [True, ],
-                default = True,
-            )
-        )
+            readonly=dict(
+                values=[
+                    True,
+                ],
+                default=True,
+            ),
+        ),
     )
 
     @property
     def entry(self):
-        cache = (
-            self.rootdir or
-            config.from_config(section="data-tree", key="op_rootdir")
+        cache = self.rootdir or config.from_config(
+            section="data-tree", key="op_rootdir"
         )
         return self.sh.path.join(cache, self.headdir)
 
@@ -1032,30 +1134,27 @@ class HackerCache(FixedEntryCache):
     """A dirty cache where users can hack things."""
 
     _footprint = dict(
-        info = 'A place to hack things...',
-        attr = dict(
-            kind = dict(
-                values   = ['hack'],
+        info="A place to hack things...",
+        attr=dict(
+            kind=dict(
+                values=["hack"],
             ),
-            rootdir = dict(
-                optional = True,
-                default  = 'auto'
+            rootdir=dict(optional=True, default="auto"),
+            readonly=dict(
+                default=True,
             ),
-            readonly = dict(
-                default = True,
-            ),
-        )
+        ),
     )
 
     @property
     def entry(self):
         """Tries to figure out what could be the actual entry point for cache space."""
         sh = self.sh
-        if self.rootdir == 'auto':
+        if self.rootdir == "auto":
             gl = sessions.current().glove
-            sweethome = sh.path.join(gl.configrc, 'hack')
+            sweethome = sh.path.join(gl.configrc, "hack")
             sh.mkdir(sweethome)
-            logger.debug('Using %s hack cache: %s', self.__class__, sweethome)
+            logger.debug("Using %s hack cache: %s", self.__class__, sweethome)
         else:
             sweethome = self.rootdir
         return sh.path.join(sweethome, self.headdir)

--- a/src/vortex/tools/surfex.py
+++ b/src/vortex/tools/surfex.py
@@ -15,7 +15,7 @@ logger = loggers.getLogger(__name__)
 
 def use_in_shell(sh, **kw):
     """Extend current shell with the sfxtools interface defined by optional arguments."""
-    kw['shell'] = sh
+    kw["shell"] = sh
     return footprints.proxy.addon(**kw)
 
 
@@ -24,38 +24,38 @@ class SFX_Tool(addons.Addon):
     Interface to the sfxtools command.
     """
 
-    LFI_HNDL_SPEC = ':1'
+    LFI_HNDL_SPEC = ":1"
     DR_HOOK_SILENT = 1
     DR_HOOK_NOT_MPI = 1
-    OMP_STACKSIZE = '32M'
-    KMP_STACKSIZE = '32M'
-    KMP_MONITOR_STACKSIZE = '32M'
+    OMP_STACKSIZE = "32M"
+    KMP_STACKSIZE = "32M"
+    KMP_MONITOR_STACKSIZE = "32M"
 
     _footprint = dict(
-        info = 'Default SFXTools interface',
-        attr = dict(
-            kind = dict(
-                values   = ['sfx', 'surfex'],
+        info="Default SFXTools interface",
+        attr=dict(
+            kind=dict(
+                values=["sfx", "surfex"],
             ),
-            cmd = dict(
-                alias    = ('sfxcmd',),
-                default  = 'sfxtools',
+            cmd=dict(
+                alias=("sfxcmd",),
+                default="sfxtools",
             ),
-            path = dict(
-                alias    = ('sfxpath',),
+            path=dict(
+                alias=("sfxpath",),
             ),
-            toolkind = dict(
-                default  = 'sfxtools',
-            )
-        )
+            toolkind=dict(
+                default="sfxtools",
+            ),
+        ),
     )
 
     def sfx_fa2lfi(self, fafile, lfifile):
-        return self._spawn(['sfxfa2lfi',
-                            '--sfx-fa--file', fafile,
-                            '--sfx-lfi-file', lfifile])
+        return self._spawn(
+            ["sfxfa2lfi", "--sfx-fa--file", fafile, "--sfx-lfi-file", lfifile]
+        )
 
     def sfx_lfi2fa(self, lfifile, fafile):
-        return self._spawn(['sfxlfi2fa',
-                            '--sfx-fa--file', fafile,
-                            '--sfx-lfi-file', lfifile])
+        return self._spawn(
+            ["sfxlfi2fa", "--sfx-fa--file", fafile, "--sfx-lfi-file", lfifile]
+        )

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -74,13 +74,13 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 #: Pre-compiled regex to check a none str value
-isnonedef = re.compile(r'\s*none\s*$', re.IGNORECASE)
+isnonedef = re.compile(r"\s*none\s*$", re.IGNORECASE)
 
 #: Pre-compiled regex to check a boolean true str value
-istruedef = re.compile(r'\s*(on|true|ok)\s*$', re.IGNORECASE)
+istruedef = re.compile(r"\s*(on|true|ok)\s*$", re.IGNORECASE)
 
 #: Pre-compiled regex to check a boolean false str value
-isfalsedef = re.compile(r'\s*(off|false|ko)\s*$', re.IGNORECASE)
+isfalsedef = re.compile(r"\s*(off|false|ko)\s*$", re.IGNORECASE)
 
 #: Global lock to protect temporary locale changes
 LOCALE_LOCK = threading.Lock()
@@ -97,7 +97,9 @@ _fmtshcmd_docbonus = """
 # Constant items
 
 #: Definition of a named tuple ftpflavour
-FtpFlavourTuple = namedtuple('FtpFlavourTuple', ['STD', 'RETRIES', 'CONNECTION_POOLS'])
+FtpFlavourTuple = namedtuple(
+    "FtpFlavourTuple", ["STD", "RETRIES", "CONNECTION_POOLS"]
+)
 
 #: Predefined FTP_FLAVOUR values IN, OUT and INOUT.
 FTP_FLAVOUR = FtpFlavourTuple(STD=0, RETRIES=1, CONNECTION_POOLS=2)
@@ -114,10 +116,12 @@ def fmtshcmd(func):
     """
 
     def formatted_method(self, *args, **kw):
-        fmt = kw.pop('fmt', None)
+        fmt = kw.pop("fmt", None)
         shtarget = self if isinstance(self, System) else self.sh
-        fmtcall = getattr(shtarget, str(fmt).lower() + '_' + func.__name__, func)
-        if getattr(fmtcall, 'func_extern', False):
+        fmtcall = getattr(
+            shtarget, str(fmt).lower() + "_" + func.__name__, func
+        )
+        if getattr(fmtcall, "func_extern", False):
             return fmtcall(*args, **kw)
         else:
             return fmtcall(self, *args, **kw)
@@ -144,11 +148,13 @@ def _kw2spawn(func):
 
 class ExecutionError(RuntimeError):
     """Go through exception for internal :meth:`OSExtended.spawn` errors."""
+
     pass
 
 
 class CopyTreeError(OSError):
     """An error raised during the recursive copy of a directory."""
+
     pass
 
 
@@ -171,12 +177,12 @@ class CdContext:
         self.newpath = self.sh.path.expanduser(newpath)
 
     def __enter__(self):
-        if self.newpath not in ('', '.'):
+        if self.newpath not in ("", "."):
             self.oldpath = self.sh.getcwd()
             self.sh.cd(self.newpath, create=self.create)
 
     def __exit__(self, etype, value, traceback):  # @UnusedVariable
-        if self.newpath not in ('', '.'):
+        if self.newpath not in ("", "."):
             self.sh.cd(self.oldpath)
             if self.clean_onexit:
                 self.sh.rm(self.newpath)
@@ -220,14 +226,14 @@ class PythonSimplifiedVersion:
     It can be used in a footprint specification.
     """
 
-    _VERSION_RE = re.compile(r'(\d+)\.(\d+)\.(\d+)')
+    _VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 
     def __init__(self, versionstr):
         v_match = self._VERSION_RE.match(versionstr)
         if v_match:
             self._version = tuple([int(d) for d in v_match.groups()])
         else:
-            raise ValueError('Malformed version string: {}'.format(versionstr))
+            raise ValueError("Malformed version string: {}".format(versionstr))
 
     @property
     def version(self):
@@ -250,10 +256,12 @@ class PythonSimplifiedVersion:
         return self.version > other.version
 
     def __str__(self):
-        return '.'.join([str(d) for d in self.version])
+        return ".".join([str(d) for d in self.version])
 
     def __repr__(self):
-        return '<{} | {!s}>'.format(object.__repr__(self).lstrip('<').rstrip('>'), self)
+        return "<{} | {!s}>".format(
+            object.__repr__(self).lstrip("<").rstrip(">"), self
+        )
 
     def export_dict(self):
         """The pure dict/json output is the raw integer"""
@@ -269,50 +277,50 @@ class System(footprints.FootprintBase):
 
     _abstract = True
     _explicit = False
-    _collector = ('system',)
+    _collector = ("system",)
 
     _footprint = dict(
-        info = 'Default system interface',
-        attr = dict(
-            hostname = dict(
-                info     = "The computer's network name",
-                optional = True,
-                default  = platform.node(),
-                alias    = ('nodename',)
+        info="Default system interface",
+        attr=dict(
+            hostname=dict(
+                info="The computer's network name",
+                optional=True,
+                default=platform.node(),
+                alias=("nodename",),
             ),
-            sysname = dict(
-                info     = "The underlying system/OS name (e.g. Linux, Darwin, ...)",
-                optional = True,
-                default  = platform.system(),
+            sysname=dict(
+                info="The underlying system/OS name (e.g. Linux, Darwin, ...)",
+                optional=True,
+                default=platform.system(),
             ),
-            arch = dict(
-                info     = "The underlying machine type (e.g. i386, x86_64, ...)",
-                optional = True,
-                default  = platform.machine(),
-                alias    = ('machine',)
+            arch=dict(
+                info="The underlying machine type (e.g. i386, x86_64, ...)",
+                optional=True,
+                default=platform.machine(),
+                alias=("machine",),
             ),
-            release = dict(
-                info     = "The underlying system's release, (e.g. 2.2.0, NT, ...)",
-                optional = True,
-                default  = platform.release()
+            release=dict(
+                info="The underlying system's release, (e.g. 2.2.0, NT, ...)",
+                optional=True,
+                default=platform.release(),
             ),
-            version = dict(
-                info     = "The underlying system's release version",
-                optional = True,
-                default  = platform.version()
+            version=dict(
+                info="The underlying system's release version",
+                optional=True,
+                default=platform.version(),
             ),
-            python = dict(
-                info     = "The Python's version (e.g 2.7.5)",
-                type     = PythonSimplifiedVersion,
-                optional = True,
-                default  = platform.python_version(),
+            python=dict(
+                info="The Python's version (e.g 2.7.5)",
+                type=PythonSimplifiedVersion,
+                optional=True,
+                default=platform.python_version(),
             ),
-            glove = dict(
-                info     = "The session's Glove object",
-                optional = True,
-                type     = Glove,
-            )
-        )
+            glove=dict(
+                info="The session's Glove object",
+                optional=True,
+                type=Glove,
+            ),
+        ),
     )
 
     def __init__(self, *args, **kw):
@@ -364,25 +372,29 @@ class System(footprints.FootprintBase):
         user will be able to call ``sh.greatstuff``).
 
         """
-        logger.debug('Abstract System init %s', self.__class__)
-        self.__dict__['_os'] = kw.pop('os', os)
-        self.__dict__['_rl'] = kw.pop('rlimit', resource)
-        self.__dict__['_sh'] = kw.pop('shutil', kw.pop('sh', shutil))
-        self.__dict__['_search'] = [self.__dict__['_os'], self.__dict__['_sh'], self.__dict__['_rl']]
-        self.__dict__['_xtrack'] = dict()
-        self.__dict__['_history'] = History(tag='shell')
-        self.__dict__['_rclast'] = 0
-        self.__dict__['prompt'] = str(kw.pop('prompt', ''))
-        for flag in ('trace', 'timer'):
+        logger.debug("Abstract System init %s", self.__class__)
+        self.__dict__["_os"] = kw.pop("os", os)
+        self.__dict__["_rl"] = kw.pop("rlimit", resource)
+        self.__dict__["_sh"] = kw.pop("shutil", kw.pop("sh", shutil))
+        self.__dict__["_search"] = [
+            self.__dict__["_os"],
+            self.__dict__["_sh"],
+            self.__dict__["_rl"],
+        ]
+        self.__dict__["_xtrack"] = dict()
+        self.__dict__["_history"] = History(tag="shell")
+        self.__dict__["_rclast"] = 0
+        self.__dict__["prompt"] = str(kw.pop("prompt", ""))
+        for flag in ("trace", "timer"):
             self.__dict__[flag] = kw.pop(flag, False)
-        for flag in ('output',):
+        for flag in ("output",):
             self.__dict__[flag] = kw.pop(flag, True)
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
         """The object/class realkind."""
-        return 'system'
+        return "system"
 
     @property
     def history(self):
@@ -407,18 +419,18 @@ class System(footprints.FootprintBase):
     @property
     def default_syslog(self):
         """Address to use in logging.handler.SysLogHandler()."""
-        return '/dev/log'
+        return "/dev/log"
 
     def extend(self, obj=None):
         """Extend the current external attribute resolution to **obj** (module or object)."""
         if obj is not None:
-            if hasattr(obj, 'kind'):
+            if hasattr(obj, "kind"):
                 for k, v in self._xtrack.items():
-                    if hasattr(v, 'kind'):
+                    if hasattr(v, "kind"):
                         if hasattr(self, k):
                             delattr(self, k)
                 for addon in self.search:
-                    if hasattr(addon, 'kind') and addon.kind == obj.kind:
+                    if hasattr(addon, "kind") and addon.kind == obj.kind:
                         self.search.remove(addon)
             self.search.append(obj)
         return len(self.search)
@@ -429,7 +441,7 @@ class System(footprints.FootprintBase):
         (*i.e.* :class:`~vortex.tools.addons.Addon objects previously
         loaded with the :meth:`extend` method).
         """
-        return [addon.kind for addon in self.search if hasattr(addon, 'kind')]
+        return [addon.kind for addon in self.search if hasattr(addon, "kind")]
 
     def external(self, key):
         """Return effective module object reference if any, or *None*."""
@@ -446,12 +458,14 @@ class System(footprints.FootprintBase):
         This is the place where the ``self.search`` list is looked for...
         """
         actualattr = None
-        if key.startswith('_'):
+        if key.startswith("_"):
             # Do not attempt to look for hidden attributes
-            raise AttributeError('Method or attribute ' + key + ' not found')
+            raise AttributeError("Method or attribute " + key + " not found")
         for shxobj in self.search:
             if hasattr(shxobj, key):
-                if isinstance(shxobj, footprints.FootprintBase) and shxobj.footprint_has_attribute(key):
+                if isinstance(
+                    shxobj, footprints.FootprintBase
+                ) and shxobj.footprint_has_attribute(key):
                     # Ignore footprint attributes
                     continue
                 if actualattr is None:
@@ -459,17 +473,24 @@ class System(footprints.FootprintBase):
                     self._xtrack[key] = shxobj
                 else:
                     # Do not warn for a restricted list of keys
-                    if key not in ('stat',):
-                        logger.warning('System: duplicate entry while looking for key="%s". ' +
-                                       'First result in %s but also available in %s.',
-                                       key, self._xtrack[key], shxobj)
+                    if key not in ("stat",):
+                        logger.warning(
+                            'System: duplicate entry while looking for key="%s". '
+                            + "First result in %s but also available in %s.",
+                            key,
+                            self._xtrack[key],
+                            shxobj,
+                        )
         if actualattr is None:
-            raise AttributeError('Method or attribute ' + key + ' not found')
+            raise AttributeError("Method or attribute " + key + " not found")
         if callable(actualattr):
+
             def osproxy(*args, **kw):
                 cmd = [key]
                 cmd.extend(args)
-                cmd.extend(['{:s}={:s}'.format(x, str(kw[x])) for x in kw.keys()])
+                cmd.extend(
+                    ["{:s}={:s}".format(x, str(kw[x])) for x in kw.keys()]
+                )
                 self.stderr(*cmd)
                 return actualattr(*args, **kw)
 
@@ -484,15 +505,21 @@ class System(footprints.FootprintBase):
 
     def stderr(self, *args):
         """Write a formatted message to standard error (if ``self.trace == True``)."""
-        count, justnow, = self.history.append(*args)
+        (
+            count,
+            justnow,
+        ) = self.history.append(*args)
         if self.trace:
-            if self.trace == 'log':
-                logger.info('[sh:#%d] %s', count, ' '.join([str(x) for x in args]))
+            if self.trace == "log":
+                logger.info(
+                    "[sh:#%d] %s", count, " ".join([str(x) for x in args])
+                )
             else:
                 sys.stderr.write(
                     "* [{:s}][{:d}] {:s}\n".format(
-                        justnow.strftime('%Y/%m/%d-%H:%M:%S'), count,
-                        ' '.join([str(x) for x in args])
+                        justnow.strftime("%Y/%m/%d-%H:%M:%S"),
+                        count,
+                        " ".join([str(x) for x in args]),
                     )
                 )
 
@@ -512,9 +539,9 @@ class System(footprints.FootprintBase):
 
     def echo(self, *args):
         """Joined **args** are echoed."""
-        print('>>>', ' '.join([str(arg) for arg in args]))
+        print(">>>", " ".join([str(arg) for arg in args]))
 
-    def title(self, textlist, tchar='=', autolen=96):
+    def title(self, textlist, tchar="=", autolen=96):
         """Formated title output.
 
         :param list|str textlist: A list of strings that contains the title's text
@@ -530,12 +557,16 @@ class System(footprints.FootprintBase):
         print()
         print(tchar * (nbc + 4))
         for text in textlist:
-            print('{0:s} {1:^{size}s} {0:s}'.format(tchar, text.upper(), size=nbc))
+            print(
+                "{0:s} {1:^{size}s} {0:s}".format(
+                    tchar, text.upper(), size=nbc
+                )
+            )
         print(tchar * (nbc + 4))
         print()
         self.flush_stdall()
 
-    def subtitle(self, text='', tchar='-', autolen=96):
+    def subtitle(self, text="", tchar="-", autolen=96):
         """Formatted subtitle output.
 
         :param str text: The subtitle's text
@@ -549,11 +580,13 @@ class System(footprints.FootprintBase):
         print()
         print(tchar * (nbc + 4))
         if text:
-            print('# {0:{size}s} #'.format(text, size=nbc))
+            print("# {0:{size}s} #".format(text, size=nbc))
             print(tchar * (nbc + 4))
         self.flush_stdall()
 
-    def header(self, text='', tchar='-', autolen=False, xline=True, prompt=None):
+    def header(
+        self, text="", tchar="-", autolen=False, xline=True, prompt=None
+    ):
         """Formatted header output.
 
         :param str text: The subtitle's text
@@ -572,15 +605,17 @@ class System(footprints.FootprintBase):
             if not prompt:
                 prompt = self.prompt
             if prompt:
-                prompt = str(prompt) + ' '
+                prompt = str(prompt) + " "
             else:
-                prompt = ''
+                prompt = ""
             print(prompt + str(text))
             if xline:
                 print(tchar * nbc)
         self.flush_stdall()
 
-    def highlight(self, text='', hchar='----', bchar='#', bline=False, bline0=True):
+    def highlight(
+        self, text="", hchar="----", bchar="#", bline=False, bline0=True
+    ):
         """Highlight some text.
 
         :param str text: The text to be highlighted
@@ -591,8 +626,11 @@ class System(footprints.FootprintBase):
         """
         if bline0:
             print()
-        print('{0:s} {1:s}  {2:s}  {1:s} {3:s}'
-              .format(bchar.rstrip(), hchar, text, bchar.lstrip()))
+        print(
+            "{0:s} {1:s}  {2:s}  {1:s} {3:s}".format(
+                bchar.rstrip(), hchar, text, bchar.lstrip()
+            )
+        )
         if bline:
             print()
         self.flush_stdall()
@@ -600,18 +638,18 @@ class System(footprints.FootprintBase):
     @property
     def executable(self):
         """Return the actual ``sys.executable``."""
-        self.stderr('executable')
+        self.stderr("executable")
         return sys.executable
 
     def pythonpath(self, output=None):
         """Return or print actual ``sys.path``."""
         if output is None:
             output = self.output
-        self.stderr('pythonpath')
+        self.stderr("pythonpath")
         if output:
             return sys.path[:]
         else:
-            self.subtitle('Python PATH')
+            self.subtitle("Python PATH")
             for pypath in sys.path:
                 print(pypath)
             return True
@@ -625,12 +663,12 @@ class System(footprints.FootprintBase):
         """Try to determine an identification string for the current script."""
         #       PBS scheduler    SLURM scheduler     Good-old PID
         env = self.env
-        label = env.PBS_JOBID or env.SLURM_JOB_ID or 'localpid'
-        if label == 'localpid':
+        label = env.PBS_JOBID or env.SLURM_JOB_ID or "localpid"
+        if label == "localpid":
             label = str(self.getpid())
         return label
 
-    def vortex_modules(self, only='.'):
+    def vortex_modules(self, only="."):
         """Return a filtered list of modules in the vortex package.
 
         :param str only: The regex used to filter the modules list.
@@ -638,22 +676,26 @@ class System(footprints.FootprintBase):
         if self.glove is not None:
             g = self.glove
             mfiles = [
-                re.sub(r'^' + mroot + r'/', '', x)
-                for mroot in (g.siteroot + '/src', g.siteroot + '/site')
+                re.sub(r"^" + mroot + r"/", "", x)
+                for mroot in (g.siteroot + "/src", g.siteroot + "/site")
                 for x in self.ffind(mroot)
-                if self.path.isfile(self.path.join(self.path.dirname(x), '__init__.py'))
+                if self.path.isfile(
+                    self.path.join(self.path.dirname(x), "__init__.py")
+                )
             ]
             return [
-                re.sub(r'(?:/__init__)?\.py$', '', x).replace('/', '.')
+                re.sub(r"(?:/__init__)?\.py$", "", x).replace("/", ".")
                 for x in mfiles
-                if (not x.startswith('.') and
-                    re.search(only, x, re.IGNORECASE) and
-                    x.endswith('.py'))
+                if (
+                    not x.startswith(".")
+                    and re.search(only, x, re.IGNORECASE)
+                    and x.endswith(".py")
+                )
             ]
         else:
             raise RuntimeError("A glove must be defined")
 
-    def vortex_loaded_modules(self, only='.', output=None):
+    def vortex_loaded_modules(self, only=".", output=None):
         """Check loaded modules, producing either a dump or a list of tuple (status, modulename).
 
         :param str only: The regex used to filter the modules list.
@@ -666,7 +708,7 @@ class System(footprints.FootprintBase):
         if not output:
             for m, s in checklist:
                 print(str(s).ljust(8), m)
-            print('--')
+            print("--")
             return True
         else:
             return checklist
@@ -674,13 +716,17 @@ class System(footprints.FootprintBase):
     def systems_reload(self):
         """Load extra systems modules not yet loaded."""
         extras = list()
-        for modname in self.vortex_modules(only='systems'):
+        for modname in self.vortex_modules(only="systems"):
             if modname not in sys.modules:
                 try:
                     self.import_module(modname)
                     extras.append(modname)
                 except ValueError as err:
-                    logger.critical('systems_reload: cannot import module %s (%s)', modname, str(err))
+                    logger.critical(
+                        "systems_reload: cannot import module %s (%s)",
+                        modname,
+                        str(err),
+                    )
         return extras
 
     # Redefinition of methods of the resource package...
@@ -692,16 +738,16 @@ class System(footprints.FootprintBase):
         """
         if type(r_id) is not int:
             r_id = r_id.upper()
-            if not r_id.startswith('RLIMIT_'):
-                r_id = 'RLIMIT_' + r_id
+            if not r_id.startswith("RLIMIT_"):
+                r_id = "RLIMIT_" + r_id
             r_id = getattr(self._rl, r_id, None)
         if r_id is None:
-            raise ValueError('Invalid resource specified')
+            raise ValueError("Invalid resource specified")
         return r_id
 
     def setrlimit(self, r_id, r_limits):
         """Proxy to :mod:`resource` function of the same name."""
-        self.stderr('setrlimit', r_id, r_limits)
+        self.stderr("setrlimit", r_id, r_limits)
         try:
             r_limits = tuple(r_limits)
         except TypeError:
@@ -710,14 +756,14 @@ class System(footprints.FootprintBase):
 
     def getrlimit(self, r_id):
         """Proxy to :mod:`resource` function of the same name."""
-        self.stderr('getrlimit', r_id)
+        self.stderr("getrlimit", r_id)
         return self._rl.getrlimit(self.numrlimit(r_id))
 
     def getrusage(self, pid=None):
         """Proxy to :mod:`resource` function of the same name with current process as defaut."""
         if pid is None:
             pid = self._rl.RUSAGE_SELF
-        self.stderr('getrusage', pid)
+        self.stderr("getrusage", pid)
         return self._rl.getrusage(pid)
 
     def import_module(self, modname):
@@ -728,12 +774,12 @@ class System(footprints.FootprintBase):
     def import_function(self, funcname):
         """Import the function named **funcname** qualified by a proper module name package."""
         thisfunc = None
-        if '.' in funcname:
-            thismod = self.import_module('.'.join(funcname.split('.')[:-1]))
+        if "." in funcname:
+            thismod = self.import_module(".".join(funcname.split(".")[:-1]))
             if thismod:
-                thisfunc = getattr(thismod, funcname.split('.')[-1], None)
+                thisfunc = getattr(thismod, funcname.split(".")[-1], None)
         else:
-            logger.error('Bad function path name <%s>' % funcname)
+            logger.error("Bad function path name <%s>" % funcname)
         return thisfunc
 
 
@@ -744,9 +790,7 @@ class OSExtended(System):
     """
 
     _abstract = True
-    _footprint = dict(
-        info = 'Abstract extended base system'
-    )
+    _footprint = dict(info="Abstract extended base system")
 
     def __init__(self, *args, **kw):
         """
@@ -766,15 +810,15 @@ class OSExtended(System):
               (default: `FTP_FLAVOUR.CONNECTION_POOLS`). See the :meth:`ftp` method
               for more details.
         """
-        logger.debug('Abstract System init %s', self.__class__)
-        self._rmtreemin = kw.pop('rmtreemin', 3)
-        self._cmpaftercp = kw.pop('cmpaftercp', True)
+        logger.debug("Abstract System init %s", self.__class__)
+        self._rmtreemin = kw.pop("rmtreemin", 3)
+        self._cmpaftercp = kw.pop("cmpaftercp", True)
         # Switches for rawft* methods
-        self._ftraw = kw.pop('ftraw', None)
-        self.ftputcmd = kw.pop('ftputcmd', None)
-        self.ftgetcmd = kw.pop('ftgetcmd', None)
+        self._ftraw = kw.pop("ftraw", None)
+        self.ftputcmd = kw.pop("ftputcmd", None)
+        self.ftgetcmd = kw.pop("ftgetcmd", None)
         # FTP stuff again
-        self.ftpflavour = kw.pop('ftpflavour', FTP_FLAVOUR.CONNECTION_POOLS)
+        self.ftpflavour = kw.pop("ftpflavour", FTP_FLAVOUR.CONNECTION_POOLS)
         self._current_ftppool = None
         # Some internal variables used by particular methods
         self._ftspool_cache = None
@@ -784,10 +828,10 @@ class OSExtended(System):
         # Go for the superclass' constructor
         super().__init__(*args, **kw)
         # Initialise possibly missing objects
-        self.__dict__['_cpusinfo'] = None
-        self.__dict__['_numainfo'] = None
-        self.__dict__['_memoryinfo'] = None
-        self.__dict__['_netstatsinfo'] = None
+        self.__dict__["_cpusinfo"] = None
+        self.__dict__["_numainfo"] = None
+        self.__dict__["_memoryinfo"] = None
+        self.__dict__["_netstatsinfo"] = None
 
         # Initialise the signal handler object
         self._signal_intercept_init()
@@ -819,10 +863,7 @@ class OSExtended(System):
         * The object returned by this method will be used in subsequent calls
           to ::attr:`default_target` (this is the concept of frozen target).
         """
-        desc = dict(
-            hostname=self.hostname,
-            sysname=self.sysname
-        )
+        desc = dict(hostname=self.hostname, sysname=self.sysname)
         desc.update(kw)
         self._frozen_target = footprints.proxy.targets.default(**desc)
         return self._frozen_target
@@ -834,10 +875,18 @@ class OSExtended(System):
 
     def fmtspecific_mtd(self, method, fmt):
         """Check if a format specific implementation is available for a given format."""
-        return hasattr(self, '{:s}_{:s}'.format(fmt, method))
+        return hasattr(self, "{:s}_{:s}".format(fmt, method))
 
-    def popen(self, args, stdin=None, stdout=None, stderr=None, shell=False,
-              output=False, bufsize=0):  # @UnusedVariable
+    def popen(
+        self,
+        args,
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        shell=False,
+        output=False,
+        bufsize=0,
+    ):  # @UnusedVariable
         """Return an open pipe for the **args** command.
 
         :param str|list args: The command (+ its command-line arguments) to be
@@ -882,7 +931,14 @@ class OSExtended(System):
             stdin = subprocess.PIPE
         if stderr is True:
             stderr = subprocess.PIPE
-        return subprocess.Popen(args, bufsize=bufsize, stdin=stdin, stdout=stdout, stderr=stderr, shell=shell)
+        return subprocess.Popen(
+            args,
+            bufsize=bufsize,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            shell=shell,
+        )
 
     def pclose(self, p, ok=None):
         """Do its best to nicely shutdown the process started by **p**.
@@ -905,7 +961,7 @@ class OSExtended(System):
             p.terminate()
         except OSError as e:
             if e.errno == 3:
-                logger.debug('Processus %s alreaded terminated.' % str(p))
+                logger.debug("Processus %s alreaded terminated." % str(p))
             else:
                 raise
 
@@ -917,9 +973,21 @@ class OSExtended(System):
         else:
             return False
 
-    def spawn(self, args, ok=None, shell=False, stdin=None, output=None,
-              outmode='a+b', outsplit=True, silent=False, fatal=True,
-              taskset=None, taskset_id=0, taskset_bsize=1):
+    def spawn(
+        self,
+        args,
+        ok=None,
+        shell=False,
+        stdin=None,
+        output=None,
+        outmode="a+b",
+        outsplit=True,
+        silent=False,
+        fatal=True,
+        taskset=None,
+        taskset_id=0,
+        taskset_bsize=1,
+    ):
         """Subprocess call of **args**.
 
         :param str|list[str] args: The command (+ its command-line arguments) to be
@@ -986,25 +1054,25 @@ class OSExtended(System):
             stdin = subprocess.PIPE
         localenv = self._os.environ.copy()
         if taskset is not None:
-            taskset_def = taskset.split('_')
-            taskset, taskset_cmd, taskset_env = self.cpus_affinity_get(taskset_id,
-                                                                       taskset_bsize,
-                                                                       *taskset_def)
+            taskset_def = taskset.split("_")
+            taskset, taskset_cmd, taskset_env = self.cpus_affinity_get(
+                taskset_id, taskset_bsize, *taskset_def
+            )
             if taskset:
                 localenv.update(taskset_env)
             else:
                 logger.warning("CPU binding is not available on this platform")
         if isinstance(args, str):
             if taskset:
-                args = taskset_cmd + ' ' + args
+                args = taskset_cmd + " " + args
             if self.timer:
-                args = 'time ' + args
+                args = "time " + args
             self.stderr(args)
         else:
             if taskset:
                 args[:0] = taskset_cmd
             if self.timer:
-                args[:0] = ['time']
+                args[:0] = ["time"]
             self.stderr(*args)
         if isinstance(output, bool):
             if output:
@@ -1017,36 +1085,47 @@ class OSExtended(System):
             cmdout, cmderr = output, output
         p = None
         try:
-            p = subprocess.Popen(args, stdin=stdin, stdout=cmdout, stderr=cmderr,
-                                 shell=shell, env=localenv)
+            p = subprocess.Popen(
+                args,
+                stdin=stdin,
+                stdout=cmdout,
+                stderr=cmderr,
+                shell=shell,
+                env=localenv,
+            )
             p_out, p_err = p.communicate()
         except ValueError as e:
             logger.critical(
-                'Weird arguments to Popen ({!s}, stdout={!s}, stderr={!s}, shell={!s})'.format(
+                "Weird arguments to Popen ({!s}, stdout={!s}, stderr={!s}, shell={!s})".format(
                     args, cmdout, cmderr, shell
                 )
             )
-            logger.critical('Caught exception: %s', e)
+            logger.critical("Caught exception: %s", e)
             if fatal:
                 raise
             else:
-                logger.warning('Carry on because fatal is off')
+                logger.warning("Carry on because fatal is off")
         except OSError:
-            logger.critical('Could not call %s', str(args))
+            logger.critical("Could not call %s", str(args))
             if fatal:
                 raise
             else:
-                logger.warning('Carry on because fatal is off')
+                logger.warning("Carry on because fatal is off")
         except Exception as perr:
-            logger.critical('System returns %s', str(perr))
+            logger.critical("System returns %s", str(perr))
             if fatal:
-                raise RuntimeError('System {!s} spawned {!s} got [{!s}]: {!s}'
-                                   .format(self, args, p.returncode, perr))
+                raise RuntimeError(
+                    "System {!s} spawned {!s} got [{!s}]: {!s}".format(
+                        self, args, p.returncode, perr
+                    )
+                )
             else:
-                logger.warning('Carry on because fatal is off')
+                logger.warning("Carry on because fatal is off")
         except (SignalInterruptError, KeyboardInterrupt) as perr:
-            logger.critical('The python process was killed: %s. Trying to terminate the subprocess.',
-                            str(perr))
+            logger.critical(
+                "The python process was killed: %s. Trying to terminate the subprocess.",
+                str(perr),
+            )
             if p:
                 if shell:
                     # Kill the process group: apparently it's the only way when shell=T
@@ -1056,24 +1135,26 @@ class OSExtended(System):
                 p.wait()
             raise  # Fatal has no effect on that !
         else:
-            plocale = locale.getlocale()[1] or 'ascii'
+            plocale = locale.getlocale()[1] or "ascii"
             if p.returncode in ok:
                 if isinstance(output, bool) and output:
-                    rc = p_out.decode(plocale, 'replace')
+                    rc = p_out.decode(plocale, "replace")
                     if outsplit:
-                        rc = rc.rstrip('\n').split('\n')
+                        rc = rc.rstrip("\n").split("\n")
                     p.stdout.close()
                 else:
                     rc = not bool(p.returncode)
             else:
                 if not silent:
-                    logger.warning('Bad return code [%d] for %s', p.returncode, str(args))
+                    logger.warning(
+                        "Bad return code [%d] for %s", p.returncode, str(args)
+                    )
                     if isinstance(output, bool) and output:
-                        sys.stderr.write(p_err.decode(plocale, 'replace'))
+                        sys.stderr.write(p_err.decode(plocale, "replace"))
                 if fatal:
                     raise ExecutionError()
                 else:
-                    logger.warning('Carry on because fatal is off')
+                    logger.warning("Carry on because fatal is off")
         finally:
             self._rclast = p.returncode if p else 1
             if isinstance(output, bool) and p:
@@ -1107,11 +1188,11 @@ class OSExtended(System):
         """Current working directory."""
         if output is None:
             output = self.output
-        self.stderr('pwd')
+        self.stderr("pwd")
         try:
             realpwd = self._os.getcwd()
         except OSError as e:
-            logger.error('getcwdu failed: %s.', str(e))
+            logger.error("getcwdu failed: %s.", str(e))
             return None
         if output:
             return realpwd
@@ -1122,7 +1203,7 @@ class OSExtended(System):
     def cd(self, pathtogo, create=False):
         """Change the current working directory to **pathtogo**."""
         pathtogo = self.path.expanduser(pathtogo)
-        self.stderr('cd', pathtogo, create)
+        self.stderr("cd", pathtogo, create)
         if create:
             self.mkdir(pathtogo)
         self._os.chdir(pathtogo)
@@ -1143,11 +1224,13 @@ class OSExtended(System):
         :param prefix: The temporary directory name will start with that suffix
         :param dir: The temporary directory will be created in that directory
         """
-        self.stderr('temporary_dir_context starts', suffix)
-        self.stderr('tempfile.TemporaryDirectory', suffix, prefix, dir)
-        with tempfile.TemporaryDirectory(suffix=suffix, prefix=prefix, dir=dir) as tmp_dir:
+        self.stderr("temporary_dir_context starts", suffix)
+        self.stderr("tempfile.TemporaryDirectory", suffix, prefix, dir)
+        with tempfile.TemporaryDirectory(
+            suffix=suffix, prefix=prefix, dir=dir
+        ) as tmp_dir:
             yield tmp_dir
-            self.stderr('tempfile.TemporaryDirectory cleanup', tmp_dir)
+            self.stderr("tempfile.TemporaryDirectory cleanup", tmp_dir)
 
     @contextlib.contextmanager
     def temporary_dir_cdcontext(self, suffix=None, prefix=None, dir=None):
@@ -1155,23 +1238,27 @@ class OSExtended(System):
 
         For a description of the context's arguments, see :func:`temporary_dir_context`.
         """
-        with self.temporary_dir_context(suffix=suffix, prefix=prefix, dir=dir) as tmp_dir:
+        with self.temporary_dir_context(
+            suffix=suffix, prefix=prefix, dir=dir
+        ) as tmp_dir:
             with self.cdcontext(tmp_dir, create=False, clean_onexit=False):
                 yield tmp_dir
 
     def ffind(self, *args):
         """Recursive file find. Arguments are starting paths."""
         if not args:
-            args = ['*']
+            args = ["*"]
         else:
             args = [self.path.expanduser(x) for x in args]
         files = []
-        self.stderr('ffind', *args)
+        self.stderr("ffind", *args)
         for pathtogo in self.glob(*args):
             if self.path.isfile(pathtogo):
                 files.append(pathtogo)
             else:
-                for root, u_dirs, filenames in self._os.walk(pathtogo):  # @UnusedVariable
+                for root, u_dirs, filenames in self._os.walk(
+                    pathtogo
+                ):  # @UnusedVariable
                     files.extend([self.path.join(root, f) for f in filenames])
         return sorted(files)
 
@@ -1184,8 +1271,13 @@ class OSExtended(System):
         if self._os.path.exists(filename):
             is_x = bool(self._os.stat(filename).st_mode & 1)
             if not is_x and force:
-                self.chmod(filename,
-                           self._os.stat(filename).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+                self.chmod(
+                    filename,
+                    self._os.stat(filename).st_mode
+                    | stat.S_IXUSR
+                    | stat.S_IXGRP
+                    | stat.S_IXOTH,
+                )
                 is_x = True
             return is_x
         else:
@@ -1199,9 +1291,16 @@ class OSExtended(System):
         """
         if self._os.path.exists(filename):
             mode = self._os.stat(filename).st_mode
-            is_r = all([bool(mode & i) for i in [stat.S_IRUSR, stat.S_IRGRP, stat.S_IROTH]])
+            is_r = all(
+                [
+                    bool(mode & i)
+                    for i in [stat.S_IRUSR, stat.S_IRGRP, stat.S_IROTH]
+                ]
+            )
             if not is_r and force:
-                self.chmod(filename, mode | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+                self.chmod(
+                    filename, mode | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+                )
                 is_r = True
             return is_r
         else:
@@ -1238,7 +1337,7 @@ class OSExtended(System):
     def readonly(self, inodename):
         """Set permissions of the ``inodename`` object to read-only."""
         inodename = self.path.expanduser(inodename)
-        self.stderr('readonly', inodename)
+        self.stderr("readonly", inodename)
         rc = None
         if self._os.path.exists(inodename):
             if self._os.path.isdir(inodename):
@@ -1246,7 +1345,10 @@ class OSExtended(System):
             else:
                 st = self.stat(inodename).st_mode
                 if st & stat.S_IWUSR or st & stat.S_IWGRP or st & stat.S_IWOTH:
-                    rc = self.chmod(inodename, st & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+                    rc = self.chmod(
+                        inodename,
+                        st & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH),
+                    )
                 else:
                     rc = True
         return rc
@@ -1266,7 +1368,7 @@ class OSExtended(System):
     def touch(self, filename):
         """Clone of the eponymous unix command."""
         filename = self.path.expanduser(filename)
-        self.stderr('touch', filename)
+        self.stderr("touch", filename)
         rc = True
         if self.path.exists(filename):
             # Note: "filename" might as well be a directory...
@@ -1275,7 +1377,7 @@ class OSExtended(System):
             except Exception:
                 rc = False
         else:
-            fh = open(filename, 'a')
+            fh = open(filename, "a")
             fh.close()
         return rc
 
@@ -1287,13 +1389,13 @@ class OSExtended(System):
         """
         objpath = self.path.expanduser(objpath)
         if self._os.path.exists(objpath):
-            self.stderr('remove', objpath)
+            self.stderr("remove", objpath)
             if self._os.path.isdir(objpath):
                 self.rmtree(objpath)
             else:
                 self.unlink(objpath)
         else:
-            self.stderr('clear', objpath)
+            self.stderr("clear", objpath)
         return not self._os.path.exists(objpath)
 
     @fmtshcmd
@@ -1311,35 +1413,48 @@ class OSExtended(System):
         expressions are used).
         """
         if not pscmd:
-            pscmd = ['ps']
+            pscmd = ["ps"]
         if opts is None:
             opts = []
         pscmd.extend(self._psopts)
         pscmd.extend(opts)
         self.stderr(*pscmd)
-        psall = subprocess.Popen(pscmd, stdout=subprocess.PIPE).communicate()[0].split('\n')
+        psall = (
+            subprocess.Popen(pscmd, stdout=subprocess.PIPE)
+            .communicate()[0]
+            .split("\n")
+        )
         if search:
             psall = filter(lambda x: re.search(search, x), psall)
         return [x.strip() for x in psall]
 
     def sleep(self, nbsecs):
         """Clone of the unix eponymous command."""
-        self.stderr('sleep', nbsecs)
+        self.stderr("sleep", nbsecs)
         time.sleep(nbsecs)
 
     def setulimit(self, r_id):
         """Set an unlimited value to the specified resource (**r_id**)."""
-        self.stderr('setulimit', r_id)
+        self.stderr("setulimit", r_id)
         u_soft, hard = self.getrlimit(r_id)  # @UnusedVariable
         if hard != self._rl.RLIM_INFINITY:
-            logger.info('Unable to raise the %s soft limit to "unlimited", ' +
-                        'using the hard limit instead (%s).', str(r_id), str(hard))
+            logger.info(
+                'Unable to raise the %s soft limit to "unlimited", '
+                + "using the hard limit instead (%s).",
+                str(r_id),
+                str(hard),
+            )
         return self.setrlimit(r_id, (hard, hard))
 
     def ulimit(self):
         """Dump the user limits currently defined."""
-        for limit in [r for r in dir(self._rl) if r.startswith('RLIMIT_')]:
-            print(' ', limit.ljust(16), ':', self._rl.getrlimit(getattr(self._rl, limit)))
+        for limit in [r for r in dir(self._rl) if r.startswith("RLIMIT_")]:
+            print(
+                " ",
+                limit.ljust(16),
+                ":",
+                self._rl.getrlimit(getattr(self._rl, limit)),
+            )
 
     @property
     def cpus_info(self):
@@ -1352,7 +1467,9 @@ class OSExtended(System):
         """
         return self._cpusinfo
 
-    def cpus_ids_per_blocks(self, blocksize=1, topology='raw', hexmask=False):  # @UnusedVariable
+    def cpus_ids_per_blocks(
+        self, blocksize=1, topology="raw", hexmask=False
+    ):  # @UnusedVariable
         """Get the list of CPUs IDs ordered for subsequent binding.
 
         :param int blocksize: The number of thread consumed by one task
@@ -1361,14 +1478,16 @@ class OSExtended(System):
         """
         return []
 
-    def cpus_ids_dispenser(self, topology='raw'):
+    def cpus_ids_dispenser(self, topology="raw"):
         """Get a dispenser of CPUs IDs for nicely ordered for subsequent binding.
 
         :param str topology: The task distribution scheme
         """
         return None
 
-    def cpus_affinity_get(self, taskid, blocksize=1, method='default', topology='raw'):  # @UnusedVariable
+    def cpus_affinity_get(
+        self, taskid, blocksize=1, method="default", topology="raw"
+    ):  # @UnusedVariable
         """Get the necessary command/environment to set the CPUs affinity.
 
         :param int taskid: the task number
@@ -1421,7 +1540,9 @@ class OSExtended(System):
             netstat may not be implemented.
         """
         if self.netstatsinfo is None:
-            raise NotImplementedError('This function is not implemented on this system.')
+            raise NotImplementedError(
+                "This function is not implemented on this system."
+            )
         return self.netstatsinfo.available_localport()
 
     def check_localport(self, port):
@@ -1431,12 +1552,14 @@ class OSExtended(System):
             netstat may not be implemented.
         """
         if self.netstatsinfo is None:
-            raise NotImplementedError('This function is not implemented on this system.')
+            raise NotImplementedError(
+                "This function is not implemented on this system."
+            )
         return self.netstatsinfo.check_localport(port)
 
     def clear(self):
         """Clone of the unix eponymous command."""
-        self._os.system('clear')
+        self._os.system("clear")
 
     @property
     def cls(self):
@@ -1444,8 +1567,14 @@ class OSExtended(System):
         self.clear()
         return None
 
-    def rawopts(self, cmdline=None, defaults=None,
-                isnone=isnonedef, istrue=istruedef, isfalse=isfalsedef):
+    def rawopts(
+        self,
+        cmdline=None,
+        defaults=None,
+        isnone=isnonedef,
+        istrue=istruedef,
+        isfalse=isfalsedef,
+    ):
         """Parse a simple options command line that looks like `` key=value``.
 
         :param str cmdline: The command line to be processed (if *None*, ``sys.argv``
@@ -1461,11 +1590,13 @@ class OSExtended(System):
             try:
                 opts.update(defaults)
             except (ValueError, TypeError):
-                logger.warning('Could not update options default: %s', defaults)
+                logger.warning(
+                    "Could not update options default: %s", defaults
+                )
 
         if cmdline is None:
             cmdline = sys.argv[1:]
-        opts.update(dict([x.split('=') for x in cmdline]))
+        opts.update(dict([x.split("=") for x in cmdline]))
         for k, v in opts.items():
             if v not in (None, True, False):
                 if istrue.match(v):
@@ -1479,9 +1610,10 @@ class OSExtended(System):
     def is_iofile(self, iocandidate):
         """Check if actual **iocandidate** is a valid filename or io stream."""
         return iocandidate is not None and (
-            (isinstance(iocandidate, str) and self.path.exists(iocandidate)) or
-            isinstance(iocandidate, io.IOBase) or
-            isinstance(iocandidate, io.BytesIO) or isinstance(iocandidate, io.StringIO)
+            (isinstance(iocandidate, str) and self.path.exists(iocandidate))
+            or isinstance(iocandidate, io.IOBase)
+            or isinstance(iocandidate, io.BytesIO)
+            or isinstance(iocandidate, io.StringIO)
         )
 
     @contextlib.contextmanager
@@ -1512,20 +1644,28 @@ class OSExtended(System):
             hostname = self.glove.default_fthost
             if not hostname:
                 if fatal:
-                    raise ValueError('An *hostname* must be provided one way or another')
+                    raise ValueError(
+                        "An *hostname* must be provided one way or another"
+                    )
         return hostname
 
     def fix_ftuser(self, hostname, logname, fatal=True, defaults_to_user=True):
         """Given *hostname*, if *logname* is None, tries to find a default value for it."""
         if logname is None:
             if self.glove is not None:
-                logname = self.glove.getftuser(hostname, defaults_to_user=defaults_to_user)
+                logname = self.glove.getftuser(
+                    hostname, defaults_to_user=defaults_to_user
+                )
             else:
                 if fatal:
-                    raise ValueError("Either a *logname* or a glove must be set-up")
+                    raise ValueError(
+                        "Either a *logname* or a glove must be set-up"
+                    )
         return logname
 
-    def ftp(self, hostname, logname=None, delayed=False, port=DEFAULT_FTP_PORT):
+    def ftp(
+        self, hostname, logname=None, delayed=False, port=DEFAULT_FTP_PORT
+    ):
         """Return an FTP client object.
 
         :param str hostname: the remote host's name for FTP.
@@ -1555,20 +1695,36 @@ class OSExtended(System):
         logname = self.fix_ftuser(hostname, logname)
         if port is None:
             port = DEFAULT_FTP_PORT
-        if self.ftpflavour == FTP_FLAVOUR.CONNECTION_POOLS and self._current_ftppool is not None:
-            return self._current_ftppool.deal(hostname, logname, port=port, delayed=delayed)
+        if (
+            self.ftpflavour == FTP_FLAVOUR.CONNECTION_POOLS
+            and self._current_ftppool is not None
+        ):
+            return self._current_ftppool.deal(
+                hostname, logname, port=port, delayed=delayed
+            )
         else:
-            ftpclass = AutoRetriesFtp if self.ftpflavour != FTP_FLAVOUR.STD else StdFtp
+            ftpclass = (
+                AutoRetriesFtp
+                if self.ftpflavour != FTP_FLAVOUR.STD
+                else StdFtp
+            )
             ftpbox = ftpclass(self, hostname, port=port)
             rc = ftpbox.fastlogin(logname, delayed=delayed)
             if rc:
                 return ftpbox
             else:
-                logger.warning('Could not login on %s as %s [%s]', hostname, logname, str(rc))
+                logger.warning(
+                    "Could not login on %s as %s [%s]",
+                    hostname,
+                    logname,
+                    str(rc),
+                )
                 return None
 
     @contextlib.contextmanager
-    def ftpcontext(self, hostname, logname=None, delayed=False, port=DEFAULT_FTP_PORT):
+    def ftpcontext(
+        self, hostname, logname=None, delayed=False, port=DEFAULT_FTP_PORT
+    ):
         """Create an FTP object and close it when the context exits.
 
         For a description of the context's arguments, see :func:`ftp`.
@@ -1591,8 +1747,15 @@ class OSExtended(System):
         return remote
 
     @fmtshcmd
-    def ftget(self, source, destination, hostname=None, logname=None, port=DEFAULT_FTP_PORT,
-              cpipeline=None):
+    def ftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+    ):
         """Proceed to a direct ftp get on the specified target (using Vortex's FTP client).
 
         :param str source: the remote path to get data
@@ -1616,10 +1779,12 @@ class OSExtended(System):
                 if cpipeline is None:
                     rc = ftp.get(source, destination)
                 else:
-                    with cpipeline.stream2uncompress(destination) as cdestination:
+                    with cpipeline.stream2uncompress(
+                        destination
+                    ) as cdestination:
                         rc = ftp.get(source, cdestination)
             except ftplib.all_errors as e:
-                logger.warning('An FTP error occured: %s', str(e))
+                logger.warning("An FTP error occured: %s", str(e))
                 rc = False
             finally:
                 ftp.close()
@@ -1628,8 +1793,16 @@ class OSExtended(System):
             return False
 
     @fmtshcmd
-    def ftput(self, source, destination, hostname=None, logname=None, port=DEFAULT_FTP_PORT,
-              cpipeline=None, sync=False):  # @UnusedVariable
+    def ftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+        sync=False,
+    ):  # @UnusedVariable
         """Proceed to a direct ftp put on the specified target (using Vortex's FTP client).
 
         :param source: The source of data (either a path to file or a
@@ -1655,33 +1828,40 @@ class OSExtended(System):
                     if cpipeline is None:
                         rc = ftp.put(source, destination)
                     else:
-                        with cpipeline.compress2stream(source, iosponge=True) as csource:
+                        with cpipeline.compress2stream(
+                            source, iosponge=True
+                        ) as csource:
                             # csource is an IoSponge consequently the size attribute exists
-                            rc = ftp.put(csource, destination, size=csource.size)
+                            rc = ftp.put(
+                                csource, destination, size=csource.size
+                            )
                 except ftplib.all_errors as e:
-                    logger.warning('An FTP error occured: %s', str(e))
+                    logger.warning("An FTP error occured: %s", str(e))
                     rc = False
                 finally:
                     ftp.close()
         else:
-            raise OSError('No such file or directory: {!r}'.format(source))
+            raise OSError("No such file or directory: {!r}".format(source))
         return rc
 
     def ftspool_cache(self):
         """Return a cache object for the FtSpool."""
         if self._ftspool_cache is None:
-            self._ftspool_cache = footprints.proxy.cache(kind='ftstash')
+            self._ftspool_cache = footprints.proxy.cache(kind="ftstash")
         return self._ftspool_cache
 
     def copy2ftspool(self, source, nest=False, **kwargs):
         """Make a copy of **source** to the FtSpool cache."""
-        h = hashlib.new('md5')
-        h.update(source.encode(encoding='utf-8'))
-        outputname = 'vortex_{:s}_P{:06d}_{:s}'.format(date.now().strftime('%Y%m%d%H%M%S-%f'),
-                                                       self.getpid(), h.hexdigest())
+        h = hashlib.new("md5")
+        h.update(source.encode(encoding="utf-8"))
+        outputname = "vortex_{:s}_P{:06d}_{:s}".format(
+            date.now().strftime("%Y%m%d%H%M%S-%f"),
+            self.getpid(),
+            h.hexdigest(),
+        )
         if nest:
             outputname = self.path.join(outputname, self.path.basename(source))
-        kwargs['intent'] = 'in'  # Force intent=in
+        kwargs["intent"] = "in"  # Force intent=in
         if self.ftspool_cache().insert(outputname, source, **kwargs):
             return self.ftspool_cache().fullpath(outputname)
         else:
@@ -1691,42 +1871,69 @@ class OSExtended(System):
         """Given **source** and **destination**, is FtServ usable ?"""
         return isinstance(source, str) and isinstance(destination, str)
 
-    def ftserv_put(self, source, destination, hostname=None, logname=None, port=None,
-                   specialshell=None, sync=False):
+    def ftserv_put(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        specialshell=None,
+        sync=False,
+    ):
         """Asynchronous put of a file using FtServ."""
         if self.ftserv_allowed(source, destination):
             if self.path.exists(source):
-                ftcmd = self.ftputcmd or 'ftput'
+                ftcmd = self.ftputcmd or "ftput"
                 hostname = self.fix_fthostname(hostname, fatal=False)
                 logname = self.fix_ftuser(hostname, logname, fatal=False)
                 extras = list()
                 if not sync:
-                    extras.extend(['-q', ])
+                    extras.extend(
+                        [
+                            "-q",
+                        ]
+                    )
                 if hostname:
                     if port is not None:
-                        hostname += ':{:s}'.format(port)
-                    extras.extend(['-h', hostname])
+                        hostname += ":{:s}".format(port)
+                    extras.extend(["-h", hostname])
                 if logname:
-                    extras.extend(['-u', logname])
+                    extras.extend(["-u", logname])
                 if specialshell:
-                    extras.extend(['-s', specialshell])
+                    extras.extend(["-s", specialshell])
                 # Remove ~/ and ~logname/ from the destinations' path
-                actual_dest = re.sub('^~/+', '', destination)
+                actual_dest = re.sub("^~/+", "", destination)
                 if logname:
-                    actual_dest = re.sub('^~{:s}/+'.format(logname), '', actual_dest)
+                    actual_dest = re.sub(
+                        "^~{:s}/+".format(logname), "", actual_dest
+                    )
                 try:
-                    rc = self.spawn([ftcmd,
-                                     '-o', 'mkdir', ] +  # Automatically create subdirectories
-                                    extras + [source, actual_dest], output=False)
+                    rc = self.spawn(
+                        [
+                            ftcmd,
+                            "-o",
+                            "mkdir",
+                        ]  # Automatically create subdirectories
+                        + extras
+                        + [source, actual_dest],
+                        output=False,
+                    )
                 except ExecutionError:
                     rc = False
             else:
-                raise OSError('No such file or directory: {!s}'.format(source))
+                raise OSError("No such file or directory: {!s}".format(source))
         else:
-            raise OSError('Source or destination is not a plain file path: {!r}'.format(source))
+            raise OSError(
+                "Source or destination is not a plain file path: {!r}".format(
+                    source
+                )
+            )
         return rc
 
-    def ftserv_get(self, source, destination, hostname=None, logname=None, port=None):
+    def ftserv_get(
+        self, source, destination, hostname=None, logname=None, port=None
+    ):
         """Get a file using FtServ."""
         if self.ftserv_allowed(source, destination):
             if self.filecocoon(destination):
@@ -1736,67 +1943,103 @@ class OSExtended(System):
                 extras = list()
                 if hostname:
                     if port is not None:
-                        hostname += ':{:s}'.format(port)
-                    extras.extend(['-h', hostname])
+                        hostname += ":{:s}".format(port)
+                    extras.extend(["-h", hostname])
                 if logname:
-                    extras.extend(['-u', logname])
-                ftcmd = self.ftgetcmd or 'ftget'
+                    extras.extend(["-u", logname])
+                ftcmd = self.ftgetcmd or "ftget"
                 try:
-                    rc = self.spawn([ftcmd, ] + extras + [source, destination], output=False)
+                    rc = self.spawn(
+                        [
+                            ftcmd,
+                        ]
+                        + extras
+                        + [source, destination],
+                        output=False,
+                    )
                 except ExecutionError:
                     rc = False
             else:
-                raise OSError('Could not cocoon: {!s}'.format(destination))
+                raise OSError("Could not cocoon: {!s}".format(destination))
         else:
-            raise OSError('Source or destination is not a plain file path: {!r}'.format(source))
+            raise OSError(
+                "Source or destination is not a plain file path: {!r}".format(
+                    source
+                )
+            )
         return rc
 
-    def ftserv_batchget(self, source, destination, hostname=None, logname=None, port=None):
+    def ftserv_batchget(
+        self, source, destination, hostname=None, logname=None, port=None
+    ):
         """Get a list of files using FtServ.
 
         :note: **source** and **destination** are list or tuple.
         """
-        if all([self.ftserv_allowed(s, d) for s, d in zip(source, destination)]):
+        if all(
+            [self.ftserv_allowed(s, d) for s, d in zip(source, destination)]
+        ):
             for d in destination:
                 if not self.filecocoon(d):
-                    raise OSError('Could not cocoon: {!s}'.format(d))
+                    raise OSError("Could not cocoon: {!s}".format(d))
             extras = list()
             hostname = self.fix_fthostname(hostname, fatal=False)
             logname = self.fix_ftuser(hostname, logname, fatal=False)
             if hostname:
                 if port is not None:
-                    hostname += ':{:s}'.format(port)
-                extras.extend(['-h', hostname])
+                    hostname += ":{:s}".format(port)
+                extras.extend(["-h", hostname])
             if logname:
-                extras.extend(['-u', logname])
-            ftcmd = self.ftgetcmd or 'ftget'
-            plocale = locale.getlocale()[1] or 'ascii'
-            with tempfile.TemporaryFile(dir=self.path.dirname(self.path.abspath(destination[0])),
-                                        mode='wb') as tmpio:
-                tmpio.writelines(['{:s} {:s}\n'.format(s, d).encode(plocale)
-                                  for s, d in zip(source, destination)])
+                extras.extend(["-u", logname])
+            ftcmd = self.ftgetcmd or "ftget"
+            plocale = locale.getlocale()[1] or "ascii"
+            with tempfile.TemporaryFile(
+                dir=self.path.dirname(self.path.abspath(destination[0])),
+                mode="wb",
+            ) as tmpio:
+                tmpio.writelines(
+                    [
+                        "{:s} {:s}\n".format(s, d).encode(plocale)
+                        for s, d in zip(source, destination)
+                    ]
+                )
                 tmpio.seek(0)
-                with tempfile.TemporaryFile(dir=self.path.dirname(self.path.abspath(destination[0])),
-                                            mode='w+b') as tmpoutput:
+                with tempfile.TemporaryFile(
+                    dir=self.path.dirname(self.path.abspath(destination[0])),
+                    mode="w+b",
+                ) as tmpoutput:
                     try:
-                        rc = self.spawn([ftcmd, ] + extras, output=tmpoutput, stdin=tmpio)
+                        rc = self.spawn(
+                            [
+                                ftcmd,
+                            ]
+                            + extras,
+                            output=tmpoutput,
+                            stdin=tmpio,
+                        )
                     except ExecutionError:
                         rc = False
                     # Process output data
                     tmpoutput.seek(0)
                     ft_outputs = tmpoutput.read()
-            ft_outputs = ft_outputs.decode(locale.getlocale()[1] or 'ascii', 'replace')
-            logger.info('Here is the ftget command output: \n%s', ft_outputs)
+            ft_outputs = ft_outputs.decode(
+                locale.getlocale()[1] or "ascii", "replace"
+            )
+            logger.info("Here is the ftget command output: \n%s", ft_outputs)
             # Expand the return codes
             if rc:
-                x_rc = [True, ] * len(source)
+                x_rc = [
+                    True,
+                ] * len(source)
             else:
-                ack_re = re.compile(r'.*FT_(OK|ABORT)\s*:\s*GET\s+(.*)$')
+                ack_re = re.compile(r".*FT_(OK|ABORT)\s*:\s*GET\s+(.*)$")
                 ack_lines = dict()
-                for line in ft_outputs.split('\n'):
+                for line in ft_outputs.split("\n"):
                     ack_match = ack_re.match(line)
                     if ack_match:
-                        ack_lines[ack_match.group(2)] = ack_match.group(1) == 'OK'
+                        ack_lines[ack_match.group(2)] = (
+                            ack_match.group(1) == "OK"
+                        )
                 x_rc = []
                 for a_source in source:
                     my_rc = None
@@ -1806,7 +2049,11 @@ class OSExtended(System):
                             break
                     x_rc.append(my_rc)
         else:
-            raise OSError('Source or destination is not a plain file path: {!r}'.format(source))
+            raise OSError(
+                "Source or destination is not a plain file path: {!r}".format(
+                    source
+                )
+            )
         return x_rc
 
     def rawftput_worthy(self, source, destination):
@@ -1814,8 +2061,16 @@ class OSExtended(System):
         return self.ftraw and self.ftserv_allowed(source, destination)
 
     @fmtshcmd
-    def rawftput(self, source, destination, hostname=None, logname=None, port=None,
-                 cpipeline=None, sync=False):
+    def rawftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        sync=False,
+    ):
         """Proceed with some external ftput command on the specified target.
 
         :param str source: Path to the source filename
@@ -1829,21 +2084,43 @@ class OSExtended(System):
         """
         if cpipeline is not None:
             if cpipeline.compress2rawftp(source):
-                return self.ftserv_put(source, destination, hostname,
-                                       logname=logname, port=port,
-                                       specialshell=cpipeline.compress2rawftp(source),
-                                       sync=sync)
+                return self.ftserv_put(
+                    source,
+                    destination,
+                    hostname,
+                    logname=logname,
+                    port=port,
+                    specialshell=cpipeline.compress2rawftp(source),
+                    sync=sync,
+                )
             else:
                 if port is None:
                     port = DEFAULT_FTP_PORT
-                return self.ftput(source, destination, hostname, logname=logname,
-                                  port=port, cpipeline=cpipeline, sync=sync)
+                return self.ftput(
+                    source,
+                    destination,
+                    hostname,
+                    logname=logname,
+                    port=port,
+                    cpipeline=cpipeline,
+                    sync=sync,
+                )
         else:
-            return self.ftserv_put(source, destination, hostname, logname,
-                                   port=port, sync=sync)
+            return self.ftserv_put(
+                source, destination, hostname, logname, port=port, sync=sync
+            )
 
-    def smartftput(self, source, destination, hostname=None, logname=None, port=None,
-                   cpipeline=None, sync=False, fmt=None):
+    def smartftput(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        sync=False,
+        fmt=None,
+    ):
         """Select the best alternative between ``ftput`` and ``rawftput``.
 
         :param source: The source of data (either a path to file or a
@@ -1867,21 +2144,48 @@ class OSExtended(System):
             * **destination** is a string (as opposed to a File like object)
         """
         if self.rawftput_worthy(source, destination):
-            return self.rawftput(source, destination, hostname=hostname, logname=logname,
-                                 port=port, cpipeline=cpipeline, sync=sync, fmt=fmt)
+            return self.rawftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                sync=sync,
+                fmt=fmt,
+            )
         else:
             if port is None:
                 port = DEFAULT_FTP_PORT
-            return self.ftput(source, destination, hostname=hostname, logname=logname,
-                              port=port, cpipeline=cpipeline, sync=sync, fmt=fmt)
+            return self.ftput(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                sync=sync,
+                fmt=fmt,
+            )
 
     def rawftget_worthy(self, source, destination, cpipeline=None):
         """Is it allowed to use FtServ given **source** and **destination**."""
-        return self.ftraw and cpipeline is None and self.ftserv_allowed(source, destination)
+        return (
+            self.ftraw
+            and cpipeline is None
+            and self.ftserv_allowed(source, destination)
+        )
 
     @fmtshcmd
-    def rawftget(self, source, destination, hostname=None, logname=None, port=None,
-                 cpipeline=None):
+    def rawftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+    ):
         """Proceed with some external ftget command on the specified target.
 
         :param str source: the remote path to get data
@@ -1893,11 +2197,20 @@ class OSExtended(System):
         """
         if cpipeline is not None:
             raise OSError("cpipeline is not supported by this method.")
-        return self.ftserv_get(source, destination, hostname, logname, port=port)
+        return self.ftserv_get(
+            source, destination, hostname, logname, port=port
+        )
 
     @fmtshcmd
-    def batchrawftget(self, source, destination, hostname=None, logname=None,
-                      port=None, cpipeline=None):
+    def batchrawftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+    ):
         """Proceed with some external ftget command on the specified target.
 
         :param source: A list of remote paths to get data
@@ -1909,10 +2222,20 @@ class OSExtended(System):
         """
         if cpipeline is not None:
             raise OSError("cpipeline is not supported by this method.")
-        return self.ftserv_batchget(source, destination, hostname, logname, port=port)
+        return self.ftserv_batchget(
+            source, destination, hostname, logname, port=port
+        )
 
-    def smartftget(self, source, destination, hostname=None, logname=None, port=None,
-                   cpipeline=None, fmt=None):
+    def smartftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        fmt=None,
+    ):
         """Select the best alternative between ``ftget`` and ``rawftget``.
 
         :param str source: the remote path to get data
@@ -1937,16 +2260,38 @@ class OSExtended(System):
         """
         if self.rawftget_worthy(source, destination, cpipeline):
             # FtServ is uninteresting when dealing with compression
-            return self.rawftget(source, destination, hostname=hostname, logname=logname,
-                                 port=port, cpipeline=cpipeline, fmt=fmt)
+            return self.rawftget(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                fmt=fmt,
+            )
         else:
             if port is None:
                 port = DEFAULT_FTP_PORT
-            return self.ftget(source, destination, hostname=hostname, logname=logname,
-                              port=port, cpipeline=cpipeline, fmt=fmt)
+            return self.ftget(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=port,
+                cpipeline=cpipeline,
+                fmt=fmt,
+            )
 
-    def smartbatchftget(self, source, destination, hostname=None, logname=None,
-                        port=None, cpipeline=None, fmt=None):
+    def smartbatchftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+        fmt=None,
+    ):
         """
         Select the best alternative between ``ftget`` and ``batchrawftget``
         when retrieving several files.
@@ -1964,18 +2309,37 @@ class OSExtended(System):
             uncompress the data during the file transfer.
         :param str fmt: The format of data.
         """
-        if all([self.rawftget_worthy(s, d, cpipeline) for s, d in zip(source, destination)]):
+        if all(
+            [
+                self.rawftget_worthy(s, d, cpipeline)
+                for s, d in zip(source, destination)
+            ]
+        ):
             # FtServ is uninteresting when dealing with compression
-            return self.batchrawftget(source, destination, hostname=hostname, logname=logname,
-                                      port=None, cpipeline=cpipeline, fmt=fmt)
+            return self.batchrawftget(
+                source,
+                destination,
+                hostname=hostname,
+                logname=logname,
+                port=None,
+                cpipeline=cpipeline,
+                fmt=fmt,
+            )
         else:
             rc = True
             if port is None:
                 port = DEFAULT_FTP_PORT
             with self.ftppool():
                 for s, d in zip(source, destination):
-                    rc = rc and self.ftget(s, d, hostname=hostname, logname=logname,
-                                           port=port, cpipeline=cpipeline, fmt=fmt)
+                    rc = rc and self.ftget(
+                        s,
+                        d,
+                        hostname=hostname,
+                        logname=logname,
+                        port=port,
+                        cpipeline=cpipeline,
+                        fmt=fmt,
+                    )
             return rc
 
     def ssh(self, hostname, logname=None, *args, **kw):
@@ -1993,7 +2357,9 @@ class OSExtended(System):
         return AssistedSsh(self, hostname, logname, *args, **kw)
 
     @fmtshcmd
-    def scpput(self, source, destination, hostname, logname=None, cpipeline=None):
+    def scpput(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """Perform an scp to the specified target.
 
         :param source: The source of data (either a path to file or a
@@ -2005,14 +2371,16 @@ class OSExtended(System):
         :param CompressionPipeline cpipeline: If not *None*, the object used to
             compress the data during the file transfer (default: *None*).
         """
-        logname = self.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
-        msg = '[hostname={!s} logname={!s}]'.format(hostname, logname)
+        logname = self.fix_ftuser(
+            hostname, logname, fatal=False, defaults_to_user=False
+        )
+        msg = "[hostname={!s} logname={!s}]".format(hostname, logname)
         ssh = self.ssh(hostname, logname)
         if isinstance(source, str) and cpipeline is None:
-            self.stderr('scpput', source, destination, msg)
+            self.stderr("scpput", source, destination, msg)
             return ssh.scpput(source, destination)
         else:
-            self.stderr('scpput_stream', source, destination, msg)
+            self.stderr("scpput_stream", source, destination, msg)
             if cpipeline is None:
                 return ssh.scpput_stream(source, destination)
             else:
@@ -2020,7 +2388,9 @@ class OSExtended(System):
                     return ssh.scpput_stream(csource, destination)
 
     @fmtshcmd
-    def scpget(self, source, destination, hostname, logname=None, cpipeline=None):
+    def scpget(
+        self, source, destination, hostname, logname=None, cpipeline=None
+    ):
         """Perform an scp to get the specified source.
 
         :param str source: the remote path to get data
@@ -2032,14 +2402,16 @@ class OSExtended(System):
         :param CompressionPipeline cpipeline: If not *None*, the object used to
             uncompress the data during the file transfer (default: *None*).
         """
-        logname = self.fix_ftuser(hostname, logname, fatal=False, defaults_to_user=False)
-        msg = '[hostname={!s} logname={!s}]'.format(hostname, logname)
+        logname = self.fix_ftuser(
+            hostname, logname, fatal=False, defaults_to_user=False
+        )
+        msg = "[hostname={!s} logname={!s}]".format(hostname, logname)
         ssh = self.ssh(hostname, logname)
         if isinstance(destination, str) and cpipeline is None:
-            self.stderr('scpget', source, destination, msg)
+            self.stderr("scpget", source, destination, msg)
             return ssh.scpget(source, destination)
         else:
-            self.stderr('scpget_stream', source, destination, msg)
+            self.stderr("scpget_stream", source, destination, msg)
             if cpipeline is None:
                 return ssh.scpget_stream(source, destination)
             else:
@@ -2048,7 +2420,7 @@ class OSExtended(System):
 
     def softlink(self, source, destination):
         """Set a symbolic link if **source** is not **destination**."""
-        self.stderr('softlink', source, destination)
+        self.stderr("softlink", source, destination)
         if source == destination:
             return False
         else:
@@ -2057,7 +2429,7 @@ class OSExtended(System):
     def size(self, filepath):
         """Returns the actual size in bytes of the specified **filepath**."""
         filepath = self.path.expanduser(filepath)
-        self.stderr('size', filepath)
+        self.stderr("size", filepath)
         try:
             return self.stat(filepath).st_size
         except Exception:
@@ -2076,7 +2448,9 @@ class OSExtended(System):
             total_size = self.size(objpath)
             for dirpath, dirnames, filenames in self.walk(objpath):
                 for f in filenames + dirnames:
-                    total_size += self.lstat(self.path.join(dirpath, f)).st_size
+                    total_size += self.lstat(
+                        self.path.join(dirpath, f)
+                    ).st_size
             return total_size
         return self.lstat(objpath).st_size
 
@@ -2084,8 +2458,8 @@ class OSExtended(System):
         """Normalises path name of **dirpath** and recursively creates this directory."""
         normdir = self.path.normpath(self.path.expanduser(dirpath))
         if normdir and not self.path.isdir(normdir):
-            logger.debug('Cocooning directory %s', normdir)
-            self.stderr('mkdir', normdir)
+            logger.debug("Cocooning directory %s", normdir)
+            self.stderr("mkdir", normdir)
             try:
                 self.makedirs(normdir)
                 return True
@@ -2102,17 +2476,17 @@ class OSExtended(System):
         """Normalises path name of ``destination`` and creates **destination**'s directory."""
         return self.mkdir(self.path.dirname(self.path.expanduser(destination)))
 
-    _SAFE_SUFFIX_RE = re.compile('_[a-f0-9]{32}$')
+    _SAFE_SUFFIX_RE = re.compile("_[a-f0-9]{32}$")
 
     def safe_filesuffix(self):
         """Returns a file suffix that should be unique across the system."""
-        return '_' + uuid.uuid1().hex
+        return "_" + uuid.uuid1().hex
 
     def safe_fileaddsuffix(self, name):
         """Returns a file path that will look like name + a unique suffix."""
         d_name = self.path.dirname(name)
         b_name = self.path.basename(name)
-        b_name = self._SAFE_SUFFIX_RE.sub('', b_name)
+        b_name = self._SAFE_SUFFIX_RE.sub("", b_name)
         return self.path.join(d_name, b_name + self.safe_filesuffix())
 
     def _validate_symlink_below(self, symlink, valid_below):
@@ -2125,20 +2499,26 @@ class OSExtended(System):
         """
         link_to = self._os.readlink(symlink)
         # Is it relative ?
-        if re.match('^([^{0:s}]|..{0:s}|.{0:s})'.format(re.escape(os.path.sep)),
-                    link_to):
+        if re.match(
+            "^([^{0:s}]|..{0:s}|.{0:s})".format(re.escape(os.path.sep)),
+            link_to,
+        ):
             symlink_dir = self.path.realpath(
-                self.path.abspath(
-                    self.path.dirname(symlink)
-                )
+                self.path.abspath(self.path.dirname(symlink))
             )
             abspath_to = self.path.normpath(
                 self.path.join(symlink_dir, link_to)
             )
             # Valid ?
-            valid = self.path.commonprefix([valid_below, abspath_to]) == valid_below
-            return (self.path.relpath(abspath_to, start=symlink_dir)
-                    if valid else None)
+            valid = (
+                self.path.commonprefix([valid_below, abspath_to])
+                == valid_below
+            )
+            return (
+                self.path.relpath(abspath_to, start=symlink_dir)
+                if valid
+                else None
+            )
         else:
             return None
 
@@ -2150,10 +2530,11 @@ class OSExtended(System):
 
         The destination directory must not already exist.
         """
-        self.stderr('_copydatatree', src, dst)
+        self.stderr("_copydatatree", src, dst)
         with self.mute_stderr():
-            keep_symlinks_below = (keep_symlinks_below or
-                                   self.path.realpath(self.path.abspath(src)))
+            keep_symlinks_below = keep_symlinks_below or self.path.realpath(
+                self.path.abspath(src)
+            )
             names = self._os.listdir(src)
             self._os.makedirs(dst)
             errors = []
@@ -2162,10 +2543,15 @@ class OSExtended(System):
                 dstname = self._os.path.join(dst, name)
                 try:
                     if self.path.isdir(srcname):
-                        self._copydatatree(srcname, dstname,
-                                           keep_symlinks_below=keep_symlinks_below)
+                        self._copydatatree(
+                            srcname,
+                            dstname,
+                            keep_symlinks_below=keep_symlinks_below,
+                        )
                     elif self._os.path.islink(srcname):
-                        linkto = self._validate_symlink_below(srcname, keep_symlinks_below)
+                        linkto = self._validate_symlink_below(
+                            srcname, keep_symlinks_below
+                        )
                         if linkto is not None:
                             self._os.symlink(linkto, dstname)
                         else:
@@ -2191,7 +2577,7 @@ class OSExtended(System):
         """
         source = self.path.expanduser(source)
         destination = self.path.expanduser(destination)
-        self.stderr('rawcp', source, destination)
+        self.stderr("rawcp", source, destination)
         tmp = self.safe_fileaddsuffix(destination)
         if self.path.isdir(source):
             self._copydatatree(source, tmp)
@@ -2218,29 +2604,35 @@ class OSExtended(System):
         If **destination** is a real-word file name (i.e. not e File-like object),
         the operation is atomic.
         """
-        self.stderr('hybridcp', source, destination)
+        self.stderr("hybridcp", source, destination)
         if isinstance(source, str):
             if not self.path.exists(source):
                 if not silent:
-                    logger.error('Missing source %s', source)
+                    logger.error("Missing source %s", source)
                 return False
-            source = open(self.path.expanduser(source), 'rb')
+            source = open(self.path.expanduser(source), "rb")
             xsource = True
         else:
             xsource = False
             try:
                 source.seek(0)
             except AttributeError:
-                logger.warning('Could not rewind io source before cp: ' + str(source))
+                logger.warning(
+                    "Could not rewind io source before cp: " + str(source)
+                )
         if isinstance(destination, str):
             if self.filecocoon(destination):
                 # Write to a temp file
                 original_dest = self.path.expanduser(destination)
-                tmp_dest = self.safe_fileaddsuffix(self.path.expanduser(destination))
-                destination = open(tmp_dest, 'wb')
+                tmp_dest = self.safe_fileaddsuffix(
+                    self.path.expanduser(destination)
+                )
+                destination = open(tmp_dest, "wb")
                 xdestination = True
             else:
-                logger.error('Could not create a cocoon for file %s', destination)
+                logger.error(
+                    "Could not create a cocoon for file %s", destination
+                )
                 return False
         else:
             destination.seek(0)
@@ -2253,8 +2645,13 @@ class OSExtended(System):
         if xdestination:
             destination.close()
             # Move the tmp_file to the real destination
-            if not self.move(tmp_dest, original_dest):  # Move is atomic for a file
-                logger.error('Cannot move the tmp file to the final destination %s', original_dest)
+            if not self.move(
+                tmp_dest, original_dest
+            ):  # Move is atomic for a file
+                logger.error(
+                    "Cannot move the tmp file to the final destination %s",
+                    original_dest,
+                )
                 return False
         return rc
 
@@ -2265,7 +2662,7 @@ class OSExtended(System):
         return st1.st_dev == st2.st_dev and not self.path.islink(path1)
 
     def _rawcp_instead_of_hardlink(self, source, destination, securecopy=True):
-        self.stderr('rawcp_instead_of_hardlink', source, destination)
+        self.stderr("rawcp_instead_of_hardlink", source, destination)
         if securecopy:
             rc = self.rawcp(source, destination)
         else:
@@ -2294,19 +2691,29 @@ class OSExtended(System):
         except OSError as e:
             if e.errno == errno.EMLINK:
                 # Too many links
-                logger.warning('Too many links for the source file (%s).', source)
+                logger.warning(
+                    "Too many links for the source file (%s).", source
+                )
                 if self.usr_file(source):
-                    rc = self._rawcp_instead_of_hardlink(source, destination, securecopy=securecopy)
+                    rc = self._rawcp_instead_of_hardlink(
+                        source, destination, securecopy=securecopy
+                    )
                     if rc:
                         try:
-                            logger.warning('Replacing the orignal file with a copy...')
+                            logger.warning(
+                                "Replacing the orignal file with a copy..."
+                            )
                             self.move(destination, source)
                         except OSError as ebis:
                             if ebis.errno == errno.EACCES:
                                 # Permission denied
-                                logger.warning('No permissions to create a copy of the source file (%s)',
-                                               source)
-                                logger.warning('Going on with the copy instead of the link...')
+                                logger.warning(
+                                    "No permissions to create a copy of the source file (%s)",
+                                    source,
+                                )
+                                logger.warning(
+                                    "Going on with the copy instead of the link..."
+                                )
                             else:
                                 raise
                         else:
@@ -2319,9 +2726,15 @@ class OSExtended(System):
             rc = self.path.samefile(source, destination)
         return rc
 
-    def hardlink(self, source, destination,
-                 link_threshold=0, readonly=True, securecopy=True,
-                 keep_symlinks_below=None):
+    def hardlink(
+        self,
+        source,
+        destination,
+        link_threshold=0,
+        readonly=True,
+        securecopy=True,
+        keep_symlinks_below=None,
+    ):
         """Create hardlinks for both single files or directories.
 
         :param int link_threshold: if the source file size is smaller than
@@ -2337,10 +2750,17 @@ class OSExtended(System):
                                         directory (if omitted, **source** is used)
         """
         if self.path.isdir(source):
-            self.stderr('hardlink', source, destination,
-                        '#', 'directory,', 'readonly={!s}'.format(readonly))
-            keep_symlinks_below = (keep_symlinks_below or
-                                   self.path.realpath(self.path.abspath(source)))
+            self.stderr(
+                "hardlink",
+                source,
+                destination,
+                "#",
+                "directory,",
+                "readonly={!s}".format(readonly),
+            )
+            keep_symlinks_below = keep_symlinks_below or self.path.realpath(
+                self.path.abspath(source)
+            )
             with self.mute_stderr():
                 # Mimics 'cp -al'
                 names = self._os.listdir(source)
@@ -2350,30 +2770,53 @@ class OSExtended(System):
                     srcname = self._os.path.join(source, name)
                     dstname = self._os.path.join(destination, name)
                     if self._os.path.islink(srcname):
-                        linkto = self._validate_symlink_below(srcname, keep_symlinks_below)
+                        linkto = self._validate_symlink_below(
+                            srcname, keep_symlinks_below
+                        )
                         if linkto is None:
-                            link_target = self.path.join(self.path.dirname(srcname),
-                                                         self._os.readlink(srcname))
-                            rc = self.hardlink(link_target, dstname,
-                                               link_threshold=link_threshold,
-                                               readonly=readonly, securecopy=securecopy,
-                                               keep_symlinks_below=keep_symlinks_below)
+                            link_target = self.path.join(
+                                self.path.dirname(srcname),
+                                self._os.readlink(srcname),
+                            )
+                            rc = self.hardlink(
+                                link_target,
+                                dstname,
+                                link_threshold=link_threshold,
+                                readonly=readonly,
+                                securecopy=securecopy,
+                                keep_symlinks_below=keep_symlinks_below,
+                            )
                         else:
                             self._os.symlink(linkto, dstname)
                     elif self.path.isdir(srcname):
-                        rc = self.hardlink(srcname, dstname,
-                                           link_threshold=link_threshold,
-                                           readonly=readonly, securecopy=securecopy,
-                                           keep_symlinks_below=keep_symlinks_below)
+                        rc = self.hardlink(
+                            srcname,
+                            dstname,
+                            link_threshold=link_threshold,
+                            readonly=readonly,
+                            securecopy=securecopy,
+                            keep_symlinks_below=keep_symlinks_below,
+                        )
                     else:
-                        if link_threshold and self.size(srcname) < link_threshold:
-                            rc = self._rawcp_instead_of_hardlink(srcname, dstname, securecopy=securecopy)
+                        if (
+                            link_threshold
+                            and self.size(srcname) < link_threshold
+                        ):
+                            rc = self._rawcp_instead_of_hardlink(
+                                srcname, dstname, securecopy=securecopy
+                            )
                         else:
-                            rc = self._safe_hardlink(srcname, dstname, securecopy=securecopy)
+                            rc = self._safe_hardlink(
+                                srcname, dstname, securecopy=securecopy
+                            )
                         if readonly and rc:
                             self.readonly(dstname)
                     if not rc:
-                        logger.error('Error while processing %s (rc=%s)', srcname, str(rc))
+                        logger.error(
+                            "Error while processing %s (rc=%s)",
+                            srcname,
+                            str(rc),
+                        )
                         break
                 if rc:
                     self._sh.copystat(source, destination)
@@ -2381,16 +2824,27 @@ class OSExtended(System):
                 return rc
         else:
             if link_threshold and self.size(source) < link_threshold:
-                rc = self._rawcp_instead_of_hardlink(source, destination, securecopy=securecopy)
+                rc = self._rawcp_instead_of_hardlink(
+                    source, destination, securecopy=securecopy
+                )
             else:
-                self.stderr('hardlink', source, destination)
-                rc = self._safe_hardlink(source, destination, securecopy=securecopy)
+                self.stderr("hardlink", source, destination)
+                rc = self._safe_hardlink(
+                    source, destination, securecopy=securecopy
+                )
             if readonly and rc:
                 self.readonly(destination)
             return rc
 
-    def _smartcp_cross_users_links_fallback(self, source, destination, smartcp_threshold, silent,
-                                            exc, tmp_destination=None):
+    def _smartcp_cross_users_links_fallback(
+        self,
+        source,
+        destination,
+        smartcp_threshold,
+        silent,
+        exc,
+        tmp_destination=None,
+    ):
         """Catch errors related to Kernel configuration."""
         if (exc.errno == errno.EPERM) and not self.usr_file(source):
             # This is expected to fail if the fs.protected_hardlinks
@@ -2400,8 +2854,12 @@ class OSExtended(System):
             logger.info("Force System's allow_cross_users_links to False")
             self.allow_cross_users_links = False
             logger.info("Re-running the smartcp command")
-            return self.smartcp(source, destination,
-                                smartcp_threshold=smartcp_threshold, silent=silent)
+            return self.smartcp(
+                source,
+                destination,
+                smartcp_threshold=smartcp_threshold,
+                silent=silent,
+            )
         else:
             raise
 
@@ -2415,30 +2873,39 @@ class OSExtended(System):
         When working on a file, the operation is atomic. When working on a
         directory some restrictions apply (see :meth:`rawcp`)
         """
-        self.stderr('smartcp', source, destination)
+        self.stderr("smartcp", source, destination)
         if not isinstance(source, str) or not isinstance(destination, str):
             return self.hybridcp(source, destination)
         source = self.path.expanduser(source)
         if not self.path.exists(source):
             if not silent:
-                logger.error('Missing source %s', source)
+                logger.error("Missing source %s", source)
             return False
         if self.filecocoon(destination):
             destination = self.path.expanduser(destination)
             if self.path.islink(source):
                 # Solve the symbolic link: this may avoid a rawcp
                 source = self.path.realpath(source)
-            if (self.is_samefs(source, destination) and
-                    (self.allow_cross_users_links or self.usr_file(source))):
+            if self.is_samefs(source, destination) and (
+                self.allow_cross_users_links or self.usr_file(source)
+            ):
                 tmp_destination = self.safe_fileaddsuffix(destination)
                 if self.path.isdir(source):
                     try:
-                        rc = self.hardlink(source, tmp_destination,
-                                           link_threshold=smartcp_threshold, securecopy=False)
+                        rc = self.hardlink(
+                            source,
+                            tmp_destination,
+                            link_threshold=smartcp_threshold,
+                            securecopy=False,
+                        )
                     except OSError as e:
                         rc = self._smartcp_cross_users_links_fallback(
-                            source, destination,
-                            smartcp_threshold, silent, e, tmp_destination=tmp_destination
+                            source,
+                            destination,
+                            smartcp_threshold,
+                            silent,
+                            e,
+                            tmp_destination=tmp_destination,
                         )
                     else:
                         if rc:
@@ -2446,44 +2913,71 @@ class OSExtended(System):
                             with self.secure_directory_move(destination):
                                 rc = self.move(tmp_destination, destination)
                             if not rc:
-                                logger.error('Cannot move the tmp directory to the final destination %s',
-                                             destination)
-                                self.remove(tmp_destination)  # Anyway, try to clean-up things
+                                logger.error(
+                                    "Cannot move the tmp directory to the final destination %s",
+                                    destination,
+                                )
+                                self.remove(
+                                    tmp_destination
+                                )  # Anyway, try to clean-up things
                         else:
-                            logger.error('Cannot copy the data to the tmp directory %s', tmp_destination)
-                            self.remove(tmp_destination)  # Anyway, try to clean-up things
+                            logger.error(
+                                "Cannot copy the data to the tmp directory %s",
+                                tmp_destination,
+                            )
+                            self.remove(
+                                tmp_destination
+                            )  # Anyway, try to clean-up things
                     return rc
                 else:
                     try:
-                        rc = self.hardlink(source, tmp_destination,
-                                           link_threshold=smartcp_threshold, securecopy=False)
+                        rc = self.hardlink(
+                            source,
+                            tmp_destination,
+                            link_threshold=smartcp_threshold,
+                            securecopy=False,
+                        )
                     except OSError as e:
-                        rc = self._smartcp_cross_users_links_fallback(source, destination,
-                                                                      smartcp_threshold, silent, e)
+                        rc = self._smartcp_cross_users_links_fallback(
+                            source, destination, smartcp_threshold, silent, e
+                        )
                     else:
-                        rc = rc and self.move(tmp_destination, destination)  # Move is atomic for a file
+                        rc = rc and self.move(
+                            tmp_destination, destination
+                        )  # Move is atomic for a file
                         # On some systems, the temporary file may remain (if the
                         # destination's inode is identical to the tmp_destination's
                         # inode). The following call to remove will remove leftovers.
                         self.remove(tmp_destination)
                     return rc
             else:
-                rc = self.rawcp(source, destination)  # Rawcp is atomic as much as possible
+                rc = self.rawcp(
+                    source, destination
+                )  # Rawcp is atomic as much as possible
                 if rc:
                     if self.path.isdir(destination):
                         for copiedfile in self.ffind(destination):
-                            if not self.path.islink(copiedfile):  # This make no sense to chmod symlinks
+                            if not self.path.islink(
+                                copiedfile
+                            ):  # This make no sense to chmod symlinks
                                 self.chmod(copiedfile, 0o444)
                     else:
                         self.readonly(destination)
                 return rc
         else:
-            logger.error('Could not create a cocoon for file %s', destination)
+            logger.error("Could not create a cocoon for file %s", destination)
             return False
 
     @fmtshcmd
-    def cp(self, source, destination, intent='inout',
-           smartcp=True, smartcp_threshold=0, silent=False):
+    def cp(
+        self,
+        source,
+        destination,
+        intent="inout",
+        smartcp=True,
+        smartcp_threshold=0,
+        silent=False,
+    ):
         """Copy the **source** file to a safe **destination**.
 
         :param source: The source of data (either a path to file or a
@@ -2504,27 +2998,31 @@ class OSExtended(System):
 
         The fastest option should be used...
         """
-        self.stderr('cp', source, destination)
+        self.stderr("cp", source, destination)
         if not isinstance(source, str) or not isinstance(destination, str):
             return self.hybridcp(source, destination, silent=silent)
         if not self.path.exists(source):
             if not silent:
-                logger.error('Missing source %s', source)
+                logger.error("Missing source %s", source)
             return False
-        if smartcp and intent == 'in':
-            return self.smartcp(source, destination,
-                                smartcp_threshold=smartcp_threshold, silent=silent)
+        if smartcp and intent == "in":
+            return self.smartcp(
+                source,
+                destination,
+                smartcp_threshold=smartcp_threshold,
+                silent=silent,
+            )
         if self.filecocoon(destination):
             return self.rawcp(source, destination)
         else:
-            logger.error('Could not create a cocoon for file %s', destination)
+            logger.error("Could not create a cocoon for file %s", destination)
             return False
 
     def glob(self, *args):
         """Glob file system entries according to ``args``. Returns a list."""
         entries = []
         for entry in args:
-            if entry.startswith(':'):
+            if entry.startswith(":"):
                 entries.append(entry[1:])
             else:
                 entries.extend(glob.glob(self.path.expanduser(entry)))
@@ -2544,15 +3042,23 @@ class OSExtended(System):
         """
         safe = True
         if len(thispath.split(self._os.sep)) < self._rmtreemin + 1:
-            logger.warning('Unsafe starting point depth %s (min is %s)', thispath, self._rmtreemin)
+            logger.warning(
+                "Unsafe starting point depth %s (min is %s)",
+                thispath,
+                self._rmtreemin,
+            )
             safe = False
         else:
             for safepack in safedirs:
                 (safedir, d) = safepack
                 rp = self.path.relpath(thispath, safedir)
-                if not rp.startswith('..'):
+                if not rp.startswith(".."):
                     if len(rp.split(self._os.sep)) < d:
-                        logger.warning('Unsafe access to %s relative to %s', thispath, safedir)
+                        logger.warning(
+                            "Unsafe access to %s relative to %s",
+                            thispath,
+                            safedir,
+                        )
                         safe = False
         return safe
 
@@ -2565,43 +3071,47 @@ class OSExtended(System):
         if isinstance(pathlist, str):
             pathlist = [pathlist]
         for pname in pathlist:
-            for entry in filter(lambda x: self.safepath(x, safedirs), self.glob(pname)):
+            for entry in filter(
+                lambda x: self.safepath(x, safedirs), self.glob(pname)
+            ):
                 ok = self.remove(entry) and ok
         return ok
 
     def _globcmd(self, cmd, args, **kw):
         """Globbing files or directories as arguments before running ``cmd``."""
-        cmd.extend([opt for opt in args if opt.startswith('-')])
+        cmd.extend([opt for opt in args if opt.startswith("-")])
         cmdlen = len(cmd)
         cmdargs = False
-        globtries = [self.path.expanduser(x) for x in args if not x.startswith('-')]
+        globtries = [
+            self.path.expanduser(x) for x in args if not x.startswith("-")
+        ]
         for pname in globtries:
             cmdargs = True
             cmd.extend(self.glob(pname))
         if cmdargs and len(cmd) == cmdlen:
-            logger.warning('Could not find any matching pattern %s', globtries)
+            logger.warning("Could not find any matching pattern %s", globtries)
             return False
         else:
-            kw.setdefault('ok', [0])
+            kw.setdefault("ok", [0])
             return self.spawn(cmd, **kw)
 
     @_kw2spawn
     def wc(self, *args, **kw):
         """Word count on globbed files."""
-        return self._globcmd(['wc'], args, **kw)
+        return self._globcmd(["wc"], args, **kw)
 
     @_kw2spawn
     def ls(self, *args, **kw):
         """Clone of the eponymous unix command."""
-        return self._globcmd(['ls'], args, **kw)
+        return self._globcmd(["ls"], args, **kw)
 
     @_kw2spawn
     def ll(self, *args, **kw):
         """Clone of the eponymous unix alias (ls -l)."""
-        kw['output'] = True
-        llresult = self._globcmd(['ls', '-l'], args, **kw)
+        kw["output"] = True
+        llresult = self._globcmd(["ls", "-l"], args, **kw)
         if llresult:
-            for lline in [x for x in llresult if not x.startswith('total')]:
+            for lline in [x for x in llresult if not x.startswith("total")]:
                 print(lline)
         else:
             return False
@@ -2609,25 +3119,25 @@ class OSExtended(System):
     @_kw2spawn
     def dir(self, *args, **kw):
         """Proxy to ``ls('-l')``."""
-        return self._globcmd(['ls', '-l'], args, **kw)
+        return self._globcmd(["ls", "-l"], args, **kw)
 
     @_kw2spawn
     def cat(self, *args, **kw):
         """Clone of the eponymous unix command."""
-        return self._globcmd(['cat'], args, **kw)
+        return self._globcmd(["cat"], args, **kw)
 
     @fmtshcmd
     @_kw2spawn
     def diff(self, *args, **kw):
         """Clone of the eponymous unix command."""
-        kw.setdefault('ok', [0, 1])
-        kw.setdefault('output', False)
-        return self._globcmd(['cmp'], args, **kw)
+        kw.setdefault("ok", [0, 1])
+        kw.setdefault("output", False)
+        return self._globcmd(["cmp"], args, **kw)
 
     @_kw2spawn
     def rmglob(self, *args, **kw):
         """Wrapper of the shell's ``rm`` command through the :meth:`globcmd` method."""
-        return self._globcmd(['rm'], args, **kw)
+        return self._globcmd(["rm"], args, **kw)
 
     @fmtshcmd
     def move(self, source, destination):
@@ -2636,20 +3146,23 @@ class OSExtended(System):
         :param str source: The source object (file, directory, ...)
         :param str destination: The destination object (file, directory, ...)
         """
-        self.stderr('move', source, destination)
+        self.stderr("move", source, destination)
         try:
             self._sh.move(source, destination)
         except Exception:
-            logger.critical('Could not move <%s> to <%s>', source, destination)
+            logger.critical("Could not move <%s> to <%s>", source, destination)
             raise
         else:
             return True
 
     @contextlib.contextmanager
     def secure_directory_move(self, destination):
-        with self.lockdir_context(destination + '.vortex-lockdir', sloppy=True):
-            do_cleanup = (isinstance(destination, str) and
-                          self.path.exists(destination))
+        with self.lockdir_context(
+            destination + ".vortex-lockdir", sloppy=True
+        ):
+            do_cleanup = isinstance(destination, str) and self.path.exists(
+                destination
+            )
             if do_cleanup:
                 # Warning: Not an atomic portion of code (sorry)
                 tmp_destination = self.safe_fileaddsuffix(destination)
@@ -2668,7 +3181,7 @@ class OSExtended(System):
         :param source: The source object (file, directory, File-like object, ...)
         :param destination: The destination object (file, directory, File-like object, ...)
         """
-        self.stderr('mv', source, destination)
+        self.stderr("mv", source, destination)
         if not isinstance(source, str) or not isinstance(destination, str):
             self.hybridcp(source, destination)
             if isinstance(source, str):
@@ -2679,13 +3192,13 @@ class OSExtended(System):
     @_kw2spawn
     def mvglob(self, *args):
         """Wrapper of the shell's ``mv`` command through the :meth:`globcmd` method."""
-        return self._globcmd(['mv'], args)
+        return self._globcmd(["mv"], args)
 
     def listdir(self, *args):
         """Proxy to standard :mod:`os` directory listing function."""
         if not args:
-            args = ('.',)
-        self.stderr('listdir', *args)
+            args = (".",)
+        self.stderr("listdir", *args)
         return self._os.listdir(self.path.expanduser(args[0]))
 
     def pyls(self, *args):
@@ -2694,10 +3207,10 @@ class OSExtended(System):
         :meth:`ls` method except that that shell's ``ls`` command is not actually
         called.
         """
-        rl = [x for x in args if not x.startswith('-')]
+        rl = [x for x in args if not x.startswith("-")]
         if not rl:
-            rl.append('*')
-        self.stderr('pyls', *rl)
+            rl.append("*")
+        self.stderr("pyls", *rl)
         return self.glob(*rl)
 
     def ldirs(self, *args):
@@ -2706,23 +3219,23 @@ class OSExtended(System):
         :meth:`ls` method except that that shell's ``ls`` command is not actually
         called.
         """
-        rl = [x for x in args if not x.startswith('-')]
+        rl = [x for x in args if not x.startswith("-")]
         if not rl:
-            rl.append('*')
-        self.stderr('ldirs', *rl)
+            rl.append("*")
+        self.stderr("ldirs", *rl)
         return [x for x in self.glob(*rl) if self.path.isdir(x)]
 
     @_kw2spawn
     def gzip(self, *args, **kw):
         """Simple gzip compression of a file."""
-        cmd = ['gzip', '-vf', args[0]]
+        cmd = ["gzip", "-vf", args[0]]
         cmd.extend(args[1:])
         return self.spawn(cmd, **kw)
 
     @_kw2spawn
     def gunzip(self, *args, **kw):
         """Simple gunzip of a gzip-compressed file."""
-        cmd = ['gunzip', args[0]]
+        cmd = ["gunzip", args[0]]
         cmd.extend(args[1:])
         return self.spawn(cmd, **kw)
 
@@ -2734,21 +3247,21 @@ class OSExtended(System):
         """Build a proper string sequence of tar options."""
         zopt = set(opts)
         if verbose:
-            zopt.add('v')
+            zopt.add("v")
         else:
-            zopt.discard('v')
+            zopt.discard("v")
         if autocompress:
-            if tarfile.endswith('gz'):
+            if tarfile.endswith("gz"):
                 # includes the conventional "*.tgz"
-                zopt.add('z')
+                zopt.add("z")
             else:
-                zopt.discard('z')
-            if tarfile.endswith('bz') or tarfile.endswith('bz2'):
+                zopt.discard("z")
+            if tarfile.endswith("bz") or tarfile.endswith("bz2"):
                 # includes the conventional "*.tbz"
-                zopt.add('j')
+                zopt.add("j")
             else:
-                zopt.discard('j')
-        return ''.join(zopt)
+                zopt.discard("j")
+        return "".join(zopt)
 
     @_kw2spawn
     def tar(self, *args, **kw):
@@ -2756,8 +3269,13 @@ class OSExtended(System):
 
         :example: ``self.tar('destination.tar', 'directory1', 'directory2')``
         """
-        opts = self.taropts(args[0], 'cf', kw.pop('verbose', True), kw.pop('autocompress', True))
-        cmd = ['tar', opts, args[0]]
+        opts = self.taropts(
+            args[0],
+            "cf",
+            kw.pop("verbose", True),
+            kw.pop("autocompress", True),
+        )
+        cmd = ["tar", opts, args[0]]
         cmd.extend(self.glob(*args[1:]))
         return self.spawn(cmd, **kw)
 
@@ -2768,8 +3286,13 @@ class OSExtended(System):
         :example: ``self.untar('source.tar')``
         :example: ``self.untar('source.tar', 'to_untar1', 'to_untar2')``
         """
-        opts = self.taropts(args[0], 'xf', kw.pop('verbose', True), kw.pop('autocompress', True))
-        cmd = ['tar', opts, args[0]]
+        opts = self.taropts(
+            args[0],
+            "xf",
+            kw.pop("verbose", True),
+            kw.pop("autocompress", True),
+        )
+        cmd = ["tar", opts, args[0]]
         cmd.extend(args[1:])
         return self.spawn(cmd, **kw)
 
@@ -2784,56 +3307,69 @@ class OSExtended(System):
         This is done in a relatively safe way since it is checked that no existing
         files/directories are overwritten.
         """
-        uniquelevel_ignore = kw.pop('uniquelevel_ignore', False)
+        uniquelevel_ignore = kw.pop("uniquelevel_ignore", False)
         fullsource = self.path.realpath(source)
         self.mkdir(destination)
-        loctmp = tempfile.mkdtemp(prefix='untar_', dir=destination)
+        loctmp = tempfile.mkdtemp(prefix="untar_", dir=destination)
         with self.cdcontext(loctmp, clean_onexit=True):
-            output_setting = kw.pop('output', True)
+            output_setting = kw.pop("output", True)
             output_txt = self.untar(fullsource, output=output_setting, **kw)
             if output_setting and output_txt:
-                logger.info('Untar command output:\n%s', '\n'.join(output_txt))
-            unpacked = self.glob('*')
-            unpacked_prefix = '.'
+                logger.info("Untar command output:\n%s", "\n".join(output_txt))
+            unpacked = self.glob("*")
+            unpacked_prefix = "."
             # If requested, ignore the first level of directory
-            if (uniquelevel_ignore and len(unpacked) == 1 and
-                    self.path.isdir(self.path.join(unpacked[0]))):
+            if (
+                uniquelevel_ignore
+                and len(unpacked) == 1
+                and self.path.isdir(self.path.join(unpacked[0]))
+            ):
                 unpacked_prefix = unpacked[0]
-                logger.info('Moving contents one level up: %s', unpacked_prefix)
+                logger.info(
+                    "Moving contents one level up: %s", unpacked_prefix
+                )
                 with self.cdcontext(unpacked_prefix):
-                    unpacked = self.glob('*')
+                    unpacked = self.glob("*")
             for untaritem in unpacked:
-                itemtarget = self.path.join('..', self.path.basename(untaritem))
+                itemtarget = self.path.join(
+                    "..", self.path.basename(untaritem)
+                )
                 if self.path.exists(itemtarget):
-                    logger.error('Some previous item exists before untar [%s]', untaritem)
+                    logger.error(
+                        "Some previous item exists before untar [%s]",
+                        untaritem,
+                    )
                 else:
-                    self.mv(self.path.join(unpacked_prefix, untaritem),
-                            itemtarget)
+                    self.mv(
+                        self.path.join(unpacked_prefix, untaritem), itemtarget
+                    )
         return unpacked
 
     def is_tarname(self, objname):
         """Check if a ``objname`` is a string with ``.tar`` suffix."""
-        return isinstance(objname, str) and (objname.endswith('.tar') or
-                                             objname.endswith('.tar.gz') or
-                                             objname.endswith('.tgz') or
-                                             objname.endswith('.tar.bz2') or
-                                             objname.endswith('.tbz'))
+        return isinstance(objname, str) and (
+            objname.endswith(".tar")
+            or objname.endswith(".tar.gz")
+            or objname.endswith(".tgz")
+            or objname.endswith(".tar.bz2")
+            or objname.endswith(".tbz")
+        )
 
     def tarname_radix(self, objname):
         """Remove any ``.tar`` specific suffix."""
         if not self.is_tarname(objname):
             return objname
         radix = self.path.splitext(objname)[0]
-        if radix.endswith('.tar'):
+        if radix.endswith(".tar"):
             radix = radix[:-4]
         return radix
 
     def tarname_splitext(self, objname):
         """Like os.path.splitext, but for tar names (e.g. might return ``.tar.gz``)."""
         if not self.is_tarname(objname):
-            return (objname, '')
+            return (objname, "")
         radix = self.tarname_radix(objname)
-        ext = objname.replace(radix, '')
+        ext = objname.replace(radix, "")
         return (radix, ext)
 
     @fmtshcmd
@@ -2852,12 +3388,14 @@ class OSExtended(System):
         (either a file descriptor or a filename).
         """
         rc = None
-        if hasattr(destination, 'write'):
+        if hasattr(destination, "write"):
             rc = gateway.dump(obj, destination, **opts)
         else:
             if self.filecocoon(destination):
-                with open(self.path.expanduser(destination),
-                          'w' + ('b' if bytesdump else '')) as fd:
+                with open(
+                    self.path.expanduser(destination),
+                    "w" + ("b" if bytesdump else ""),
+                ) as fd:
                     rc = gateway.dump(obj, fd, **opts)
         return rc
 
@@ -2866,7 +3404,9 @@ class OSExtended(System):
         Dump a pickled representation of specified **obj** in file **destination**,
         (either a file descriptor or a filename).
         """
-        return self.blind_dump(pickle, obj, destination, bytesdump=True, **opts)
+        return self.blind_dump(
+            pickle, obj, destination, bytesdump=True, **opts
+        )
 
     def json_dump(self, obj, destination, **opts):
         """
@@ -2880,11 +3420,12 @@ class OSExtended(System):
         Use **gateway** for a blind load the representation stored in file **source**,
         (either a file descriptor or a filename).
         """
-        if hasattr(source, 'read'):
+        if hasattr(source, "read"):
             obj = gateway.load(source)
         else:
-            with open(self.path.expanduser(source),
-                      'r' + ('b' if bytesload else '')) as fd:
+            with open(
+                self.path.expanduser(source), "r" + ("b" if bytesload else "")
+            ) as fd:
                 obj = gateway.load(fd)
         return obj
 
@@ -2909,13 +3450,17 @@ class OSExtended(System):
     def utlines(self, *args):
         """Return number of significant code or configuration lines in specified directories."""
         lookfiles = [
-            x for x in self.ffind(*args)
-            if self.path.splitext[1] in ['.py', '.ini', '.tpl', '.rst']
+            x
+            for x in self.ffind(*args)
+            if self.path.splitext[1] in [".py", ".ini", ".tpl", ".rst"]
         ]
-        return len([
-            x for x in self.cat(*lookfiles)
-            if re.search(r'\S', x) and re.search(r'[^\'\"\)\],\s]', x)
-        ])
+        return len(
+            [
+                x
+                for x in self.cat(*lookfiles)
+                if re.search(r"\S", x) and re.search(r"[^\'\"\)\],\s]", x)
+            ]
+        )
 
     def _signal_intercept_init(self):
         """Initialise the signal handler object (but do not activate it)."""
@@ -2935,7 +3480,9 @@ class OSExtended(System):
         """
         self._sighandler.deactivate()
 
-    _LDD_REGEX = re.compile(r'^\s*([^\s]+)\s+=>\s*(?:([^\s]+)\s+\(0x.+\)|not found)$')
+    _LDD_REGEX = re.compile(
+        r"^\s*([^\s]+)\s+=>\s*(?:([^\s]+)\s+\(0x.+\)|not found)$"
+    )
 
     def ldd(self, filename):
         """Call ldd on **filename**.
@@ -2943,14 +3490,14 @@ class OSExtended(System):
         Return the mapping between the library name and its physical path.
         """
         if self.path.isfile(filename):
-            ldd_out = self.spawn(('ldd', filename))
+            ldd_out = self.spawn(("ldd", filename))
             libs = dict()
             for ldd_match in [self._LDD_REGEX.match(l) for l in ldd_out]:
                 if ldd_match is not None:
                     libs[ldd_match.group(1)] = ldd_match.group(2) or None
             return libs
         else:
-            raise ValueError('{} is not a regular file'.format(filename))
+            raise ValueError("{} is not a regular file".format(filename))
 
     def generic_compress(self, pipelinedesc, source, destination=None):
         """Compress a file using the :class:`CompressionPipeline` class.
@@ -2964,7 +3511,9 @@ class OSExtended(System):
             if isinstance(source, str):
                 destination = source + cp.suffix
             else:
-                raise ValueError("If destination is omitted, source must be a filename.")
+                raise ValueError(
+                    "If destination is omitted, source must be a filename."
+                )
         return cp.compress2file(source, destination)
 
     def generic_uncompress(self, pipelinedesc, source, destination=None):
@@ -2978,11 +3527,17 @@ class OSExtended(System):
         if destination is None:
             if isinstance(source, str):
                 if source.endswith(cp.suffix):
-                    destination = source[:-len(cp.suffix)]
+                    destination = source[: -len(cp.suffix)]
                 else:
-                    raise ValueError("Source do not exhibit the appropriate suffix ({:s})".format(cp.suffix))
+                    raise ValueError(
+                        "Source do not exhibit the appropriate suffix ({:s})".format(
+                            cp.suffix
+                        )
+                    )
             else:
-                raise ValueError("If destination is omitted, source must be a filename.")
+                raise ValueError(
+                    "If destination is omitted, source must be a filename."
+                )
         return cp.file2uncompress(source, destination)
 
     def find_mount_point(self, path):
@@ -2993,7 +3548,7 @@ class OSExtended(System):
         :rtype: str
         """
         if not self._os.path.exists(path):
-            logger.warning('Path does not exist: <%s>', path)
+            logger.warning("Path does not exist: <%s>", path)
 
         path = self._os.path.abspath(path)
         while not self._os.path.ismount(path):
@@ -3013,7 +3568,9 @@ class OSExtended(System):
         """
         rc = None
         t0 = time.time()
-        while rc is None or (not rc and blocking and time.time() - t0 < timeout):
+        while rc is None or (
+            not rc and blocking and time.time() - t0 < timeout
+        ):
             if rc is not None:
                 self.sleep(sleeptime)
             try:
@@ -3038,8 +3595,14 @@ class OSExtended(System):
             logger.warning("'%s' did not exists... that's odd", ldir)
 
     @contextlib.contextmanager
-    def lockdir_context(self, ldir,
-                        sloppy=False, timeout=120, sleeptime_min=0.1, sleeptime_max=0.3):
+    def lockdir_context(
+        self,
+        ldir,
+        sloppy=False,
+        timeout=120,
+        sleeptime_min=0.1,
+        sleeptime_max=0.3,
+    ):
         """Try to acquire a lock directory and after that remove it.
 
         :param bool sloppy: If the lock can be acquired after *timeout* second, go on anyway
@@ -3049,14 +3612,20 @@ class OSExtended(System):
         :param float sleeptime_max: When blocking, wait at most **sleeptime_max** seconds
                                     between to attempts to acquire the lock.
         """
-        sleeptime = sleeptime_min + (sleeptime_max - sleeptime_min) * random.random()
+        sleeptime = (
+            sleeptime_min + (sleeptime_max - sleeptime_min) * random.random()
+        )
         self.filecocoon(ldir)
-        rc = self._lockdir_create(ldir, blocking=True, timeout=timeout, sleeptime=sleeptime)
+        rc = self._lockdir_create(
+            ldir, blocking=True, timeout=timeout, sleeptime=sleeptime
+        )
         try:
             if not rc:
-                msg = "Could not acquire lockdir < {:s} >. Already exists.".format(ldir)
+                msg = "Could not acquire lockdir < {:s} >. Already exists.".format(
+                    ldir
+                )
                 if sloppy:
-                    logger.warning(msg + '.. but going on.')
+                    logger.warning(msg + ".. but going on.")
                 else:
                     raise OSError(msg)
             yield
@@ -3070,9 +3639,11 @@ class OSExtended(System):
         if self.glove is not None:
             myglove = self.glove
             rcdir = myglove.configrc
-            lockdir = self.path.join(rcdir,
-                                     'appwide_locks',
-                                     '{0.vapp:s}-{0.vconf:s}'.format(myglove))
+            lockdir = self.path.join(
+                rcdir,
+                "appwide_locks",
+                "{0.vapp:s}-{0.vconf:s}".format(myglove),
+            )
             self.mkdir(lockdir)
             return lockdir
         else:
@@ -3097,10 +3668,9 @@ class OSExtended(System):
                                 attempts to acquire the lock.
         """
         ldir = self._appwide_lockdir_path(label)
-        return self._lockdir_create(ldir,
-                                    blocking=blocking,
-                                    timeout=timeout,
-                                    sleeptime=sleeptime)
+        return self._lockdir_create(
+            ldir, blocking=blocking, timeout=timeout, sleeptime=sleeptime
+        )
 
     def appwide_unlock(self, label):
         """Pseudo-lock mechanism based on atomic directory creation: release lock.
@@ -3124,7 +3694,7 @@ class Python34:
         """
 
         # Optional, netcdf comparison tool
-        b_netcdf_checker = ExternalCodeImportChecker('netdcf')
+        b_netcdf_checker = ExternalCodeImportChecker("netdcf")
         with b_netcdf_checker as npregister:
             from bronx.datagrip import netcdf as b_netcdf
 
@@ -3136,25 +3706,28 @@ class Python34:
                 """Function started by the subprocess."""
                 outcome.value = int(b_netcdf.netcdf_file_diff(nc1, nc2))
 
-            rc = multiprocessing.Value('i', 0)
-            p = multiprocessing.Process(target=_compare_function,
-                                        args=(netcdf1, netcdf2, rc))
+            rc = multiprocessing.Value("i", 0)
+            p = multiprocessing.Process(
+                target=_compare_function, args=(netcdf1, netcdf2, rc)
+            )
             p.start()
             p.join()
             return bool(rc.value)
         else:
-            logger.error("Unable to load the 'bronx.datagrip.netcdf' package. " +
-                         "The netcdf library and/or 'netCDF4' python package are probably missing.")
+            logger.error(
+                "Unable to load the 'bronx.datagrip.netcdf' package. "
+                + "The netcdf library and/or 'netCDF4' python package are probably missing."
+            )
             return False
 
     # Let's make this method compatible with fmtshcmd...
     netcdf_diff.func_extern = True
 
 
-_python34_fp = footprints.Footprint(info='An abstract footprint to be used with the Python34 Mixin',
-                                    only=dict(
-                                        after_python=PythonSimplifiedVersion('3.4.0')
-                                    ))
+_python34_fp = footprints.Footprint(
+    info="An abstract footprint to be used with the Python34 Mixin",
+    only=dict(after_python=PythonSimplifiedVersion("3.4.0")),
+)
 
 
 class Garbage(OSExtended):
@@ -3166,20 +3739,18 @@ class Garbage(OSExtended):
 
     _abstract = True
     _footprint = dict(
-        info = 'Garbage base system',
-        attr = dict(
-            sysname = dict(
-                outcast = ['Linux', 'Darwin', 'UnitTestLinux', 'UnitTestable']
+        info="Garbage base system",
+        attr=dict(
+            sysname=dict(
+                outcast=["Linux", "Darwin", "UnitTestLinux", "UnitTestable"]
             )
         ),
-        priority = dict(
-            level = footprints.priorities.top.DEFAULT
-        )
+        priority=dict(level=footprints.priorities.top.DEFAULT),
     )
 
     def __init__(self, *args, **kw):
         """Gateway to parent method after debug logging."""
-        logger.debug('Garbage system init %s', self.__class__)
+        logger.debug("Garbage system init %s", self.__class__)
         super().__init__(*args, **kw)
 
 
@@ -3188,7 +3759,7 @@ class Garbage34p(Garbage, Python34):
 
     _footprint = [
         _python34_fp,
-        dict(info = 'Garbage base system withh a blazing Python version')
+        dict(info="Garbage base system withh a blazing Python version"),
     ]
 
 
@@ -3197,12 +3768,8 @@ class Linux(OSExtended):
 
     _abstract = True
     _footprint = dict(
-        info = 'Abstract Linux base system',
-        attr = dict(
-            sysname = dict(
-                values = ['Linux']
-            )
-        )
+        info="Abstract Linux base system",
+        attr=dict(sysname=dict(values=["Linux"])),
     )
 
     def __init__(self, *args, **kw):
@@ -3212,78 +3779,86 @@ class Linux(OSExtended):
 
             * **psopts** - as default option for the ps command (default: ``-w -f -a``).
         """
-        logger.debug('Linux system init %s', self.__class__)
-        self._psopts = kw.pop('psopts', ['-w', '-f', '-a'])
+        logger.debug("Linux system init %s", self.__class__)
+        self._psopts = kw.pop("psopts", ["-w", "-f", "-a"])
         super().__init__(*args, **kw)
-        self.__dict__['_cpusinfo'] = LinuxCpusInfo()
+        self.__dict__["_cpusinfo"] = LinuxCpusInfo()
         try:
-            self.__dict__['_numainfo'] = LibNumaNodesInfo()
+            self.__dict__["_numainfo"] = LibNumaNodesInfo()
         except (OSError, NotImplementedError):
             # On very few Linux systems, libnuma is not available...
             pass
-        self.__dict__['_memoryinfo'] = LinuxMemInfo()
-        self.__dict__['_netstatsinfo'] = LinuxNetstats()
+        self.__dict__["_memoryinfo"] = LinuxMemInfo()
+        self.__dict__["_netstatsinfo"] = LinuxNetstats()
 
     @property
     def realkind(self):
-        return 'linux'
+        return "linux"
 
-    def cpus_ids_per_blocks(self, blocksize=1, topology='raw', hexmask=False):
+    def cpus_ids_per_blocks(self, blocksize=1, topology="raw", hexmask=False):
         """Get the list of CPUs IDs for nicely ordered for subsequent binding.
 
         :param int blocksize: the number of thread consumed by one task
         :param str topology: The task distribution scheme
         :param bool hexmask: Return a list of CPU masks in hexadecimal
         """
-        if topology.startswith('numa'):
-            if topology.endswith('_discardsmt'):
+        if topology.startswith("numa"):
+            if topology.endswith("_discardsmt"):
                 topology = topology[:-11]
                 smtlayout = None
             else:
                 smtlayout = self.cpus_info.physical_cores_smtthreads
             try:
-                cpulist = getattr(self.numa_info,
-                                  topology + '_cpulist')(blocksize,
-                                                         smtlayout=smtlayout)
+                cpulist = getattr(self.numa_info, topology + "_cpulist")(
+                    blocksize, smtlayout=smtlayout
+                )
             except AttributeError:
-                raise ValueError('Unknown topology ({:s}).'.format(topology))
+                raise ValueError("Unknown topology ({:s}).".format(topology))
         else:
             try:
-                cpulist = getattr(self.cpus_info, topology + '_cpulist')(blocksize)
+                cpulist = getattr(self.cpus_info, topology + "_cpulist")(
+                    blocksize
+                )
             except AttributeError:
-                raise ValueError('Unknown topology ({:s}).'.format(topology))
+                raise ValueError("Unknown topology ({:s}).".format(topology))
             cpulist = list(cpulist)
-            cpulist = [[cpulist[(taskid * blocksize + i)]
-                        for i in range(blocksize)]
-                       for taskid in range(len(cpulist) // blocksize)]
+            cpulist = [
+                [cpulist[(taskid * blocksize + i)] for i in range(blocksize)]
+                for taskid in range(len(cpulist) // blocksize)
+            ]
         if hexmask:
             cpulist = [hex(sum([1 << i for i in item])) for item in cpulist]
         return cpulist
 
-    def cpus_ids_dispenser(self, topology='raw'):
+    def cpus_ids_dispenser(self, topology="raw"):
         """Get a dispenser of CPUs IDs for nicely ordered for subsequent binding.
 
         :param str topology: The task distribution scheme
         """
-        if topology.startswith('numa'):
-            if topology.endswith('_discardsmt'):
+        if topology.startswith("numa"):
+            if topology.endswith("_discardsmt"):
                 topology = topology[:-11]
                 smtlayout = None
             else:
                 smtlayout = self.cpus_info.physical_cores_smtthreads
             try:
-                cpudisp = getattr(self.numa_info,
-                                  topology + '_cpu_dispenser')(smtlayout=smtlayout)
+                cpudisp = getattr(self.numa_info, topology + "_cpu_dispenser")(
+                    smtlayout=smtlayout
+                )
             except AttributeError:
-                raise ValueError('Unknown topology ({:s}).'.format(topology))
+                raise ValueError("Unknown topology ({:s}).".format(topology))
         else:
             try:
-                cpudisp = getattr(self.cpus_info, topology + '_cpu_dispenser')()
+                cpudisp = getattr(
+                    self.cpus_info, topology + "_cpu_dispenser"
+                )()
             except AttributeError:
-                raise ValueError('Unknown topology ({:s}).'.format(topology))
+                raise ValueError("Unknown topology ({:s}).".format(topology))
         return cpudisp
 
-    def cpus_affinity_get(self, taskid, blocksize=1, topology='socketpacked', method='taskset'):
+    def cpus_affinity_get(
+        self, taskid, blocksize=1, topology="socketpacked", method="taskset"
+    ):
         """Get the necessary command/environment to set the CPUs affinity.
 
         :param int taskid: the task number
@@ -3293,25 +3868,29 @@ class Linux(OSExtended):
         :return: A 3-elements tuple. (bool: BindingPossible,
             list: Starting command prefix, dict: Environment update)
         """
-        if method not in ('taskset', 'gomp', 'omp', 'ompverbose'):
-            raise ValueError('Unknown binding method ({:s}).'.format(method))
-        if method == 'taskset':
-            if not self.which('taskset'):
-                logger.warning("The taskset is program is missing. Going on without binding.")
+        if method not in ("taskset", "gomp", "omp", "ompverbose"):
+            raise ValueError("Unknown binding method ({:s}).".format(method))
+        if method == "taskset":
+            if not self.which("taskset"):
+                logger.warning(
+                    "The taskset is program is missing. Going on without binding."
+                )
                 return (False, list(), dict())
-        cpulist = self.cpus_ids_per_blocks(blocksize=blocksize, topology=topology)
+        cpulist = self.cpus_ids_per_blocks(
+            blocksize=blocksize, topology=topology
+        )
         cpus = cpulist[taskid % len(cpulist)]
         cmdl = list()
         env = dict()
-        if method == 'taskset':
-            cmdl += ['taskset', '--cpu-list', ','.join([str(c) for c in cpus])]
-        elif method == 'gomp':
-            env['GOMP_CPU_AFFINITY'] = ' '.join([str(c) for c in cpus])
-        elif method.startswith('omp'):
-            env['OMP_PLACES'] = ','.join(['{{{:d}}}'.format(c) for c in cpus])
-            if method.endswith('verbose'):
-                env['OMP_DISPLAY_ENV'] = 'TRUE'
-                env['OMP_DISPLAY_AFFINITY'] = 'TRUE'
+        if method == "taskset":
+            cmdl += ["taskset", "--cpu-list", ",".join([str(c) for c in cpus])]
+        elif method == "gomp":
+            env["GOMP_CPU_AFFINITY"] = " ".join([str(c) for c in cpus])
+        elif method.startswith("omp"):
+            env["OMP_PLACES"] = ",".join(["{{{:d}}}".format(c) for c in cpus])
+            if method.endswith("verbose"):
+                env["OMP_DISPLAY_ENV"] = "TRUE"
+                env["OMP_DISPLAY_AFFINITY"] = "TRUE"
         return (True, cmdl, env)
 
 
@@ -3320,7 +3899,7 @@ class Linux34p(Linux, Python34):
 
     _footprint = [
         _python34_fp,
-        dict(info = 'Linux based system with a blazing Python version')
+        dict(info="Linux based system with a blazing Python version"),
     ]
 
 
@@ -3328,26 +3907,24 @@ class LinuxDebug(Linux34p):
     """Special system class for crude debugging on Linux based systems."""
 
     _footprint = dict(
-        info = 'Linux debug system',
-        attr = dict(
-            version = dict(
-                optional = False,
-                values = ['dbug', 'debug'],
-                remap = dict(
-                    dbug = 'debug'
-                )
+        info="Linux debug system",
+        attr=dict(
+            version=dict(
+                optional=False,
+                values=["dbug", "debug"],
+                remap=dict(dbug="debug"),
             )
-        )
+        ),
     )
 
     def __init__(self, *args, **kw):
         """Gateway to parent method after debug logging."""
-        logger.debug('LinuxDebug system init %s', self.__class__)
+        logger.debug("LinuxDebug system init %s", self.__class__)
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
-        return 'linuxdebug'
+        return "linuxdebug"
 
 
 class Macosx(OSExtended):
@@ -3355,15 +3932,11 @@ class Macosx(OSExtended):
 
     _abstract = True
     _footprint = dict(
-        info = 'Apple Mac computer under Macosx',
-        attr = dict(
-            sysname = dict(
-                values = ['Darwin']
-            ),
+        info="Apple Mac computer under Macosx",
+        attr=dict(
+            sysname=dict(values=["Darwin"]),
         ),
-        priority = dict(
-            level = footprints.priorities.top.TOOLBOX
-        )
+        priority=dict(level=footprints.priorities.top.TOOLBOX),
     )
 
     def __init__(self, *args, **kw):
@@ -3373,18 +3946,18 @@ class Macosx(OSExtended):
 
             * **psopts** - as default option for the ps command (default: ``-w -f -a``).
         """
-        logger.debug('Darwin system init %s', self.__class__)
-        self._psopts = kw.pop('psopts', ['-w', '-f', '-a'])
+        logger.debug("Darwin system init %s", self.__class__)
+        self._psopts = kw.pop("psopts", ["-w", "-f", "-a"])
         super().__init__(*args, **kw)
 
     @property
     def realkind(self):
-        return 'darwin'
+        return "darwin"
 
     @property
     def default_syslog(self):
         """Address to use in logging.handler.SysLogHandler()."""
-        return '/var/run/syslog'
+        return "/var/run/syslog"
 
 
 class Macosx34p(Macosx, Python34):
@@ -3392,5 +3965,7 @@ class Macosx34p(Macosx, Python34):
 
     _footprint = [
         _python34_fp,
-        dict(info = 'Apple Mac computer under Macosx with a blazing Python version')
+        dict(
+            info="Apple Mac computer under Macosx with a blazing Python version"
+        ),
     ]

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -2555,7 +2555,7 @@ class OSExtended(System):
                         if linkto is not None:
                             self._os.symlink(linkto, dstname)
                         else:
-                            rc = self._sh.copyfile(srcname, dstname)
+                            self._sh.copyfile(srcname, dstname)
                     else:
                         # Will raise a SpecialFileError for unsupported file types
                         self._sh.copyfile(srcname, dstname)
@@ -3578,7 +3578,7 @@ class OSExtended(System):
                 # since we need to get an error if the target directory already
                 # exists
                 self._os.mkdir(ldir)
-            except FileExistsError as os_e:
+            except FileExistsError:
                 rc = False
             else:
                 rc = True
@@ -3695,8 +3695,7 @@ class Python34:
 
         # Optional, netcdf comparison tool
         b_netcdf_checker = ExternalCodeImportChecker("netdcf")
-        with b_netcdf_checker as npregister:
-            from bronx.datagrip import netcdf as b_netcdf
+        from bronx.datagrip import netcdf as b_netcdf
 
         if b_netcdf_checker.is_available():
             # Unfortunately, the netCDF4 package seems to leak memory,

--- a/src/vortex/tools/targets.py
+++ b/src/vortex/tools/targets.py
@@ -44,55 +44,55 @@ class Target(fp.FootprintBase):
 
     _abstract = True
     _explicit = False
-    _collector = ('target',)
+    _collector = ("target",)
     _footprint = dict(
-        info = 'Default target description',
-        attr = dict(
-            hostname = dict(
-                optional = True,
-                default  = platform.node(),
-                alias    = ('nodename', 'computer')
+        info="Default target description",
+        attr=dict(
+            hostname=dict(
+                optional=True,
+                default=platform.node(),
+                alias=("nodename", "computer"),
             ),
-            inetname = dict(
-                optional = True,
-                default  = platform.node(),
+            inetname=dict(
+                optional=True,
+                default=platform.node(),
             ),
-            fqdn = dict(
-                optional = True,
-                default  = default_fqdn(),
+            fqdn=dict(
+                optional=True,
+                default=default_fqdn(),
             ),
-            sysname = dict(
-                optional = True,
-                default  = platform.system(),
+            sysname=dict(
+                optional=True,
+                default=platform.system(),
             ),
-            userconfig = dict(
-                type     = GenericConfigParser,
-                optional = True,
-                default  = None,
+            userconfig=dict(
+                type=GenericConfigParser,
+                optional=True,
+                default=None,
             ),
-            inifile = dict(
-                optional = True,
-                default  = '@target-[hostname].ini',
+            inifile=dict(
+                optional=True,
+                default="@target-[hostname].ini",
             ),
-            defaultinifile = dict(
-                optional = True,
-                default  = 'target-commons.ini',
+            defaultinifile=dict(
+                optional=True,
+                default="target-commons.ini",
             ),
-            iniauto = dict(
-                type     = bool,
-                optional = True,
-                default  = True,
-            )
-        )
+            iniauto=dict(
+                type=bool,
+                optional=True,
+                default=True,
+            ),
+        ),
     )
 
-    _re_nodes_property = re.compile(r'(\w+)(nodes)$')
-    _re_proxies_property = re.compile(r'(\w+)(proxies)$')
-    _re_isnode_property = re.compile(r'is(\w+)node$')
-    _re_glove_rk_id = re.compile(r'^(.*)@\w+$')
+    _re_nodes_property = re.compile(r"(\w+)(nodes)$")
+    _re_proxies_property = re.compile(r"(\w+)(proxies)$")
+    _re_isnode_property = re.compile(r"is(\w+)node$")
+    _re_glove_rk_id = re.compile(r"^(.*)@\w+$")
 
     def __init__(self, *args, **kw):
-        logger.debug('Abstract target computer init %s', self.__class__)
+        logger.debug("Abstract target computer init %s", self.__class__)
         super().__init__(*args, **kw)
         self._actualconfig = self.userconfig
         self._specialnodes = None
@@ -101,7 +101,7 @@ class Target(fp.FootprintBase):
 
     @property
     def realkind(self):
-        return 'target'
+        return "target"
 
     @property
     def config(self):
@@ -135,23 +135,35 @@ class Target(fp.FootprintBase):
         The :meth:`get` method called whith ``key='sectionname:myoption'`` will
         return 'operations'.
         """
-        my_glove_rk = '@' + sessions.current().glove.realkind
-        if ':' in key:
-            section, option = (x.strip() for x in key.split(':', 1))
+        my_glove_rk = "@" + sessions.current().glove.realkind
+        if ":" in key:
+            section, option = (x.strip() for x in key.split(":", 1))
             # Check if an override section exists
-            sections = [x for x in (section + my_glove_rk, section)
-                        if x in self.config.sections()]
+            sections = [
+                x
+                for x in (section + my_glove_rk, section)
+                if x in self.config.sections()
+            ]
         else:
             option = key
             # First look in override sections, then in default one
-            sections = ([s for s in self.config.sections() if s.endswith(my_glove_rk)] +
-                        [s for s in self.config.sections() if not self._re_glove_rk_id.match(s)])
+            sections = [
+                s for s in self.config.sections() if s.endswith(my_glove_rk)
+            ] + [
+                s
+                for s in self.config.sections()
+                if not self._re_glove_rk_id.match(s)
+            ]
         # Return the first matching section/option
-        for section in [x for x in sections if self.config.has_option(x, option)]:
+        for section in [
+            x for x in sections if self.config.has_option(x, option)
+        ]:
             return self.config.get(section, option)
         return default
 
-    def getx(self, key, default=None, env_key=None, silent=False, aslist=False):
+    def getx(
+        self, key, default=None, env_key=None, silent=False, aslist=False
+    ):
         r"""Return a value from several sources.
 
         In turn, the following sources are considered:
@@ -179,10 +191,12 @@ class Target(fp.FootprintBase):
             value = None
 
         if value is None:
-            if ':' not in key:
+            if ":" not in key:
                 if silent:
                     return None
-                msg = 'Configuration key should be "section:option" not "{}"'.format(key)
+                msg = 'Configuration key should be "section:option" not "{}"'.format(
+                    key
+                )
                 raise KeyError(msg)
             value = self.get(key, default)
 
@@ -196,17 +210,28 @@ class Target(fp.FootprintBase):
             raise KeyError(msg)
 
         if aslist:
-            value = value.replace('\n', ' ').replace('\\', ' ').replace(',', ' ').split()
+            value = (
+                value.replace("\n", " ")
+                .replace("\\", " ")
+                .replace(",", " ")
+                .split()
+            )
 
         return value
 
     def sections(self):
         """Returns the list of sections contained in the config file."""
-        my_glove_rk = '@' + sessions.current().glove.realkind
-        return sorted({self._re_glove_rk_id.sub(r'\1', x)
-                       for x in self.config.sections()
-                       if ((not self._re_glove_rk_id.match(x)) or
-                           x.endswith(my_glove_rk))})
+        my_glove_rk = "@" + sessions.current().glove.realkind
+        return sorted(
+            {
+                self._re_glove_rk_id.sub(r"\1", x)
+                for x in self.config.sections()
+                if (
+                    (not self._re_glove_rk_id.match(x))
+                    or x.endswith(my_glove_rk)
+                )
+            }
+        )
 
     def options(self, key):
         """For a given section, returns the list of available options.
@@ -214,9 +239,10 @@ class Target(fp.FootprintBase):
         The result may depend on the current glove (see the :meth:`get`
         method documentation).
         """
-        my_glove_rk = '@' + sessions.current().glove.realkind
-        sections = [x for x in (key, key + my_glove_rk)
-                    if x in self.config.sections()]
+        my_glove_rk = "@" + sessions.current().glove.realkind
+        sections = [
+            x for x in (key, key + my_glove_rk) if x in self.config.sections()
+        ]
         options = set()
         for section in sections:
             options.update(self.config.options(section))
@@ -230,9 +256,12 @@ class Target(fp.FootprintBase):
         """
         items = dict()
         if key is not None:
-            my_glove_rk = '@' + sessions.current().glove.realkind
-            sections = [x for x in (key, key + my_glove_rk)
-                        if x in self.config.sections()]
+            my_glove_rk = "@" + sessions.current().glove.realkind
+            sections = [
+                x
+                for x in (key, key + my_glove_rk)
+                if x in self.config.sections()
+            ]
             for section in sections:
                 items.update(self.config.items(section))
         return items
@@ -241,7 +270,7 @@ class Target(fp.FootprintBase):
     def is_anonymous(cls):
         """Return a boolean either the current footprint define or not a mandatory set of hostname values."""
         fp = cls.footprint_retrieve()
-        return not bool(fp.attr['hostname']['values'])
+        return not bool(fp.attr["hostname"]["values"])
 
     def spawn_hook(self, sh):
         """Specific target hook before any serious execution."""
@@ -252,7 +281,12 @@ class Target(fp.FootprintBase):
         """Specific target hook before any component run."""
         yield
 
-    def _init_supernodes(self, main_re, rangeid='range', baseid='base',):
+    def _init_supernodes(
+        self,
+        main_re,
+        rangeid="range",
+        baseid="base",
+    ):
         """Read the configuration file in order to initialize the specialnodes
         and specialproxies lists.
 
@@ -261,40 +295,55 @@ class Target(fp.FootprintBase):
         *generic_nodes* keyword. In such a case, the node list will be
         auto-generated using the XXXrange and XXXbase configuration keys.
         """
-        confsection = 'generic_nodes'
+        confsection = "generic_nodes"
         confoptions = self.options(confsection)
-        nodetypes = [(m.group(1), m.group(2))
-                     for m in [main_re.match(k) for k in confoptions]
-                     if m is not None]
+        nodetypes = [
+            (m.group(1), m.group(2))
+            for m in [main_re.match(k) for k in confoptions]
+            if m is not None
+        ]
         outdict = dict()
         for nodetype, nodelistid in nodetypes:
-            nodelist = self.get(confsection + ':' + nodetype + nodelistid)
-            if nodelist == 'no_generic':
-                noderanges = self.get(confsection + ':' + nodetype + rangeid, None)
+            nodelist = self.get(confsection + ":" + nodetype + nodelistid)
+            if nodelist == "no_generic":
+                noderanges = self.get(
+                    confsection + ":" + nodetype + rangeid, None
+                )
                 if noderanges is None:
-                    raise ValueError('when {0:s}{1:s} == no_generic, {0:s}{2:s} must be provided'
-                                     .format(nodetype, nodelistid, rangeid))
-                nodebases = self.get(confsection + ':' + nodetype + baseid,
-                                     self.inetname + nodetype + '{:d}')
+                    raise ValueError(
+                        "when {0:s}{1:s} == no_generic, {0:s}{2:s} must be provided".format(
+                            nodetype, nodelistid, rangeid
+                        )
+                    )
+                nodebases = self.get(
+                    confsection + ":" + nodetype + baseid,
+                    self.inetname + nodetype + "{:d}",
+                )
                 outdict[nodetype] = list()
-                for (r, b) in zip(noderanges.split('+'), nodebases.split('+')):
-                    outdict[nodetype].extend([b.format(int(i)) for i in r.split(',')])
+                for r, b in zip(noderanges.split("+"), nodebases.split("+")):
+                    outdict[nodetype].extend(
+                        [b.format(int(i)) for i in r.split(",")]
+                    )
             else:
-                outdict[nodetype] = nodelist.split(',')
+                outdict[nodetype] = nodelist.split(",")
         return outdict
 
     @property
     def specialnodesaliases(self):
         """Return the list of known aliases."""
         if self._sepcialnodesaliases is None:
-            confsection = 'generic_nodes'
+            confsection = "generic_nodes"
             confoptions = self.options(confsection)
-            aliases_re = re.compile(r'(\w+)(aliases)')
-            nodetypes = [(m.group(1), m.group(2))
-                         for m in [aliases_re.match(k) for k in confoptions]
-                         if m is not None]
-            rdict = {ntype: self.get(confsection + ':' + ntype + key, '').split(',')
-                     for ntype, key in nodetypes}
+            aliases_re = re.compile(r"(\w+)(aliases)")
+            nodetypes = [
+                (m.group(1), m.group(2))
+                for m in [aliases_re.match(k) for k in confoptions]
+                if m is not None
+            ]
+            rdict = {
+                ntype: self.get(confsection + ":" + ntype + key, "").split(",")
+                for ntype, key in nodetypes
+            }
             self._sepcialnodesaliases = rdict
         return self._sepcialnodesaliases
 
@@ -320,7 +369,9 @@ class Target(fp.FootprintBase):
         equal to the specialnodes list.
         """
         if self._specialproxies is None:
-            self._specialproxies = self._init_supernodes(self._re_proxies_property, 'proxiesrange', 'proxiesbase')
+            self._specialproxies = self._init_supernodes(
+                self._re_proxies_property, "proxiesrange", "proxiesbase"
+            )
             for nodetype, nodelist in self.specialnodes.items():
                 if nodetype not in self._specialproxies:
                     self._specialproxies[nodetype] = nodelist
@@ -346,39 +397,44 @@ class Target(fp.FootprintBase):
         """
         kmatch = self._re_nodes_property.match(key)
         if kmatch is not None:
-            return fp.stdtypes.FPList(self.specialnodes.get(kmatch.group(1), []))
+            return fp.stdtypes.FPList(
+                self.specialnodes.get(kmatch.group(1), [])
+            )
         kmatch = self._re_proxies_property.match(key)
         if kmatch is not None:
-            return fp.stdtypes.FPList(self.specialproxies.get(kmatch.group(1), []))
+            return fp.stdtypes.FPList(
+                self.specialproxies.get(kmatch.group(1), [])
+            )
         kmatch = self._re_isnode_property.match(key)
         if kmatch is not None:
-            return ((kmatch.group(1) not in self.specialnodes) or
-                    any([self.hostname.startswith(s)
-                         for s in self.specialnodes[kmatch.group(1)]]))
+            return (kmatch.group(1) not in self.specialnodes) or any(
+                [
+                    self.hostname.startswith(s)
+                    for s in self.specialnodes[kmatch.group(1)]
+                ]
+            )
         raise AttributeError('The key "{:s}" does not exist.'.format(key))
 
     @property
     def ftraw_default(self):
         """The default value for the System object ftraw attribute."""
-        return ('ftraw' in self.specialnodes and
-                any([self.hostname.startswith(s)
-                     for s in self.specialnodes['ftraw']]))
+        return "ftraw" in self.specialnodes and any(
+            [self.hostname.startswith(s) for s in self.specialnodes["ftraw"]]
+        )
 
 
 class LocalTarget(Target):
     """A very generic class usable for most computers."""
 
     _footprint = dict(
-        info = 'Nice local target',
-        attr = dict(
-            sysname = dict(
-                values = ['Linux', 'Darwin', 'Local', 'Localhost']
-            ),
-        )
+        info="Nice local target",
+        attr=dict(
+            sysname=dict(values=["Linux", "Darwin", "Local", "Localhost"]),
+        ),
     )
 
 
 # Disable priority warnings on the target collector
-fcollect = fp.collectors.get(tag='target')
+fcollect = fp.collectors.get(tag="target")
 fcollect.non_ambiguous_loglevel = logging.DEBUG
 del fcollect

--- a/src/vortex/util/__init__.py
+++ b/src/vortex/util/__init__.py
@@ -6,4 +6,4 @@ capabilities.
 #: No automatic export
 __all__ = []
 
-__tocinfoline__ = 'VORTEX generic utility classes and methods'
+__tocinfoline__ = "VORTEX generic utility classes and methods"

--- a/src/vortex/util/empty.py
+++ b/src/vortex/util/empty.py
@@ -15,10 +15,10 @@ class DataConst:
 
     def __init__(self, **kw):
         self.__dict__.update(kw)
-        logger.debug('DataConst init %s', self)
+        logger.debug("DataConst init %s", self)
 
     def __str__(self):
-        return super().__str__() + ' : ' + str(sorted(self.__dict__.keys()))
+        return super().__str__() + " : " + str(sorted(self.__dict__.keys()))
 
     def __contains__(self, item):
         return item in self.__dict__

--- a/src/vortex/util/introspection.py
+++ b/src/vortex/util/introspection.py
@@ -20,10 +20,10 @@ class Sherlock:
 
     def __init__(self, **kw):
         self.verbose = False
-        self.ticket = kw.pop('ticket', sessions.current())
+        self.ticket = kw.pop("ticket", sessions.current())
         self.glove = self.ticket.glove
         self.__dict__.update(kw)
-        logger.debug('Sherlock init %s', self)
+        logger.debug("Sherlock init %s", self)
 
     def rstfile(self, modpath):
         """Return the sphinx documentation associated to module reference or module path given."""
@@ -31,28 +31,34 @@ class Sherlock:
             modpath = modpath.__file__
         subpath = modpath
         for installpath in self.glove.sitesrc:
-            subpath = re.sub(installpath, '', subpath)
-        subpath = re.sub(r'\.pyc?', '', subpath)
-        subpath = subpath.split('/')
-        if subpath[-1] == '__init__':
+            subpath = re.sub(installpath, "", subpath)
+        subpath = re.sub(r"\.pyc?", "", subpath)
+        subpath = subpath.split("/")
+        if subpath[-1] == "__init__":
             subpath[-1] = subpath[-2]
-        subpath[-1] += '.rst'
+        subpath[-1] += ".rst"
 
-        subpath[1:1] = ['library', ]
-        return self.glove.sitedoc + '/'.join(subpath)
+        subpath[1:1] = [
+            "library",
+        ]
+        return self.glove.sitedoc + "/".join(subpath)
 
     def rstshort(self, filename):
         """Return relative path name of ``filename`` according to :meth:`siteroot`."""
-        return re.sub(self.glove.siteroot, '', filename)[1:]
+        return re.sub(self.glove.siteroot, "", filename)[1:]
 
     def getlocalmembers(self, obj, topmodule=None):
         """Return members of the module ``obj`` which are defined in the source file of the module."""
         objs = dict()
         if topmodule is None:
             topmodule = obj
-        modfile = topmodule.__file__.rstrip('c')
+        modfile = topmodule.__file__.rstrip("c")
         for x, y in inspect.getmembers(obj):
-            if inspect.isclass(y) or inspect.isfunction(y) or inspect.ismethod(y):
+            if (
+                inspect.isclass(y)
+                or inspect.isfunction(y)
+                or inspect.ismethod(y)
+            ):
                 try:
                     if modfile == inspect.getsourcefile(y):
                         if self.verbose:

--- a/src/vortex/util/iosponge.py
+++ b/src/vortex/util/iosponge.py
@@ -23,7 +23,9 @@ class IoSponge(io.BufferedIOBase):
     that limit the maximum of *size_check* and *guessed_size* is returned.
     """
 
-    def __init__(self, rawio, size_check=IOSPONGE_DEFAULT_SIZECHECK, guessed_size=0):
+    def __init__(
+        self, rawio, size_check=IOSPONGE_DEFAULT_SIZECHECK, guessed_size=0
+    ):
         """
         :param file rawio: Any kind of file-like object
         :param int size_check: The first size_check bytes will be buffered in
@@ -50,12 +52,14 @@ class IoSponge(io.BufferedIOBase):
         return self._seek
 
     def _generic_read(self, size, raw_read_cb):
-        ret = b''
+        ret = b""
         if self._seek < len(self._first_bytes):
             if size is None:
-                ret = self._first_bytes[self._seek:]
+                ret = self._first_bytes[self._seek :]
             else:
-                ret = self._first_bytes[self._seek:min(self._size_check, self._seek + size)]
+                ret = self._first_bytes[
+                    self._seek : min(self._size_check, self._seek + size)
+                ]
         if size is None:
             ret += raw_read_cb(None)
         elif len(ret) < size:

--- a/src/vortex/util/roles.py
+++ b/src/vortex/util/roles.py
@@ -5,15 +5,15 @@ Factory for named roles.
 #: No automatic export
 __all__ = []
 
-_activetag = 'default'
+_activetag = "default"
 
 
 def stdfactoryrole(role):
     """Standard processing for role names."""
-    return ''.join([s[0].upper() + s[1:] for s in role.split()])
+    return "".join([s[0].upper() + s[1:] for s in role.split()])
 
 
-def switchfactory(tag='default'):
+def switchfactory(tag="default"):
     """Switch the current active factory to the existing one identified through its ``tag``."""
     if tag in _rolesgateway:
         global _activetag
@@ -46,6 +46,4 @@ def setrole(role, tag=None):
     return _rolesgateway[tag](role)
 
 
-_rolesgateway = dict(
-    default=stdfactoryrole
-)
+_rolesgateway = dict(default=stdfactoryrole)

--- a/src/vortex/util/storefunctions.py
+++ b/src/vortex/util/storefunctions.py
@@ -31,28 +31,39 @@ def mergecontents(options):
 
     :rtype: A file like object
     """
-    todo = options.get('role', None)
-    sort = vartrue.match(options.get('sort', ['false', ]).pop())
+    todo = options.get("role", None)
+    sort = vartrue.match(
+        options.get(
+            "sort",
+            [
+                "false",
+            ],
+        ).pop()
+    )
     if todo is not None:
         ctx = sessions.current().context
         sections = list()
         for a_role in todo:
             sections.extend(ctx.sequence.effective_inputs(role=a_role))
         if len(sections) == 0:
-            raise FunctionStoreCallbackError("Nothing to store: the effective inputs sequence is void.")
+            raise FunctionStoreCallbackError(
+                "Nothing to store: the effective inputs sequence is void."
+            )
         newcontent = helpers.merge_contents(sections)
         if sort:
             newcontent.sort()
     else:
-        raise FunctionStoreCallbackError('At least one *role* option must be provided')
+        raise FunctionStoreCallbackError(
+            "At least one *role* option must be provided"
+        )
     # Create a Virtual container and dump the new content inside it
     virtualcont = fpx.container(incore=True)
     newcontent.rewrite(virtualcont)
     virtualcont.rewind()
     # Force the new container to be in bytes mode
-    if virtualcont.actualmode and 'b' not in virtualcont.actualmode:
-        virtualcont_b = fpx.container(incore=True, mode='w+b')
-        virtualcont_b.write(virtualcont.read().encode(encoding='utf-8'))
+    if virtualcont.actualmode and "b" not in virtualcont.actualmode:
+        virtualcont_b = fpx.container(incore=True, mode="w+b")
+        virtualcont_b.write(virtualcont.read().encode(encoding="utf-8"))
         virtualcont = virtualcont_b
     return virtualcont
 
@@ -68,12 +79,21 @@ def dumpinputs(options):
     """
     t = sessions.current()
     ctx = t.context
-    if vartrue.match(options.get('effective', ['true', ]).pop()):
+    if vartrue.match(
+        options.get(
+            "effective",
+            [
+                "true",
+            ],
+        ).pop()
+    ):
         sequence = ctx.sequence.effective_inputs()
     else:
         sequence = list(ctx.sequence.inputs())
     if len(sequence) == 0:
-        raise FunctionStoreCallbackError("Nothing to store: the effective inputs sequence is void.")
+        raise FunctionStoreCallbackError(
+            "Nothing to store: the effective inputs sequence is void."
+        )
     fileout = io.StringIO()
     t.sh.json_dump([s.as_dict() for s in sequence], fileout, indent=4)
     return fileout
@@ -87,17 +107,23 @@ def defaultinput(options):
     content = dict()
 
     def export_value(v):
-        if hasattr(v, 'footprint_export'):
+        if hasattr(v, "footprint_export"):
             return v.footprint_export()
-        elif hasattr(v, 'export_dict'):
+        elif hasattr(v, "export_dict"):
             return v.export_dict()
         else:
             return v
 
     for k, v in options.items():
         if isinstance(k, str) and k.startswith(prefix):
-            content[k[len(prefix):]] = export_value(v)
+            content[k[len(prefix) :]] = export_value(v)
     t = sessions.current()
     fileout = io.StringIO()
-    t.sh.json_dump([content, ], fileout, indent=4)
+    t.sh.json_dump(
+        [
+            content,
+        ],
+        fileout,
+        indent=4,
+    )
     return fileout

--- a/src/vortex/util/structs.py
+++ b/src/vortex/util/structs.py
@@ -17,10 +17,10 @@ class ShellEncoder(json.JSONEncoder):
 
     def default(self, obj):
         """Overwrite the default encoding if the current object has a ``export_dict`` method."""
-        if hasattr(obj, 'export_dict'):
+        if hasattr(obj, "export_dict"):
             return obj.export_dict()
-        elif hasattr(obj, 'footprint_export'):
+        elif hasattr(obj, "footprint_export"):
             return obj.footprint_export()
-        elif hasattr(obj, '__dict__'):
+        elif hasattr(obj, "__dict__"):
             return vars(obj)
         return super().default(obj)

--- a/src/vortex/util/worker.py
+++ b/src/vortex/util/worker.py
@@ -47,12 +47,14 @@ class VortexWorker:
     See :mod:`vortex.gloves`.
     """
 
-    _PRIVATESESSION_TAG = 'asyncworker_view'
-    _PRIVATEGLOVE_TAG = 'asyncworker_id'
+    _PRIVATESESSION_TAG = "asyncworker_view"
+    _PRIVATEGLOVE_TAG = "asyncworker_id"
     _PRIVATESESSION = None
     _PRIVATEMODULES = set()
 
-    def __init__(self, modules=tuple(), verbose=False, logger=None, profile=None):
+    def __init__(
+        self, modules=tuple(), verbose=False, logger=None, profile=None
+    ):
         self._logger = logger
         self._modules = modules
         self._context_lock = False
@@ -74,21 +76,22 @@ class VortexWorker:
         """The session associated with Async Worker."""
         if self._PRIVATESESSION is None:
             import vortex
+
             t = vortex.sessions.get(
                 tag=self._PRIVATESESSION_TAG,
                 glove=vortex.sessions.getglove(
-                    tag=self._PRIVATEGLOVE_TAG,
-                    profile=self.profile
-                )
+                    tag=self._PRIVATEGLOVE_TAG, profile=self.profile
+                ),
             )
             sh = t.system()
             import vortex.tools.lfi  # @UnusedImport
             import vortex.tools.grib  # @UnusedImport
             import vortex.tools.folder  # @UnusedImport
             import footprints as fp
-            fp.proxy.addon(kind='lfi', shell=sh)
-            fp.proxy.addon(kind='grib', shell=sh)
-            fp.proxy.addon(kind='allfolders', shell=sh, verboseload=False)
+
+            fp.proxy.addon(kind="lfi", shell=sh)
+            fp.proxy.addon(kind="grib", shell=sh)
+            fp.proxy.addon(kind="allfolders", shell=sh, verboseload=False)
             self._PRIVATESESSION = t
         return self._PRIVATESESSION
 
@@ -100,8 +103,8 @@ class VortexWorker:
         if not self.verbose:
             # footprints & bronx can be very talkative... we try to limit that !
             global_level = logger.getEffectiveLevel()
-            f_logger = loggers.getLogger('footprints')
-            b_logger = loggers.getLogger('bronx')
+            f_logger = loggers.getLogger("footprints")
+            b_logger = loggers.getLogger("bronx")
             if global_level <= logging.INFO and not self.verbose:
                 f_logger.setLevel(logging.INFO)
                 b_logger.setLevel(logging.INFO)
@@ -111,7 +114,9 @@ class VortexWorker:
 
     def __enter__(self, *args):
         if self._context_lock:
-            raise RuntimeError('Imbricated context manager calls are forbidden.')
+            raise RuntimeError(
+                "Imbricated context manager calls are forbidden."
+            )
         self._context_lock = True
         if self.logger is None:
             self._logger = logger
@@ -119,6 +124,7 @@ class VortexWorker:
             self.reset_loggers(self.logger)
         # Activate our own session
         import vortex
+
         self._context_prev_ticket = vortex.sessions.current()
         if not self.session.active:
             self.session.activate()
@@ -128,23 +134,29 @@ class VortexWorker:
                 self.session.sh.import_module(modname)
                 self._PRIVATEMODULES.add(modname)
         # Ok, let's talk...
-        self.logger.info('VORTEX enter glove_profile=%s ', self.session.glove.profile)
-        self.logger.debug('       modules=%s addons=%s', self.modules, self.session.sh.loaded_addons())
+        self.logger.info(
+            "VORTEX enter glove_profile=%s ", self.session.glove.profile
+        )
+        self.logger.debug(
+            "       modules=%s addons=%s",
+            self.modules,
+            self.session.sh.loaded_addons(),
+        )
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """Well... nothing much to do..."""
         if exc_value is not None:
-            self.logger.critical('VORTEX exits on error', exc_info=exc_value)
+            self.logger.critical("VORTEX exits on error", exc_info=exc_value)
             self.rc = False
         else:
-            self.logger.debug('VORTEX exits nicely.')
+            self.logger.debug("VORTEX exits nicely.")
         self._context_prev_ticket.activate()
         self._context_lock = False
         return True
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
 
     doctest.testmod(verbose=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+import pytest
+
+from vortex import config
+
+config.VORTEX_CONFIG = {
+    "data-tree": {
+        "op-rootdir": "/op/rootdir",
+        "rootdir": "/a/b/c/rootdir",
+    },
+    "storage": {
+        "address": "storage.meteo.fr",
+        "protocol": "ftp",
+    },
+}
+
+def test_section_from_config():
+    with pytest.raises(KeyError):
+        config_section = config.from_config("nonexist")
+
+    config_section = config.from_config("data-tree")
+
+    assert config_section == config.VORTEX_CONFIG["data-tree"]
+
+
+def test_key_from_config():
+    with pytest.raises(KeyError):
+        config_value = config.from_config("data-tree", "nonexist")
+
+    config_value = config.from_config("data-tree", "rootdir")
+
+    assert config_value == config.VORTEX_CONFIG["data-tree"]["rootdir"]
+
+
+def test_set_config():
+    config.set_config("newsection", "newkey", 42)
+
+    assert config.from_config("newsection", "newkey") == 42
+
+
+def test_is_defined():
+    assert not config.is_defined("nonexist")
+    assert config.is_defined("storage")
+    assert not config.is_defined("storage", "nonexist")
+    assert config.is_defined("storage", "protocol")
+
+
+def test_get_from_config_w_default():
+
+    assert config.get_from_config_w_default(
+        "data-tree", "nonexist", "default",
+    ) == "default"
+
+    assert config.get_from_config_w_default(
+        "data-tree", "op-rootdir", "default",
+    ) == config.from_config("data-tree", "op-rootdir")
+        
+    
+    


### PR DESCRIPTION
[Ruff](https://docs.astral.sh/ruff/) is a popular tool for both linting and formatting Python code. There are numerous quality alternatives (black, blue, pyflakes, flake8...) but ruff has a track record of being the fastest out there.

This applies `ruff format` on all files under the `src` directory, as well as multiple fixes required for `ruff check` to pass as well.

The ruff  configuration is left close to the default, with the exception of the line-length set to 79 and allowing short variable names. Ruff is configured through the pyproject.toml file.

This also add a github workflo config to run ruff as part of CI checks.