### PR TITLE
Explicit choice between FTServ and standard Python FTP client

### DIFF
--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -801,7 +801,7 @@ class OSExtended(System):
 
             * **rmtreemin** - as the minimal depth needed for a :meth:`rmsafe`.
             * **cmpaftercp** - as a boolean for activating full comparison after plain cp (default: *True*).
-            * **ftraw** - allows ``smartft*`` methods to use the raw FTP commands
+            * **ftserv** - allows ``smartft*`` methods to use the raw FTP commands
               (e.g. ftget, ftput) instead of the internal Vortex's FTP client
               (default: *False*).
             * **ftputcmd** - The name of the raw FTP command for the "put" action
@@ -816,7 +816,7 @@ class OSExtended(System):
         self._rmtreemin = kw.pop("rmtreemin", 3)
         self._cmpaftercp = kw.pop("cmpaftercp", True)
         # Switches for rawft* methods
-        self._ftraw = kw.pop("ftraw", None)
+        self._ftserv = kw.pop("ftserv", None)
         self.ftputcmd = kw.pop("ftputcmd", None)
         self.ftgetcmd = kw.pop("ftgetcmd", None)
         # FTP stuff again
@@ -839,20 +839,20 @@ class OSExtended(System):
         self._signal_intercept_init()
 
     @property
-    def ftraw(self):
+    def ftserv(self):
         """Use the system's FTP service (e.g. ftserv)."""
-        if self._ftraw is None:
+        if self._ftserv is None:
             return self._use_ftserv()
         else:
-            return self._ftraw
+            return self._ftserv
 
-    @ftraw.setter
-    def ftraw(self, value):
+    @ftserv.setter
+    def ftserv(self, value):
         """Use the system's FTP service (e.g. ftserv)."""
         self._ftraw = bool(value)
 
-    @ftraw.deleter
-    def ftraw(self):
+    @ftserv.deleter
+    def ftserv(self):
         """Use the system's FTP service (e.g. ftserv)."""
         self._ftraw = None
 
@@ -2075,7 +2075,7 @@ class OSExtended(System):
 
     def rawftput_worthy(self, source, destination):
         """Is it allowed to use FtServ given **source** and **destination**."""
-        return self.ftraw and self.ftserv_allowed(source, destination)
+        return self.ftserv and self.ftserv_allowed(source, destination)
 
     @fmtshcmd
     def rawftput(
@@ -2156,7 +2156,7 @@ class OSExtended(System):
 
         ``rawftput`` will be used if all of the following conditions are met:
 
-            * ``self.ftraw`` is *True*
+            * ``self.ftserv`` is *True*
             * **source** is a string (as opposed to a File like object)
             * **destination** is a string (as opposed to a File like object)
         """
@@ -2188,7 +2188,7 @@ class OSExtended(System):
     def rawftget_worthy(self, source, destination, cpipeline=None):
         """Is it allowed to use FtServ given **source** and **destination**."""
         return (
-            self.ftraw
+            self.ftserv
             and cpipeline is None
             and self.ftserv_allowed(source, destination)
         )
@@ -2270,7 +2270,7 @@ class OSExtended(System):
 
         ``rawftget`` will be used if all of the following conditions are met:
 
-            * ``self.ftraw`` is *True*
+            * ``self.ftserv`` is *True*
             * **cpipeline** is None
             * **source** is a string (as opposed to a File like object)
             * **destination** is a string (as opposed to a File like object)

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -68,6 +68,7 @@ from vortex.tools.env import Environment
 from vortex.tools.net import AssistedSsh, AutoRetriesFtp, DEFAULT_FTP_PORT
 from vortex.tools.net import FtpConnectionPool, LinuxNetstats, StdFtp
 import vortex.tools.storage
+from vortex import config
 
 #: No automatic export
 __all__ = []
@@ -841,7 +842,7 @@ class OSExtended(System):
     def ftraw(self):
         """Use the system's FTP service (e.g. ftserv)."""
         if self._ftraw is None:
-            return self.default_target.ftraw_default
+            return self._use_ftserv()
         else:
             return self._ftraw
 
@@ -854,6 +855,16 @@ class OSExtended(System):
     def ftraw(self):
         """Use the system's FTP service (e.g. ftserv)."""
         self._ftraw = None
+
+    def _use_ftserv(self):
+        if not config.is_defined(section="ftserv"):
+            return False
+        for rgxp in config.from_config(
+            section="ftserv", key="hostname_patterns"
+        ):
+            if re.match(rgxp, self.hostname):
+                return True
+        return False
 
     def target(self, **kw):
         """

--- a/tests/test_smartftget.py
+++ b/tests/test_smartftget.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from vortex.tools.systems import Linux34p
+from vortex.config import set_config
+from vortex.tools.net import DEFAULT_FTP_PORT
+
+SOURCE = "/path/to/data"
+DESTINATION = "/path/to/destination"
+HOSTNAME = "hendrix.meteo.fr"
+
+
+@patch("vortex.tools.systems.OSExtended.ftserv_get")
+def test_use_ftserv(mocked_ftserv_get):
+    system = Linux34p(
+        ftserv=None, hostname="belenostransfert3.belenoshpc.meteo.fr"
+    )
+
+    set_config(
+        "ftserv",
+        "hostname_patterns",
+        ["(belenos|taranis)transfert\\d.\\1hpc.meteo.fr"],
+    )
+
+    system.smartftget(
+        source=SOURCE,
+        destination=DESTINATION,
+        hostname=HOSTNAME,
+    )
+    mocked_ftserv_get.assert_called_once_with(
+        SOURCE,
+        DESTINATION,
+        HOSTNAME,
+        None,
+        port=None,
+    )
+
+
+@patch("vortex.tools.systems.OSExtended.ftget")
+def test_no_ftserv(mocked_ftget):
+    system = Linux34p(ftserv=None, hostname="my_hostname")
+
+    set_config(
+        "ftserv",
+        "hostname_patterns",
+        ["(belenos|taranis)transfert\\d.\\1hpc.meteo.fr"],
+    )
+
+    system.smartftget(
+        source=SOURCE,
+        destination=DESTINATION,
+        hostname=HOSTNAME,
+    )
+    mocked_ftget.assert_called_once_with(
+        SOURCE,
+        DESTINATION,
+        hostname=HOSTNAME,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+        fmt=None,
+    )
+
+
+@patch("vortex.tools.systems.OSExtended.ftserv_get")
+def test_force_ftserv(mocked_ftserv_get):
+    system = Linux34p(
+        ftserv=True, hostname="belenostransfert3.belenoshpc.meteo.fr"
+    )
+
+    system.smartftget(
+        source=SOURCE,
+        destination=DESTINATION,
+        hostname=HOSTNAME,
+    )
+    mocked_ftserv_get.assert_called_once_with(
+        SOURCE,
+        DESTINATION,
+        HOSTNAME,
+        None,
+        port=None,
+    )


### PR DESCRIPTION
Currently the `ftraw` property on the `systems.OSExtended` class is used to determine whether or not to use a MF specific FTP client (`ftserv`). If not, the standard Python FTP client is used. The `smartftget` and `smartftput` methods redirect to one or the other depending on the return value of `rawftget_worthy`:

```python
def rawftget_worthy(self, source, destination, cpipeline=None):
    """Is it allowed to use FtServ given **source** and **destination**."""
    return self.ftraw and cpipeline is None and self.ftserv_allowed(source, destination)
```

The `ftraw` property returns a boolean value that depends on
- Whether or not it was set to a value that is not `None` -> in which case this value is returned
- If the attribute `_ftraw` is  `None`, then the value returned is obtained through the `default_target` mechanism: the configuration for the current execution target (derived from tools.targets.Target) is looked up for the list of nodes that support ftserv. See `tools.targets.Target.specialnodes`.

The current PR replaces (2) by an explicit check on the hostname against a list of hostnames patterns that are to be specified in the global `vortex.toml` config file. The behavior is as follows:

1. If no `ftserv` section is defined in the configuration, then the `ftserv` property always return `False`. The standard Python FTP client will be used
2. If an `ftserv` section is defined it must declare an entry `hostname_patterns` that is a list of valid Python regexp patterns. If one or more match the hostname at the time of execution, then FTServ will be used. 

Example
   
```toml
[ftserv]
hostname_patterns = "(belenos|taranis)transfert\\d.\\1hpc.meteo.fr"
 ```

In short this bypasses quite a lot of code involved beyond the call to `default_target.ftraw_default`, using only a simple check on the hostname and explicit configuration of hostnames that support FTServ.

Note that FTServ is specific to Météo-France. Ideally, any logic supporting its use should move away from this package. However at this time it is not clear to me where the FTServ specific code should go, and I chose to leave it there. It is, however, only actived when a `ftserv` configuration section is declared.