### PR TITLE
Remove `@` suffix in front of some template names

### DIFF
--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -182,8 +182,8 @@ class MpiTool(footprints.FootprintBase):
     )
 
     _envelope_bit_kind = "basicenvelopebit"
-    _envelope_wrapper_tpl = "@envelope_wrapper_default.tpl"
-    _wrapstd_wrapper_tpl = "@wrapstd_wrapper_default.tpl"
+    _envelope_wrapper_tpl = "envelope_wrapper_default.tpl"
+    _wrapstd_wrapper_tpl = "wrapstd_wrapper_default.tpl"
     _envelope_wrapper_name = "./global_envelope_wrapper.py"
     _wrapstd_wrapper_name = "./global_wrapstd_wrapper.py"
     _envelope_rank_var = "MPIRANK"

--- a/src/vortex/nwp/algo/mpitools.py
+++ b/src/vortex/nwp/algo/mpitools.py
@@ -72,7 +72,7 @@ class MpiAuto(mpitools.MpiTool):
         )
     )
 
-    _envelope_wrapper_tpl = "@envelope_wrapper_mpiauto.tpl"
+    _envelope_wrapper_tpl = "envelope_wrapper_mpiauto.tpl"
     _envelope_rank_var = "MPIAUTORANK"
     _needs_mpilib_specific_mpienv = False
 

--- a/src/vortex/util/config.py
+++ b/src/vortex/util/config.py
@@ -164,7 +164,8 @@ def load_template(tplpath, encoding=None, default_templating="legacy"):
     """
     tplpath = Path(tplpath).absolute()
     if not tplpath.exists():
-        raise FileNotFoundError
+        msg = f"Template file {tplpath} not found"
+        raise FileNotFoundError(msg)
     ignored_lines = set()
     actual_encoding = None if encoding == "script" else encoding
     actual_templating = default_templating


### PR DESCRIPTION
Since #8 , template file names should not be prefixed by `@`. Otherwise `util.config.load_template` will not be able to find the template file.

In addition, print template path when the template is not found, instead of just raising an empty `FileNotFoundError`.