### PR TITLE
Set MPI tool's `bindingmethod` depending on whether or not executable is linked against MPL

### DIFF
--- a/src/vortex/algo/components.py
+++ b/src/vortex/algo/components.py
@@ -1850,7 +1850,7 @@ class Parallel(xExecutableAlgoComponent):
         possible_attrs = functools.reduce(
             lambda s, t: s | t,
             [
-                set(cls._footprint.attr.keys())
+                set(cls.footprint_retrieve().attr.keys())
                 for cls in footprints.proxy.mpitools
             ],
         )

--- a/src/vortex/nwp/algo/ifsroot.py
+++ b/src/vortex/nwp/algo/ifsroot.py
@@ -120,6 +120,10 @@ class IFSParallel(
         """Extend default tag with ``kind`` value."""
         return super().fstag() + "." + self.kind
 
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
+
     def valid_executable(self, rh):
         """Be sure that the specifed executable is ifsmodel compatible."""
         valid = super().valid_executable(rh)

--- a/src/vortex/nwp/algo/monitoring.py
+++ b/src/vortex/nwp/algo/monitoring.py
@@ -57,6 +57,10 @@ class OdbMonitoring(
         )
     )
 
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
+
     def _fix_nam_macro(self, rh, macro, value):
         """Set a given namelist macro and issue a log message."""
         rh.contents.setmacro(macro, value)

--- a/src/vortex/nwp/algo/mpitools.py
+++ b/src/vortex/nwp/algo/mpitools.py
@@ -62,6 +62,13 @@ class MpiAuto(mpitools.MpiTool):
                     False,
                 ],
             ),
+            bindingmethod=dict(
+                info="How to bind the MPI processes",
+                values=["vortex", "arch", "launcherspecific"],
+                optional=True,
+                doc_visibility=footprints.doc.visibility.ADVANCED,
+                doc_zorder=-90,
+            ),
             mplbased=dict(
                 info="Is the executable based on MPL?",
                 type=bool,

--- a/src/vortex/nwp/algo/mpitools.py
+++ b/src/vortex/nwp/algo/mpitools.py
@@ -62,12 +62,11 @@ class MpiAuto(mpitools.MpiTool):
                     False,
                 ],
             ),
-            bindingmethod=dict(
-                info="How to bind the MPI processes",
-                values=["arch", "launcherspecific", "vortex"],
+            mplbased=dict(
+                info="Is the executable based on MPL?",
+                type=bool,
                 optional=True,
-                doc_visibility=footprints.doc.visibility.ADVANCED,
-                doc_zorder=-90,
+                default=False,
             ),
         )
     )
@@ -75,6 +74,10 @@ class MpiAuto(mpitools.MpiTool):
     _envelope_wrapper_tpl = "envelope_wrapper_mpiauto.tpl"
     _envelope_rank_var = "MPIAUTORANK"
     _needs_mpilib_specific_mpienv = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bindingmethod = "arch" if self.mplbased else "vortex"
 
     def _reshaped_mpiopts(self):
         """Raw list of mpi tool command line options."""

--- a/src/vortex/nwp/algo/odbtools.py
+++ b/src/vortex/nwp/algo/odbtools.py
@@ -850,6 +850,10 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         )
     )
 
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
+
     def prepare(self, rh, opts):
         """Find any ODB candidate in input files."""
 
@@ -962,6 +966,10 @@ class OdbCompress(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
         )
     )
 
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
+
     def prepare(self, rh, opts):
         """Find any ODB candidate in input files and fox ODB env accordingly."""
 
@@ -1026,6 +1034,10 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
             ),
         )
     )
+
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
 
     def prepare(self, rh, opts):
         """Find ODB candidates in input files."""
@@ -1115,6 +1127,10 @@ class OdbReshuffle(
 
     _OUT_DIRECTORY = "reshuffled"
     _BARE_OUT_LAYOUT = "ccma"
+
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        return conf_dict | {"mplbased": True}
 
     def prepare(self, rh, opts):
         """Find ODB candidates in input files."""


### PR DESCRIPTION
In Vortex 1.x, some algo components have an attribute `mpiconflabel`. The following classes have the `mpiconflabel` attribute set to `mplbased`(*):

- `common.algo.ifsroot.IFSParallel`
- `common.algo.monitoring.OdbMonitoring`
- `common.algo.odbtools.OdbAverage`
- `common.algo.odbtools.OdbCompress`
- `common.algo.odbtools.OdbMatchup`
- `common.algo.odbtools.OdbReshuffle`
- `common.algo.oopsroot.OOPSParallel`

The value of this attribute determines the value of the `bindindmethod` attribute for the `MpiTool` instance, through configuration files. At the end of the day, it boils down to `bindingmethod="arch"` if `mpiconflabel == "mplbased"`, and `bindingmethod="vortex"` otherwise.

The `mplbased` attribute and the associated logic all the way down to `MpiTool` had been removed from vortex 2. It however required for the above algo component classes to run correctly.

This MR reintroduces the `bindingmethod` attribute for `MpiTool`. However, the `mplbased` attribute is moved from the algo component classes to the `MpiTool` class, and its value is set by the relevant classes by redefining the `_mpitools_attributes` method.

(*) Looking into the vortex 1 repo, it seems like the only other value for `mpiconflabel` is `"mocage"`.