### PR TITLE
Fix path wrangling when writing to standard archive store

### DIFF
--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -527,6 +527,10 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
         """Remap actual remote path to distant store path for intrusive actions."""
         raise NotImplementedError
 
+    def remap_write(self, remote, options):
+        """Remap actual remote path to distant store path for intrusive actions."""
+        raise NotImplementedError
+
     def remap_list(self, remote, options):
         """Reformulates the remote path to compatible vortex namespace."""
         if len(remote["path"].split("/")) >= 4:

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -537,8 +537,6 @@ class _VortexBaseArchiveStore(ArchiveStore, _VortexStackedStorageMixin):
             )
             return None
 
-    remap_write = remap_read
-
     @property
     def stacks_autorefill(self):
         """Where to refill a stack retrieved from the archive."""
@@ -754,6 +752,8 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
             logger.error(msg)
             raise e
         return remote
+
+    remap_write = remap_read
 
 
 class VortexStdStackedArchiveStore(VortexStdBaseArchiveStore):


### PR DESCRIPTION
The `remap_read` (`remap_write`) methods defined on the archive stores are responsible for tweaking the resource's path before getting (putting) the corresponding file from the archive.

In #4 the responsibility of providing an implementation for `remap_read` and `remap_write` was pushed down to concrete archive stores: the standard archive store (`VortexStdBaseArchiveStore`) and the operations archive store (`VortexOpBaseArchiveStore`). 
Currently, the implementation of `VortexStdBaseArchiveStore` does not redefine `remap_write` and therefore inherits it from the parent `_VortexBaseArchiveStore`, which sets it the the unimplemented `remap_read`.

This fixes this, plus add an empty `remap_write` on the parent class for consistency.

Fixes http://gitlab.meteo.fr/cnrm-gmap/vortex-nwp/-/issues/8