### PR TITLE
Make arbitrary experiment names the base case

### DIFF
--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -515,7 +515,7 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
 
     def remap_read(self, remote, options):
         """Remap actual remote path to distant store path for intrusive actions."""
-        return copy.copy(remote)
+        raise NotImplementedError
 
     def remap_list(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -742,9 +742,6 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
             )
             logger.error(msg)
             raise e
-        xpath = remote["path"].split("/")
-        xpath[3:4] = list(xpath[3])
-        remote["path"] = self.system.path.join(*xpath)
         return remote
 
 

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -769,65 +769,6 @@ class VortexStdStackedArchiveStore(VortexStdBaseArchiveStore):
     ]
 
 
-class VortexFreeStdBaseArchiveStore(
-    _VortexBaseArchiveStore, ConfigurableArchiveStore
-):
-    """Archive for casual VORTEX experiments: Support for Free XPIDs.
-
-    This 'archive-legacy' store looks into the resource 'main' location not
-    into a potential stack.
-    """
-
-    #: Path to the vortex-free Store configuration file
-    _store_global_config = "@store-vortex-free.ini"
-    _datastore_id = "store-vortex-free-conf"
-
-    _footprint = dict(
-        info="VORTEX archive access for casual experiments",
-        attr=dict(
-            netloc=dict(
-                values=["vortex-free.archive-legacy.fr"],
-            ),
-        ),
-    )
-
-    def remap_read(self, remote, options):
-        """Reformulates the remote path to compatible vortex namespace."""
-        remote = copy.copy(remote)
-        xpath = remote["path"].strip("/").split("/")
-        f_xpid = FreeXPid(xpath[2])
-        xpath[2] = f_xpid.id
-        if "root" not in remote:
-            remote["root"] = self._actual_storeroot(f_xpid)
-        remote["path"] = self.system.path.join(*xpath)
-        return remote
-
-    remap_write = remap_read
-
-
-class VortexFreeStdStackedArchiveStore(VortexFreeStdBaseArchiveStore):
-    """Archive for casual VORTEX experiments: Support for Free XPIDs.
-
-    This 'stacked-archive-legacy' or 'stacked-archive-smart' store looks into
-    the stack associated to the resource. The '-smart' variant, has the ability
-    to refill the whole stack into local cache (to be faster in the future).
-    """
-
-    _footprint = [
-        _vortex_readonly_store,
-        dict(
-            attr=dict(
-                netloc=dict(
-                    values=[
-                        "vortex-free.stacked-archive-legacy.fr",
-                        "vortex-free.stacked-archive-smart.fr",
-                    ],
-                ),
-            )
-        ),
-    ]
-
-
 class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
     """Archive for op VORTEX experiments.
 

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -731,12 +731,13 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
         remote = copy.copy(remote)
         try:
             remote["root"] = config.from_config(
-                section="storage", key="rootdir",
+                section="storage",
+                key="rootdir",
             )
         except config.ConfigurationError as e:
             msg = (
                 "Trying to write to archive but location is not configured.\n"
-                "Make sure key \"rootdir\" is defined in storage section of "
+                'Make sure key "rootdir" is defined in storage section of '
                 "the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )
@@ -792,12 +793,13 @@ class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
         remote = copy.copy(remote)
         try:
             remote["root"] = config.from_config(
-                section="storage", key="op_rootdir",
+                section="storage",
+                key="op_rootdir",
             )
         except config.ConfigurationError as e:
             msg = (
                 "Trying to write to operational data archive but location"
-                "is not configured.\nMake sure key \"rootdir\" is defined in "
+                'is not configured.\nMake sure key "rootdir" is defined in '
                 "the storage section of the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -18,14 +18,12 @@ from vortex import config
 from vortex.data.abstractstores import (
     Store,
     ArchiveStore,
-    ConfigurableArchiveStore,
     CacheStore,
 )
 from vortex.data.abstractstores import MultiStore, PromiseStore
 from vortex.data.abstractstores import ARCHIVE_GET_INTENT_DEFAULT
 from vortex.layout import dataflow
 from vortex.syntax.stdattrs import hashalgo_avail_list
-from vortex.syntax.stdattrs import FreeXPid
 from vortex.syntax.stdattrs import DelayedEnvValue
 from vortex.tools.systems import ExecutionError
 


### PR DESCRIPTION
The current inheritance tree for archive stores is as follows:

![image](https://github.com/user-attachments/assets/7cdd3212-d163-481b-aef4-01f5b6f7c875)

The `remap_read` method is responsible for fixing the remote path according to the nature of the store:
- For a standard store, assume this is an OLive experiment name with 4 characters (e.g. `XP8D `) and split the exp name into 4 subdirectory (e.g. `X/P/8/D`).
- For a `VortexFreeStd` store, assume exp name follows the `xpname@user` pattern and fix the remote path accordingly.

This logic originates from tight coupling between Vortex and the OLIVE NWP configuration management application used at Météo-France.

This PR aims at breaking this coupling by making the `VortexStdBaseStore` handle the case where the experiment name is just an arbitrary string that correspond to a single directory on a file system. For instance data for a `vortex-exp` experiment would be stored at `/home/path/to/data/tree/vortex-exp` instead of `/home/path/to/data/tree/v/o/r/t/e/x-/e/x/p`.

The OLIVE specific logic is moved into  the vortex-olive plugin as a specific provider/store couple that performs the path splitting if the experiment name conforms to the OLIVE pattern (and the plugin is loaded). See [vortex-olive!1](http://gitlab.meteo.fr/cnrm-gmap/vortex-olive/-/merge_requests/1).

This means the `VortexFreeStdBaseArchiveStore` is not required anymore and the concept of "free experiment" is obsoleted.