### PR TITLE
Reduce `TunableAction` class to `tune` method

### DIFF
--- a/src/vortex/tools/actions.py
+++ b/src/vortex/tools/actions.py
@@ -216,7 +216,7 @@ class TemplatedMail(TunableAction):
         return rc
 
 
-class Report(Action):
+class Report(TunableAction):
     """
     Class responsible for sending reports.
     """


### PR DESCRIPTION
Arguments passed to an action's execute method are used to instantiate the underlying service object. Some actions inherit from
`TunableAction`. `TunableAction` subclasses can add extra parameters to the service instanciation through the config file or the tune method. If extra parameters are read from the config file, the configuration section is usually the value of the `kind` attribute. See 'TunableAction._conf_items'.

So far I can't find any example of an action that is configured through the config file. I'm removing `TunableAction._conf_items` and helper methods for now.

Looking at the oper jobs, the only use of tune is to set the `jname` and driver parameters. Both are only relevant for actions that instantiate a Report service.

This PR removes the `_config_dict` method and associated helper methods. This reduces the functionality provided by `TunableAction` to the `tune` method that is used by oper jobs to setup attributes `jname` (jeeves process identifier) and `dryrun`.
It still feels like `tune` and the whole `TunableAction` class is way too general for what it is actually used for. However in the interest of time, I'm leaving this as it this.
