### PR TITLE
Make Report action inherit from Action instead of TunableAction

### DIFF
--- a/src/vortex/tools/actions.py
+++ b/src/vortex/tools/actions.py
@@ -293,7 +293,7 @@ class TemplatedMail(TunableAction):
         return rc
 
 
-class Report(TunableAction):
+class Report(Action):
     """
     Class responsible for sending reports.
     """


### PR DESCRIPTION
At the moment I can't find any code that makes use of the fact that `Report' is a subclass of `TunableAction'. 

Moreover the `service_info` method relies on the existence of a configuration file, which breaks now that configurations are not distributed along with the package. I can't really find any configuration related to "report" in the vortex 1 configuration files `(vortex/conf` directory)