### PR TITLE
Release `2.0.0b2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vortex-nwp"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = "A Python library to write Numerical Weather Prediction pipelines components"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -42,10 +42,10 @@ from .toolbox import algo as task
 
 from . import nwp as nwp  # footprints import
 
-__version__ = "2.0.0b1"
+__version__ = "2.0.0b2"
 __prompt__ = "Vortex v-" + __version__ + ":"
 
-__nextversion__ = "2.0.0b2"
+__nextversion__ = "2.0.0b3"
 __tocinfoline__ = "VORTEX core package"
 
 __all__ = [


### PR DESCRIPTION
sources:
- Lint and format Python source code with ruff

docs:
- Setup ReadTheDocs integration (7a2f205d, ee13a0b8 and ee5b55ec)
- Add a section on writing plugin packages (d0f1dcfa)

Data management:
- Remove assumption that standard store is working with data from an OLIVE experiment (#4)
- Remove inheritance tree for cache classes, by making cache entryxo
  point location an attribute of `storage.Cache`. (#5)
- Move `abstractstores.ConfigurableArchiveStore` to vortex-gco plugin (#6)

Communications
- Assume email configuration is shipped with plugins. Delegate reading
  it to modules calling `actions.TemplatedMail`. (#7)

Configuration:
- Remove looking for templates in user's `.vortexrc` directory. (#8)

Repo:
- Setup minimal ci workflow (2b71da64)
- Setup automatic publishing to PyPI on GitHub release (#9)