### PR TITLE
Don't assume structure of namespace for cache store

### DIFF
--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -1213,13 +1213,7 @@ class VortexStackStore(_AbstractVortexStackMultiStore):
 
     def alternates_netloc(self):
         """Go through the various stacked stores."""
-        netloc_m = re.match(
-            r"(?P<base>vortex.*)\.stack\.(?P<country>\w+)", self.netloc
-        )
-        s_mt_netloc = "{base:s}.stacked-cache-mt.{country:s}".format(
-            **netloc_m.groupdict()
-        )
-        return [s_mt_netloc]
+        return [f"{self.netloc.firstname}.stacked-cache-mt.fr"]
 
 
 class VortexVsopStackStore(_AbstractVortexStackMultiStore):

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -1105,16 +1105,10 @@ class VortexCacheStore(_AbstractVortexCacheMultiStore):
 
     def alternates_netloc(self):
         """For Non-Op users, Op caches may be accessed in read-only mode."""
-        netloc_m = re.match(
-            r"(?P<base>vortex.*)\.cache\.(?P<country>\w+)", self.netloc
-        )
-        mt_netloc = "{base:s}.cache-mt.{country:s}".format(
-            **netloc_m.groupdict()
-        )
-        s_mt_netloc = "{base:s}.stacked-cache-mt.{country:s}".format(
-            **netloc_m.groupdict()
-        )
-        return [mt_netloc, s_mt_netloc]
+        return [
+            f"{self.netloc.firstname}.cache-mt.fr",
+            f"{self.netloc.firstname}.stacked-cache-mt.fr",
+        ]
 
 
 class VortexVsopCacheStore(_AbstractVortexCacheMultiStore):


### PR DESCRIPTION
Currently the `VortexCacheStore.alternate_netloc` and `VortexStackStore.alternate_netloc` methods assume that the cache store namespaces will match the following pattern
```
(?P<base>vortex.*)\.cache\.(?P<country>\w+)
```

This removes this constraints in order to enable namespaces based on the `olive-exp` prefix. See [vortex-olive!3](http://gitlab.meteo.fr/cnrm-gmap/vortex-olive/-/merge_requests/3). 

In addition, the namespace suffix is always `.fr`.