### PR TITLE
Include running tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,22 @@ jobs:
     - run: pip install ruff==0.9.*
     - run: ruff format --check src/
 
+  test:
+    needs: [ruff-check, ruff-format]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: pip install pytest
+    - run: pip install .
+    - name: Run tests
+      # Run two example test modules
+
+      # Most tests in the tests/ directory date back to vortex 1.* and need
+      # to be ported to vortex 2.*. This is ongoing work.
+      run: python -m pytest tests/test_config.py tests/tests_algo/test_basics.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = ["sphinx", "sphinx-book-theme", "sphinx-copybutton"]
+dev = ["ruff==0.9.1", "pytest"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -100,15 +100,6 @@ footprints.setup.callback = vortexfpdefaults
 ticket = sessions.get
 sh = sessions.system
 
-# Specific toolbox exceptions
-
-
-class VortexForceComplete(Exception):
-    """Exception for handling fast exit mecanisms."""
-
-    pass
-
-
 # If a config file can be found in current dir, load it
 config.load_config()
 

--- a/src/vortex/layout/nodes.py
+++ b/src/vortex/layout/nodes.py
@@ -20,7 +20,7 @@ from bronx.syntax.iterators import izip_pcn
 from bronx.system.interrupt import SignalInterruptError
 from footprints import proxy as fpx
 from footprints.stdtypes import FPDict
-from vortex import toolbox, VortexForceComplete
+from vortex import toolbox
 from vortex.layout.appconf import ConfigSet
 from vortex.layout.subjobs import subjob_handling, SubJobLauncherError
 from vortex.syntax.stdattrs import Namespace
@@ -32,6 +32,7 @@ logger = loggers.getLogger(__name__)
 __all__ = ["Driver", "Task", "Family"]
 
 OBSERVER_TAG = "Layout-Nodes"
+
 
 #: Definition of a named tuple for Node Statuses
 _NodeStatusTuple = collections.namedtuple(
@@ -1470,7 +1471,7 @@ class Task(Node):
                     self.warmstart()
                     self.refill()
                     self.process()
-                except VortexForceComplete:
+                except toolbox.VortexForceComplete:
                     self.sh.title("Force complete")
                 finally:
                     self.complete()

--- a/src/vortex/toolbox.py
+++ b/src/vortex/toolbox.py
@@ -16,7 +16,7 @@ from bronx.syntax import mktuple
 
 import footprints
 
-from vortex import sessions, data, proxy, VortexForceComplete
+from vortex import sessions, data, proxy
 from vortex.layout.dataflow import stripargs_section, intent, ixo, Section
 
 #: Automatic export of superstar interface.
@@ -28,6 +28,12 @@ logger = loggers.getLogger(__name__)
 defaults = footprints.setup.defaults
 
 sectionmap = {"input": "get", "output": "put", "executable": "get"}
+
+
+class VortexForceComplete(Exception):
+    """Exception for handling fast exit mecanisms."""
+
+    pass
 
 
 # Toolbox defaults

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,29 @@
+## tests
+
+With the exception of `test_config.py`, all the test modules listed
+in this directory have been included as-is from vortex 1.  They are
+not expected to pass, mostly due to breaking changes in some modules'
+interface.
+
+Porting this test suite for vortex 2 is ongoing work.  If you'd like
+to help, just pick a test module and try to repait the tests it
+contains.  It is also possible that some tests do not make sense
+anymore.
+
+### Running the tests
+
+The test suite can be run with
+[`pytest`](https://docs.pytest.org/en/stable/).  If your installation
+of *vortex* included the `dev` optional set of dependencies, then
+`pytest` should already be installed in your environnement.  If not,
+you can install it with 
+
+```
+pip install pytest
+```
+
+To run the tests:
+
+```
+pytest
+```


### PR DESCRIPTION
This adds a `tests` job to the github workflows config running a couple of tests modules.

Most of the tests in the `tests/` directory have not yet been ported to vortex 2.X, and this is ongoing work. This PR only adds a bit of infrastructure around continuous integration.