### PR TITLE
Explicit SSH configuration

### DIFF
--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -207,3 +207,67 @@ correspond to the value to give the environment variable.
 .. attention::
 
    All values are **strings**.
+
+``ssh``
+^^^^^^^
+
+Some operations carried out by vortex require establishing a SSH
+connection with a remote machine. A common example is sending a
+request to a remote server from a compute node without network
+access. In such a case the request would be sent from another machine,
+through SSH.
+
+``sshcmd``
+
+Name of the SSH client executable.
+
+**Type**: string
+
+**Default value**: ``ssh``
+
+``scp``
+
+Name of the SSH copy client executable.
+
+**Type**: string
+
+**Default value**: ``scp``
+
+``sshopts``
+
+Options to pass the SSH client executable
+
+**Type**: string
+
+**Default value**: ``""`` (empty string)
+
+``scpopts``
+
+Options to pass the SSH copy client executable
+
+**Type**: string
+
+**Default value**: ``""`` (empty string)
+
+Value for the above configuration options can be set for specific
+machine by specifying the configuration key as the option name
+(e.g. ``sshopts``) followed by a regular expression matching the
+machine's hostname, separated by a dot. When specifying options for
+one or more hostname pattern, a defaut configuration value *must* be
+declared using the ``default`` keyword (e.g. ``sshopts.default``).
+
+.. topic:: Example
+
+   .. code:: toml
+
+      [ssh]
+      sshcmd = "/usr/bin/ssh"
+      scpcmd = "/usr/bin/scp"
+      sshopts.default = "-x -o NoHostAuthenticationForLocalhost=true -o PasswordAuthentication=false -o ConnectTimeout=6"
+      sshopts."sotrtm\\d\\d-sidev" = "-x -o PasswordAuthentication=false"
+
+.. attention::
+
+   According to the `TOML specification
+   <https://toml.io/en/v1.0.0#string>`_ , special characters used in
+   regular expressions, such as backslashes, must be escaped.

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import vortex
+from vortex.tools.net import Ssh
+
+
+@patch("socket.gethostname")
+def test_ssh_config(mocked_gethostname, tmp_path):
+    vortex.config.set_config("ssh", "sshcmd", "mysshcmd")
+    vortex.config.set_config(
+        "ssh",
+        "sshopts",
+        {"default": "default_opts", "sotrtm\\d\\d-sidev": "other opts"},
+    )
+
+    mocked_gethostname.return_value = "sotrtm35-sidev"
+
+    sshobj = Ssh(vortex.ticket().sh, "myhostname")
+
+    assert sshobj._sshcmd == "mysshcmd"
+    assert sshobj._scpcmd == "scp"  # The default
+    assert sshobj._sshopts == ["other", "opts"]
+    assert sshobj._scpopts == []


### PR DESCRIPTION
The `tools.net.Ssh.__init__` method currently relies on the target configuration mechanism to set the value of the ssh and scp commands as well as the corresponding command line options.

In vortex 2 we want this information to be configured explicitely in the `vortex.toml` config file. Currently at Météo-France the values for the ssh and scp command and scp options are always the same across machines. But the ssh options are different for a set of nodes (soprano nodes). Therefore SSH configuration mechanism must allow a user to specify different command names or command line options for specific hostnames.

This PR introduces a new configuration section `[ssh]` for which entries can either
- be strings, when the value does not change across execution hosts
- have subsections named after a regexp pattern, with a `default` section that applies if the hostname does not match any specified pattern.

Example:

```toml

[ssh]
sshcmd = "/usr/bin/ssh"
scpcmd = "/usr/bin/scp"
sshopts.default = "-x -o NoHostAuthenticationForLocalhost=true -o PasswordAuthentication=false -o ConnectTimeout=6"
sshopts."sotrtm\\d\\d-sidev" = "-x -o PasswordAuthentication=false"
```