### PR TITLE
Look for config in `.vortex.d` if non present in current working dir

### DIFF
--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -112,10 +112,10 @@ ticket = sessions.get
 sh = sessions.system
 
 # If a config file can be found in current dir, load it else load .vortex.d/vortex.toml
-if os.path.isfile('vortex.toml'):
-    config.load_config('vortex.toml') 
+if os.path.isfile("vortex.toml"):
+    config.load_config("vortex.toml")
 else:
-    config.load_config(os.environ['HOME']+'/.vortex.d/vortex.toml')
+    config.load_config(os.environ["HOME"] + "/.vortex.d/vortex.toml")
 
 # Load some superstars sub-packages
 

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -22,6 +22,7 @@ strongly advised.
 
 import atexit
 import sys
+import os
 
 # importlib.metadata included in stdlib from 3.8 onwards.
 # For older versions, import third-party importlib_metadata
@@ -110,8 +111,11 @@ footprints.setup.callback = vortexfpdefaults
 ticket = sessions.get
 sh = sessions.system
 
-# If a config file can be found in current dir, load it
-config.load_config()
+# If a config file can be found in current dir, load it else load .vortex.d/vortex.toml
+if os.path.isfile('vortex.toml'):
+    config.load_config('vortex.toml') 
+else:
+    config.load_config(os.environ['HOME']+'/.vortex.d/vortex.toml')
 
 # Load some superstars sub-packages
 


### PR DESCRIPTION
Currently the configuration file is only looked in the current directory.

According to the documentation, vortex should first check in the current working directory, then in `$HOME/.vortex.d/vortex.toml`.