### PR TITLE
More informative messages if missing configuration

### DIFF
--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -45,13 +45,20 @@ trees if they are specified.
 ``storage``
 ^^^^^^^^^^^
 
+The `storage` section of the configuration is used to configure access
+to a remote data tree, see :doc:`remote-data-trees`.
+
 ``address``
 
 The address of the server hosting a remote data tree.
 
 **Type**: Arbitrary string.
 
-**Default value**: None
+```protocol``
+
+The protocol with which to communicate with the server hosting the remote data tree
+
+**Type**: Arbitrary string
 
 ``rootdir``
 
@@ -126,6 +133,12 @@ Option flags to pass the MPI launcher command.
 **Type**: Arbitrary string
 
 **Default value**: ``""``
+
+``slurmversion``
+
+Slurm version
+
+**Type**: Integer
 
 ``mpienv``
 ^^^^^^^^^^

--- a/sphinx/user-guide/remote-data-trees.rst
+++ b/sphinx/user-guide/remote-data-trees.rst
@@ -4,13 +4,13 @@ Remote data trees
 
 
 By default, vortex fetches and write data from and from a *local* data
-tree, see <todolink>.  It is however possible to configure access to a
+tree, see :doc:`data-layout`.  It is however possible to configure access to a
 remote data tree usinf the FTP protocol, for instance acting as a data archive.
 
 Remote data tree configuration
 ------------------------------
 
-In the vortex configuration file (see <todolink>), specify a section
+In the vortex configuration file (:doc:`configuration`), specify a section
 ``storage`` defining the following key/value pairs:
 
 
@@ -18,13 +18,15 @@ In the vortex configuration file (see <todolink>), specify a section
 
     [storage]
     address = "example.meteo.fr"
+    protocol = "ftp"
     rootdir = "/path/to/data/tree/root"
     op_rootdir = "/path/to/oper/data/tree/root"
-    export_mapping = false
 
 ``address``
-    the network address of a reachable filserver using
-    the FTP protocol.
+    the network address of the server hosting the remote data tree.
+
+``protocol``
+   the protocol with which to communicate with the server hosting the remote data tree.
 
 ``rootdir``
     Path to the root of the vortex data tree on the remote

--- a/src/vortex/algo/components.py
+++ b/src/vortex/algo/components.py
@@ -1841,7 +1841,10 @@ class Parallel(xExecutableAlgoComponent):
     def _mpitool_attributes(self, opts):
         """Return the dictionary of attributes needed to create the mpitool object."""
         # Read the appropriate configuration in the target file
-        conf_dict = config.from_config(section="mpitool")
+        if not config.is_defined(section="mpitool"):
+            conf_dict = {}
+        else:
+            conf_dict = config.from_config(section="mpitool")
         if self.mpiname:
             conf_dict["mpiname"] = self.mpiname
         # Make "mpirun" the default mpi command name

--- a/src/vortex/algo/mpitools.py
+++ b/src/vortex/algo/mpitools.py
@@ -84,6 +84,7 @@ from vortex.tools import env
 from vortex.tools.arm import ArmForgeTool
 from vortex.tools.systems import ExecutionError
 from vortex.util import config
+from vortex.config import is_defined, ConfigurationError
 
 #: No automatic export
 __all__ = []
@@ -1431,12 +1432,15 @@ class SRun(MpiTool):
     @property
     def _actual_slurmversion(self):
         """Return the slurm major version number."""
-        slurmversion = self.slurmversion or from_config(
-            section="mpitool", key="slurmversion"
-        )
-        if not slurmversion:
-            raise ValueError("No slurm version specified")
-        return slurmversion
+        if self.slurmversion:
+            return self.slurmversion
+
+        if not is_defined(section="mpitool", key="slurmversion"):
+            raise ConfigurationError(
+                "Using 'srun' MPI tool but slurm version is not configured. See "
+                "https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#mpitool"
+            )
+        return from_config(section="mpitool", key="slurmversion")
 
     def _set_binaries_hack(self, binaries):
         """Set the list of :class:`MpiBinaryDescription` objects associated with this instance."""

--- a/src/vortex/data/abstractstores.py
+++ b/src/vortex/data/abstractstores.py
@@ -14,7 +14,7 @@ from bronx.system import hash as hashutils
 import footprints
 
 from vortex import sessions
-from vortex.config import from_config, ConfigurationError
+from vortex.config import from_config, ConfigurationError, is_defined
 from vortex.syntax.stdattrs import (
     hashalgo,
     hashalgo_avail_list,
@@ -870,6 +870,13 @@ class ArchiveStore(Store):
     @property
     def actual_storetube(self):
         """This archive network name (potentially read form the configuration file)."""
+        if self._actual_storetube:
+            return self._actual_storetube
+        if not is_defined(section="storage", key="protocol"):
+            raise ConfigurationError(
+                "Using remote data tree but protocol is not configured. See "
+                "https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#storage"
+            )
         if self._actual_storetube is None:
             self._actual_storetube = from_config(
                 section="storage",

--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -1025,18 +1025,16 @@ class VortexCacheOp2ResearchStore(_VortexCacheBaseStore):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        try:
-            cachepath = config.from_config(
-                section="data-tree",
-                key="op_rootdir",
+        if not config.is_defined(section="data-tree", key="op_rootdir"):
+            raise config.ConfigurationError(
+                "Using special experiment but corresponding cache location "
+                'is not configured. Bet sure to set "op_rootdir" in configuration. '
+                "See https://vortex-nwp.readthedocs.io/en/latest/user-guide/oper-dble-data-trees"
             )
-        except config.ConfigurationError as e:
-            logger.error(
-                "Cannot use special experiment cache without providing",
-                "cache location",
-            )
-            raise e
-
+        cachepath = config.from_config(
+            section="data-tree",
+            key="op_rootdir",
+        )
         self.location = os.path.join(cachepath, "vortex")
 
 


### PR DESCRIPTION
This makes sure a `ConfigurationError` exception is raised with an informative error message if configuration keys `storage:protocol`, `data-tree:op_rootdir`, `mpitool:slurmversion` are not defined at the point where they are required.

This also make the `[mpitool]` section optional. If not provided, only `mpiname` is set to  `"mpirun"`.