### PR TITLE
Defer reading email configuration to `TemplatedMail` child classes

### DIFF
--- a/src/vortex/tools/actions.py
+++ b/src/vortex/tools/actions.py
@@ -259,17 +259,14 @@ class TemplatedMail(TunableAction):
 
     def __init__(
         self,
+        catalog,
         kind="templatedmail",
         service="templatedmail",
         active=True,
-        catalog=None,
         inputs_charset=None,
     ):
         super().__init__(
             configuration=None, kind=kind, active=active, service=service
-        )
-        self.catalog = catalog or GenericConfigParser(
-            "@{:s}-inventory.ini".format(kind), encoding=inputs_charset
         )
         self.inputs_charset = inputs_charset
 

--- a/src/vortex/tools/actions.py
+++ b/src/vortex/tools/actions.py
@@ -12,7 +12,6 @@ import footprints
 from bronx.fancies import loggers
 from bronx.fancies.display import dict_as_str
 from vortex import sessions
-from vortex.util.config import GenericConfigParser
 
 #: Export nothing
 __all__ = []

--- a/src/vortex/tools/services.py
+++ b/src/vortex/tools/services.py
@@ -5,7 +5,7 @@ With the abstract class Service (inheritating from FootprintBase)
 a default Mail Service is provided.
 """
 
-from configparser import NoOptionError, NoSectionError
+import configparser
 import contextlib
 import hashlib
 import pprint
@@ -566,7 +566,7 @@ class Directory:
         config = GenericConfigParser(inifile, encoding=encoding)
         try:
             self.domain = config.get("general", "default_domain")
-        except NoOptionError:
+        except configparser.NoOptionError:
             self.domain = domain
         self.aliases = {
             k.lower(): set(v.lower().replace(",", " ").split())
@@ -699,7 +699,7 @@ class TemplatedMailService(MailService):
                 default=None,
             ),
             catalog=dict(
-                type=GenericConfigParser,
+                type=configparser.ConfigParser,
             ),
             dryrun=dict(
                 info="Do not actually send the email. Just render the template.",
@@ -734,11 +734,10 @@ class TemplatedMailService(MailService):
         """Read section <id> (a dict-like) from the catalog."""
         try:
             section = dict(self.catalog.items(self.id))
-        except NoSectionError:
+        except configparser.NoSectionError:
             logger.error(
-                "Section <%s> is missing in catalog <%s>",
+                "Section <%s> is missing in catalog",
                 self.id,
-                self.catalog.file,
             )
             section = None
         return section


### PR DESCRIPTION
Currently `vortex.tools.actions.TemplatedMail` reads email configuration files from its `__init__` function. This assumes email config files are shipped with the code. 

This assumes instead that the configuration was processed upstream, and the `TemplatedMail` only gets a `catalog` dict-like `configparser.ConfigParser`. This means it is up to vortex plugins (e.g. olive, cen) to read the relevant config (and maybe ship it).
See http://gitlab.meteo.fr/cnrm-gmap/vortex-olive/-/merge_requests/2 for the corresponding change for `vortex_olive`.