### PR TITLE
Fix `config.print_config` and use pathlib

### DIFF
--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -21,6 +21,7 @@ strongly advised.
 """
 
 import atexit
+from pathlib import Path
 import sys
 import os
 
@@ -111,11 +112,13 @@ footprints.setup.callback = vortexfpdefaults
 ticket = sessions.get
 sh = sessions.system
 
-# If a config file can be found in current dir, load it else load .vortex.d/vortex.toml
-if os.path.isfile("vortex.toml"):
-    config.load_config("vortex.toml")
+# If a config file can be found in current dir, load it else load
+# .vortex.d/vortex.toml
+confname = Path("vortex.toml")
+if confname.exists():
+    config.load_config(confname)
 else:
-    config.load_config(os.environ["HOME"] + "/.vortex.d/vortex.toml")
+    config.load_config(Path.home() / ".vortex.d" / confname)
 
 # Load some superstars sub-packages
 

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -23,7 +23,6 @@ strongly advised.
 import atexit
 from pathlib import Path
 import sys
-import os
 
 # importlib.metadata included in stdlib from 3.8 onwards.
 # For older versions, import third-party importlib_metadata

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -57,7 +57,7 @@ def load_config(configpath=Path("vortex.toml")):
 def print_config():
     """Print configuration (key, value) pairs"""
     if VORTEX_CONFIG:
-        for k, v in VORTEX_CONFIG:
+        for k, v in VORTEX_CONFIG.items():
             print(k.upper(), v)
 
 

--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -3,6 +3,7 @@ the value of configuration options, respectively.
 
 """
 
+from pathlib import Path
 import tomli
 
 from bronx.fancies import loggers
@@ -24,7 +25,7 @@ class ConfigurationError(Exception):
     """Something is wrong with the provided configuration"""
 
 
-def load_config(configpath="vortex.toml"):
+def load_config(configpath=Path("vortex.toml")):
     """Load configuration from a TOML configuration file
 
     Existing configuration values are overriden. The configuration
@@ -41,12 +42,15 @@ def load_config(configpath="vortex.toml"):
        # ...
     """
     global VORTEX_CONFIG
+    configpath = Path(configpath)
     try:
-        with open(configpath, "rb") as f:
+        with configpath.open(mode="rb") as f:
             VORTEX_CONFIG = tomli.load(f)
-        print(f"Successfully read configuration file {configpath}")
+        print(f"Successfully read configuration file {configpath.absolute()}")
     except FileNotFoundError:
-        print(f"Could not read configuration file {configpath} (not found).")
+        print(
+            f"Could not read configuration file {configpath.absolute()} (not found)."
+        )
         print("Use load_config(/path/to/config) to update the configuration")
 
 


### PR DESCRIPTION
This leverages pathlib to determine which config file to read an read it.

This also fixes `config.print_config` by adding a missing `.items()`.