### PR TITLE
Drop Python version compatibility from 3.10 to 3.7

### DIFF
--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -21,7 +21,14 @@ strongly advised.
 """
 
 import atexit
-import importlib.metadata
+# importlib.metadata included in stdlib from 3.8 onwards.
+# For older versions, import third-party importlib_metadata
+if sys.version_info < (3, 8):
+    import importlib_metadata
+    import importlib
+    importlib.metadata = importlib_metadata
+else:
+    import importlib.metadata
 
 from bronx.fancies import loggers as bloggers
 import bronx.stdtypes.date

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -21,6 +21,7 @@ strongly advised.
 """
 
 import atexit
+import sys
 # importlib.metadata included in stdlib from 3.8 onwards.
 # For older versions, import third-party importlib_metadata
 if sys.version_info < (3, 8):

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -22,11 +22,13 @@ strongly advised.
 
 import atexit
 import sys
+
 # importlib.metadata included in stdlib from 3.8 onwards.
 # For older versions, import third-party importlib_metadata
 if sys.version_info < (3, 8):
     import importlib_metadata
     import importlib
+
     importlib.metadata = importlib_metadata
 else:
     import importlib.metadata

--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -700,11 +700,11 @@ class MpiTool(footprints.FootprintBase):
         if not self.mpiwrapstd:
             return None
         # Create the launchwrapper
-        with importlib.resources.as_file(
-            importlib.resources.files("vortex.algo")
-        ) as path:
-            tplpath = path / "mpitools_templates" / self._wrapstd_wrapper_tpl
-        wtpl = config.load_template(tplpath, encoding="utf-8")
+        with importlib.resources.path(
+            "vortex.algo.mpitools_templates",
+            self._wrapstd_wrapper_tpl,
+        ) as tplpath:
+            wtpl = config.load_template(tplpath, encoding="utf-8")
         with open(self._wrapstd_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
                 wtpl.substitute(
@@ -911,11 +911,11 @@ class MpiTool(footprints.FootprintBase):
             "Here are the envelope details:\n%s", "\n".join(binding_str)
         )
         # Create the launchwrapper
-        with importlib.resources.as_file(
-            importlib.resources.files("vortex.algo")
-        ) as path:
-            tplpath = path / "mpitools_templates" / self._envelope_wrapper_tpl
-        wtpl = config.load_template(tplpath, encoding="utf-8")
+        with importlib.resources.path(
+            "vortex.algo.mpitools_templates",
+            self._envelope_wrapper_tpl,
+        ) as tplpath:
+            wtpl = config.load_template(tplpath, encoding="utf-8")
         with open(self._envelope_wrapper_name, "w", encoding="utf-8") as fhw:
             fhw.write(
                 wtpl.substitute(

--- a/src/vortex/algo/mpitools_templates/__init__.py
+++ b/src/vortex/algo/mpitools_templates/__init__.py
@@ -1,0 +1,1 @@
+# Empty init file

--- a/src/vortex/nwp/algo/ifsroot.py
+++ b/src/vortex/nwp/algo/ifsroot.py
@@ -122,7 +122,8 @@ class IFSParallel(
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def valid_executable(self, rh):
         """Be sure that the specifed executable is ifsmodel compatible."""

--- a/src/vortex/nwp/algo/monitoring.py
+++ b/src/vortex/nwp/algo/monitoring.py
@@ -59,7 +59,8 @@ class OdbMonitoring(
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def _fix_nam_macro(self, rh, macro, value):
         """Set a given namelist macro and issue a log message."""

--- a/src/vortex/nwp/algo/odbtools.py
+++ b/src/vortex/nwp/algo/odbtools.py
@@ -852,7 +852,8 @@ class OdbAverage(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def prepare(self, rh, opts):
         """Find any ODB candidate in input files."""
@@ -968,7 +969,8 @@ class OdbCompress(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def prepare(self, rh, opts):
         """Find any ODB candidate in input files and fox ODB env accordingly."""
@@ -1037,7 +1039,8 @@ class OdbMatchup(Parallel, odb.OdbComponentDecoMixin, drhook.DrHookDecoMixin):
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def prepare(self, rh, opts):
         """Find ODB candidates in input files."""
@@ -1130,7 +1133,8 @@ class OdbReshuffle(
 
     def _mpitool_attributes(self, opts):
         conf_dict = super()._mpitool_attributes(opts)
-        return conf_dict | {"mplbased": True}
+        conf_dict.update({"mplbased": True})
+        return conf_dict
 
     def prepare(self, rh, opts):
         """Find ODB candidates in input files."""

--- a/src/vortex/nwp/algo/oopsroot.py
+++ b/src/vortex/nwp/algo/oopsroot.py
@@ -619,6 +619,11 @@ class OOPSParallel(
             logger.error("The binary < %s > has no cycle attribute", repr(rh))
             return False
 
+    def _mpitool_attributes(self, opts):
+        conf_dict = super()._mpitool_attributes(opts)
+        conf_dict.update({"mplbased": True})
+        return conf_dict
+
     def prepare(self, rh, opts):
         """Preliminary setups."""
         super().prepare(rh, opts)


### PR DESCRIPTION
In response to a bug in the latest Epygram, I set up a Python environment able to work with the default epygram version used by Olive. Python version is 3.7.

- Work with `importlib_metadata` backport if version < 3.8 ([docs](https://importlib-metadata.readthedocs.io/en/latest/))
- Use `importlib.resources.path` instead of `as_file` which is not defined yet in Python 3.7. This means making directories containing package data (e.g. `mpitools_templates`) empty packages for `importlib.resources` to find the package data path.
- Use `dict.update` instead of `|` operator.

At the time this MR is written, the bug in Epygram is fixed, see https://github.com/ACCORD-NWP/FALFILFA/pull/14