### PR TITLE
Let callers of `load_template` specify where the template lives

### DIFF
--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -70,6 +70,7 @@ Note: Namelists and environment changes are orchestrated as follows:
 
 import collections
 import collections.abc
+import importlib
 import itertools
 import locale
 import re
@@ -699,9 +700,11 @@ class MpiTool(footprints.FootprintBase):
         if not self.mpiwrapstd:
             return None
         # Create the launchwrapper
-        wtpl = config.load_template(
-            self.ticket, self._wrapstd_wrapper_tpl, encoding="utf-8"
-        )
+        with importlib.resources.as_file(
+            importlib.resources.files("vortex.algo")
+        ) as path:
+            tplpath = path / "mpitools_templates" / self._wrapstd_wrapper_tpl
+        wtpl = config.load_template(tplpath, encoding="utf-8")
         with open(self._wrapstd_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
                 wtpl.substitute(
@@ -908,9 +911,11 @@ class MpiTool(footprints.FootprintBase):
             "Here are the envelope details:\n%s", "\n".join(binding_str)
         )
         # Create the launchwrapper
-        wtpl = config.load_template(
-            self.ticket, self._envelope_wrapper_tpl, encoding="utf-8"
-        )
+        with importlib.resources.as_file(
+            importlib.resources.files("vortex.algo")
+        ) as path:
+            tplpath = path / "mpitools_templates" / self._envelope_wrapper_tpl
+        wtpl = config.load_template(tplpath, encoding="utf-8")
         with open(self._envelope_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
                 wtpl.substitute(

--- a/src/vortex/util/config.py
+++ b/src/vortex/util/config.py
@@ -240,35 +240,7 @@ def load_template(
                 "Template file not found: <{}>".format(tplfile)
             )
         return t.sh.path.abspath(tplfile)
-
     searchdirs = (persodir, pkgdir, sitedir)
-    if version:
-        autofile = autofile.group(2)
-        autodir = t.sh.path.dirname(autofile)
-        if autodir:
-            persodir = t.sh.path.join(persodir, autodir)
-            sitedir = t.sh.path.join(sitedir, sitedir)
-            autofile = t.sh.path.basename(autofile)
-        allowedre = re.compile(autofile + r"-v(\d+).tpl")
-        alloweditems = dict()
-        for inputdir in (sitedir, persodir):
-            if not t.sh.path.exists(inputdir):
-                continue
-            for fs_item in t.sh.listdir(inputdir):
-                fs_match = allowedre.match(fs_item)
-                if fs_match:
-                    alloweditems[int(fs_match.group(1))] = t.sh.path.join(
-                        inputdir, fs_item
-                    )
-        for item_version in sorted(alloweditems.keys(), reverse=True):
-            if (item_version <= version) and alloweditems[item_version]:
-                return alloweditems[item_version]
-        raise ValueError(
-            "Template file not found: <{}> with version >= {!s}.".format(
-                tplfile, version
-            )
-        )
-    # Happy path: autofile and no version specification
     autofile = autofile.group(1)
     for dirname in searchdirs:
         filename = t.sh.path.join(dirname, autofile)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from vortex.util.config import load_template
+
+TEST_TPL_DIR = Path(__file__).parent.absolute() / "test_templates"
+
+
+def test_load_template():
+    with pytest.raises(FileNotFoundError):
+        tpl = load_template(tplpath=Path("/a/b/c/d"))
+
+    tplpath = TEST_TPL_DIR / "test.tpl"
+    tpl = load_template(
+        tplpath=tplpath,
+        encoding=None,
+        default_templating="legacy",
+    )
+    assert tpl.srcfile == str(tplpath)
+
+
+def test_load_template_encoding():
+    tplpath = TEST_TPL_DIR / "test_with_encoding.tpl"
+    tpl = load_template(
+        tplpath=tplpath,
+        encoding="script",
+        default_templating="legacy",
+    )
+    assert tpl.srcfile == str(tplpath)
+
+
+def test_load_jinja2_template():
+    tplpath = TEST_TPL_DIR / "test_jinja2.tpl"
+    tpl = load_template(
+        tplpath=tplpath,
+        encoding=None,
+        default_templating="jinja2",
+    )
+    assert tpl.srcfile == str(tplpath)

--- a/tests/test_templates/test.tpl
+++ b/tests/test_templates/test.tpl
@@ -1,0 +1,1 @@
+This $verb a $what

--- a/tests/test_templates/test_jinja2.tpl
+++ b/tests/test_templates/test_jinja2.tpl
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Members{% endblock %}
+{% block content %}
+  <ul>
+  {% for user in users %}
+    <li><a href="{{ user.url }}">{{ user.username }}</a></li>
+  {% endfor %}
+  </ul>
+{% endblock %}

--- a/tests/test_templates/test_with_encoding.tpl
+++ b/tests/test_templates/test_with_encoding.tpl
@@ -1,0 +1,2 @@
+# encoding: ascii
+This $verb a $what


### PR DESCRIPTION
The `util.config.load_template` function currently can take as an argument:

1. The absolute path to a template file
2. A string prefix by '@' to enable overriding the default template (supposed to be located in the `template` directory at the root of the vortex source tree) with a user template located in `~/.vortexrc`.

This simplifies the implementation of `util.config.load_template`, removing case (2). It is now up to callers to call `load_template` with the absolute path of the target template. This change was taken into account for calls to `load_template` occurring in `vortex.algo.mpitools`, but not others. This is left to further work.

The implementation of `Jinja2TemplatingAdapter._rendering_tool_init` was also simplified, working with the template path as a `pathlib.Path` object, instead of having to pass a template directory (`searchdirs`) around.