### PR TITLE
Remove `Cache` objects inheritance tree

### DIFF
--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -20,6 +20,10 @@ VORTEX_CONFIG = {}
 logger = loggers.getLogger(__name__)
 
 
+class ConfigurationError(Exception):
+    """Something is wrong with the provided configuration"""
+
+
 def load_config(configpath="vortex.toml"):
     """Load configuration from a TOML configuration file
 
@@ -62,19 +66,18 @@ def from_config(section, key=None):
     try:
         subconfig = VORTEX_CONFIG[section]
     except KeyError as e:
-        print(f"Could not find section {section} in configuration")
-        raise (e)
-
+        raise ConfigurationError(
+            f"Missing configuration section {section}",
+        )
     if not key:
         return subconfig
 
     try:
         value = subconfig[key]
     except KeyError as e:
-        print(
-            f"Could not find key {key} in section {section} of configuration"
+        raise ConfigurationError(
+            f"Missing configuration key {key} in section {section}",
         )
-        raise (e)
     return value
 
 

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -108,5 +108,5 @@ def is_defined(section, key=None):
 def get_from_config_w_default(section, key, default):
     try:
         return from_config(section, key)
-    except KeyError:
+    except ConfigurationError:
         return default

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -65,7 +65,7 @@ def from_config(section, key=None):
     """
     try:
         subconfig = VORTEX_CONFIG[section]
-    except KeyError as e:
+    except KeyError:
         raise ConfigurationError(
             f"Missing configuration section {section}",
         )
@@ -74,7 +74,7 @@ def from_config(section, key=None):
 
     try:
         value = subconfig[key]
-    except KeyError as e:
+    except KeyError:
         raise ConfigurationError(
             f"Missing configuration key {key} in section {section}",
         )

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -862,8 +862,8 @@ class ArchiveStore(Store):
                 msg = (
                     "Trying to access storage archive but no "
                     "storage location configured.\n"
-                    "Make sure configuration section \"section\" and key "
-                    "\"address\" exist.\n"
+                    'Make sure configuration section "section" and key '
+                    '"address" exist.\n'
                     "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
                 )
                 logger.error(msg)

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -17,7 +17,7 @@ from bronx.system import hash as hashutils
 import footprints
 
 from vortex import sessions
-from vortex.config import from_config
+from vortex.config import from_config, ConfigurationError
 from vortex.util import config
 from vortex.syntax.stdattrs import (
     hashalgo,
@@ -852,11 +852,22 @@ class ArchiveStore(Store):
     def actual_storage(self):
         """This archive network name (potentially read form the configuration file)."""
         if self._actual_storage is None:
-            self._actual_storage = (
-                self.system.env.VORTEX_DEFAULT_STORAGE
-                or self.system.glove.default_fthost
-                or from_config(section="storage", key="address")
-            )
+            try:
+                self._actual_storage = (
+                    self.system.env.VORTEX_DEFAULT_STORAGE
+                    or self.system.glove.default_fthost
+                    or from_config(section="storage", key="address")
+                )
+            except ConfigurationError as e:
+                msg = (
+                    "Trying to access storage archive but no "
+                    "storage location configured.\n"
+                    "Make sure configuration section \"section\" and key "
+                    "\"address\" exist.\n"
+                    "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
+                )
+                logger.error(msg)
+                raise e
             if self._actual_storage is None:
                 raise ValueError("Unable to find the archive network name.")
         return self._actual_storage

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -1439,8 +1439,7 @@ class CacheStore(Store):
     def _get_cache(self):
         if not self._cache:
             self._cache = footprints.proxy.caches.default(
-                kind=self.underlying_cache_kind,
-                headdir=self.headdir,
+                location=self.location,
                 rtouch=self.rtouch,
                 rtouchskip=self.rtouchskip,
                 readonly=self.readonly,

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -1439,7 +1439,7 @@ class CacheStore(Store):
     def _get_cache(self):
         if not self._cache:
             self._cache = footprints.proxy.caches.default(
-                location=self.location,
+                entry=self.location,
                 rtouch=self.rtouch,
                 rtouchskip=self.rtouchskip,
                 readonly=self.readonly,

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -8,6 +8,7 @@ Store objects use the :mod:`footprints` mechanism.
 import copy
 import ftplib
 import io
+import os
 import re
 
 from bronx.fancies import loggers
@@ -989,6 +990,17 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
         ),
     )
 
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        try:
+            cachepath = config.from_config(
+                section="data-tree",
+                key="rootdir",
+            )
+        except KeyError:
+            cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
+        self.location = cachepath
+
 
 # TODO Not sure this class is needed anymore
 class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
@@ -1016,6 +1028,16 @@ class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
     def underlying_cache_kind(self):
         """The kind of cache that will be used."""
         return self.strategy
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        try:
+            cachepath = config.from_config(
+                section="data-tree",
+                key="op_rootdir",
+            )
+        except KeyError:
+            raise ValueError
+        self.location = os.path.join(cachepath, "vortex")
 
 
 class _AbstractVortexCacheMultiStore(MultiStore):

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -994,7 +994,7 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
                 section="data-tree",
                 key="rootdir",
             )
-        except KeyError:
+        except config.ConfigurationError:
             cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
         self.location = cachepath
 
@@ -1024,8 +1024,13 @@ class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
                 section="data-tree",
                 key="op_rootdir",
             )
-        except KeyError:
-            raise ValueError
+        except config.ConfigurationError as e:
+            logger.error(
+                "Cannot use special experiment cache without providing",
+                "cache location",
+            )
+            raise e
+
         self.location = os.path.join(cachepath, "vortex")
 
 

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -743,12 +743,13 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
         remote = copy.copy(remote)
         try:
             remote["root"] = config.from_config(
-                section="storage", key="rootdir",
+                section="storage",
+                key="rootdir",
             )
         except config.ConfigurationError as e:
             msg = (
                 "Trying to write to archive but location is not configured.\n"
-                "Make sure key \"rootdir\" is defined in storage section of "
+                'Make sure key "rootdir" is defined in storage section of '
                 "the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )
@@ -804,12 +805,13 @@ class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
         remote = copy.copy(remote)
         try:
             remote["root"] = config.from_config(
-                section="storage", key="op_rootdir",
+                section="storage",
+                key="op_rootdir",
             )
         except config.ConfigurationError as e:
             msg = (
                 "Trying to write to operational data archive but location"
-                "is not configured.\nMake sure key \"rootdir\" is defined in "
+                'is not configured.\nMake sure key "rootdir" is defined in '
                 "the storage section of the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -984,9 +984,6 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
                     for s in ("", "stacked-")
                 ]
             ),
-            strategy=dict(
-                default="mtool",
-            ),
         ),
     )
 
@@ -1002,7 +999,6 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
         self.location = cachepath
 
 
-# TODO Not sure this class is needed anymore
 class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
     """The DSI/OP VORTEX cache where researchers can get the freshest data."""
 
@@ -1015,19 +1011,12 @@ class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
                     for s in ("", "stacked-")
                 ],
             ),
-            strategy=dict(
-                default="op2r",
-            ),
             readonly=dict(
                 default=True,
             ),
         ),
     )
 
-    @property
-    def underlying_cache_kind(self):
-        """The kind of cache that will be used."""
-        return self.strategy
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         try:

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -36,6 +36,17 @@ __all__ = []
 logger = loggers.getLogger(__name__)
 
 
+def get_cache_location():
+    try:
+        cacheloc = config.from_config(
+            section="data-tree",
+            key="rootdir",
+        )
+    except config.ConfigurationError:
+        cacheloc = os.path.join(os.environ["HOME"], ".vortex.d")
+    return cacheloc
+
+
 class MagicPlace(Store):
     """Somewhere, over the rainbow!"""
 
@@ -989,14 +1000,7 @@ class VortexCacheMtStore(_VortexCacheBaseStore):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        try:
-            cachepath = config.from_config(
-                section="data-tree",
-                key="rootdir",
-            )
-        except config.ConfigurationError:
-            cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
-        self.location = cachepath
+        self.location = get_cache_location()
 
 
 class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -19,14 +19,12 @@ from vortex import config
 from vortex.data.abstractstores import (
     Store,
     ArchiveStore,
-    ConfigurableArchiveStore,
     CacheStore,
 )
 from vortex.data.abstractstores import MultiStore, PromiseStore
 from vortex.data.abstractstores import ARCHIVE_GET_INTENT_DEFAULT
 from vortex.layout import dataflow
 from vortex.syntax.stdattrs import hashalgo_avail_list
-from vortex.syntax.stdattrs import FreeXPid
 from vortex.syntax.stdattrs import DelayedEnvValue
 from vortex.tools.systems import ExecutionError
 

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -33,7 +33,6 @@ import ftplib
 import re
 import time
 from datetime import datetime
-import os
 
 import footprints
 from bronx.fancies import loggers

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -428,6 +428,8 @@ class Cache(Storage):
         fmt = kwargs.get("fmt", "foo")
         # Insert the element
         tpath = self._formatted_path(item)
+        if not self.sh.path.exists(self.entry):
+            self.sh.mkdit(self.entry)
         if tpath is not None:
             rc = self.sh.cp(
                 local,

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -304,10 +304,10 @@ class Cache(Storage):
     _footprint = dict(
         info="Default cache description",
         attr=dict(
-            headdir=dict(
-                info="The cache's subdirectory (within **rootdir**).",
-                optional=True,
-                default="cache",
+            location=dict(
+                optional=False,
+                type=str,
+                info="The absolute path to the cache space",
             ),
             # TODO is 'storage' used in any way?
             storage=dict(

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -115,10 +115,6 @@ class Storage(footprints.FootprintBase):
     _footprint = dict(
         info="Default/Abstract storage place description.",
         attr=dict(
-            kind=dict(
-                info="The storage place's kind.",
-                values=["std"],
-            ),
             storage=dict(
                 info="The storage target.",
             ),
@@ -400,7 +396,7 @@ class Cache(Storage):
     def _actual_prestageinfo(self, item, **kwargs):
         """Returns pre-staging informations."""
         return dict(
-            strategy=self.kind, location=self.fullpath(item, **kwargs)
+            strategy="std", location=self.fullpath(item, **kwargs)
         ), dict()
 
     def _actual_check(self, item, **kwargs):
@@ -557,7 +553,7 @@ class AbstractArchive(Storage):
     @property
     def tag(self):
         """The identifier of this cache place."""
-        return "{:s}_{:s}_{:s}".format(self.realkind, self.storage, self.kind)
+        return "{:s}_{:s}".format(self.realkind, self.storage)
 
     @property
     def realkind(self):

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -304,7 +304,7 @@ class Cache(Storage):
     _footprint = dict(
         info="Default cache description",
         attr=dict(
-            location=dict(
+            entry=dict(
                 optional=False,
                 type=str,
                 info="The absolute path to the cache space",

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -1851,7 +1851,8 @@ class OSExtended(System):
             return self._ftspool_cache
         self._ftspool_cache = footprints.proxy.cache(
             entry=os.path.join(
-                vortex.data.stores.get_cache_location(), "ftspool"),
+                vortex.data.stores.get_cache_location(), "ftspool"
+            ),
         )
         return self._ftspool_cache
 

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -1846,8 +1846,17 @@ class OSExtended(System):
 
     def ftspool_cache(self):
         """Return a cache object for the FtSpool."""
-        if self._ftspool_cache is None:
-            self._ftspool_cache = footprints.proxy.cache(kind="ftstash")
+        if self._ftspool_cache is not None:
+            return self._ftspool_cache
+        try:
+            cachepath = config.from_config(
+                section="data-tree",
+                key="rootdir",
+            )
+        except KeyError:
+            cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
+        location = os.path.join(cachepath, "ftspool")
+        self._ftspool_cache = footprints.proxy.cache(location=location)
         return self._ftspool_cache
 
     def copy2ftspool(self, source, nest=False, **kwargs):

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -67,6 +67,7 @@ from vortex.tools.compression import CompressionPipeline
 from vortex.tools.env import Environment
 from vortex.tools.net import AssistedSsh, AutoRetriesFtp, DEFAULT_FTP_PORT
 from vortex.tools.net import FtpConnectionPool, LinuxNetstats, StdFtp
+import vortex.tools.storage
 
 #: No automatic export
 __all__ = []
@@ -1848,15 +1849,10 @@ class OSExtended(System):
         """Return a cache object for the FtSpool."""
         if self._ftspool_cache is not None:
             return self._ftspool_cache
-        try:
-            cachepath = config.from_config(
-                section="data-tree",
-                key="rootdir",
-            )
-        except config.ConfigurationError as e:
-            cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
-        location = os.path.join(cachepath, "ftspool")
-        self._ftspool_cache = footprints.proxy.cache(entry=location)
+        self._ftspool_cache = footprints.proxy.cache(
+            entry=os.path.join(
+                vortex.data.stores.get_cache_location(), "ftspool"),
+        )
         return self._ftspool_cache
 
     def copy2ftspool(self, source, nest=False, **kwargs):

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -1856,7 +1856,7 @@ class OSExtended(System):
         except config.ConfigurationError as e:
             cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
         location = os.path.join(cachepath, "ftspool")
-        self._ftspool_cache = footprints.proxy.cache(location=location)
+        self._ftspool_cache = footprints.proxy.cache(entry=location)
         return self._ftspool_cache
 
     def copy2ftspool(self, source, nest=False, **kwargs):

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -1853,7 +1853,7 @@ class OSExtended(System):
                 section="data-tree",
                 key="rootdir",
             )
-        except KeyError:
+        except config.ConfigurationError as e:
             cachepath = os.path.join(os.environ["HOME"], ".vortex.d")
         location = os.path.join(cachepath, "ftspool")
         self._ftspool_cache = footprints.proxy.cache(location=location)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ config.VORTEX_CONFIG = {
 }
 
 def test_section_from_config():
-    with pytest.raises(KeyError):
+    with pytest.raises(config.ConfigurationError):
         config_section = config.from_config("nonexist")
 
     config_section = config.from_config("data-tree")
@@ -23,7 +23,7 @@ def test_section_from_config():
 
 
 def test_key_from_config():
-    with pytest.raises(KeyError):
+    with pytest.raises(config.ConfigurationError):
         config_value = config.from_config("data-tree", "nonexist")
 
     config_value = config.from_config("data-tree", "rootdir")


### PR DESCRIPTION
The current inheritance tree for cache storage is as follows:

![image](https://github.com/user-attachments/assets/022d7f43-d4ce-4e91-ad63-30d28c097f8c)

The sole purpose of the four concrete classes is to define an `entry` property attribute that evaluates to the root directory of the cache location for a particular type of cache.

This PR makes the originally abstract `tools.storage.Cache` class concrete and the only cache type. The cache location is set as a `location` footprint attribute. It is up to the code that instantiates the cache (cache stores) to specify the cache location.

In practice:

- Concrete cache classes (e.g. `MtoolCache`, `OpResearchCache`...) are removed
- `FixedEntryCache` is merged into its parent `Cache` which becomes concrete
- New footprint attribute `location` for `Cache`
- Concrete cache stores set a `location` attribute they pass to footprints when instantiating a cache object.