### PR TITLE
Better error messages if missing archive configuration

### DIFF
--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -65,10 +65,10 @@ def from_config(section, key=None):
     """
     try:
         subconfig = VORTEX_CONFIG[section]
-    except KeyError:
+    except KeyError as e:
         raise ConfigurationError(
             f"Missing configuration section {section}",
-        )
+        ) from e
     if not key:
         return subconfig
 

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -748,13 +748,12 @@ class VortexStdBaseArchiveStore(_VortexBaseArchiveStore):
             )
         except config.ConfigurationError as e:
             msg = (
-                "Trying to write to archive but location is not configured.\n"
+                "Trying to write to archive but location is not configured. "
                 'Make sure key "rootdir" is defined in storage section of '
                 "the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )
-            logger.error(msg)
-            raise e
+            raise config.ConfigurationError(msg) from e
         return remote
 
     remap_write = remap_read
@@ -813,12 +812,11 @@ class VortexOpBaseArchiveStore(_VortexBaseArchiveStore):
         except config.ConfigurationError as e:
             msg = (
                 "Trying to write to operational data archive but location"
-                'is not configured.\nMake sure key "rootdir" is defined in '
+                ' is not configured. Make sure key "op_rootdir" is defined in '
                 "the storage section of the configuration.\n"
                 "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
             )
-            logger.error(msg)
-            raise e
+            raise config.ConfigurationError(msg) from e
         xpath = remote["path"].split("/")
         if len(xpath) >= 5 and re.match(r"^\d{8}T\d{2,4}", xpath[4]):
             # If a date is detected


### PR DESCRIPTION
A `config.ConfigurationError` is raised whenever calling `remap_read` (or remap_write) on an `VortexStdBaseArchiveStore` or `VortexOpBaseArchiveStore`, when configuration key `rootdir` (resp `op_rootdir`) is not defined.

The error message is currently buried below lines of traceback. This makes the message appear at the bottom of the error traceback.