### PR TITLE
Explicit EcFlow configuration

### DIFF
--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -271,3 +271,34 @@ declared using the ``default`` keyword (e.g. ``sshopts.default``).
    According to the `TOML specification
    <https://toml.io/en/v1.0.0#string>`_ , special characters used in
    regular expressions, such as backslashes, must be escaped.
+
+``ecflow``
+^^^^^^^^^^
+
+``clientpath``
+
+Path to the EcFlow client executable.
+
+**Type**: string
+
+**Default value**: ``ecflow_client``
+
+``sshproxy_wait``
+
+**Default value**: 6
+
+``sshproxy_wait``
+
+**Default value**: 2
+
+``sshproxy_retrydelay``
+
+**Default value**: 1
+
+``services``
+^^^^^^^^^^^^
+
+``cluster_names``
+
+A list of allowed cluster names, e.g ``["belenos", "taranis"]``
+

--- a/src/vortex/tools/schedulers.py
+++ b/src/vortex/tools/schedulers.py
@@ -363,17 +363,14 @@ class EcFlow(EcmwfLikeScheduler):
     def __init__(self, *args, **kw):
         logger.debug("EcFlow scheduler client init %s", self)
         super().__init__(*args, **kw)
-m        if not self.clientpath:
+        if not self.clientpath:
             if not config.is_defined(section="ecflow", key="clientpath"):
-                raise config.ConfigurationError(
-                    "Initialisating EcFlow scheduler interface but client "
-                    "path is not defined. See "
-                    "https://vortex-nwp.readthedocs.io/en/latest/user-guide/configuration.html#ecflow"
+                self.clientpath = "ecflow_client"
+            else:
+                self.clientpath = config.from_config(
+                    section="ecflow",
+                    key="clientpath",
                 )
-            self.clientpath = config.from_config(
-                section="ecflow",
-                key="clientpath",
-            )
 
     @contextlib.contextmanager
     def child_session_setup(self):


### PR DESCRIPTION
Currently, EcFlow interface configuration still relies on the "target" mechanism, where it is expected that the hostname of the execution platform matches a `Target` class which then can be configured through a specific `target-XXX.ini` configuration (usually distributed in the `conf/` directory in vortex 1.*).

At the moment, the EcFlow client path can be configured through the target configuration file or the `ECF_CLIENT_PATH` environment variable. Additionally, the version can be specified using `ECF_VERSION`. This is used in the case where the path specified in the target configuration file features a placeholder, e.g. `/path/to/ecflow-{version}/ecflow_client`.

Vortex can only communicate with the EcFlow server directly if it runs on machine able to reach it. This is currently determined by a call to `default_target.isnetworknode`, which relies on the "target" mechanism as well. If the EcFlow is not directly reachable, then the request is made through a SSH tunnel.

---

This simplifies path configuration by reading the path from the global TOML configuration file. Both `ECF_CLIENT_PATH` and `ECF_VERSION` have no effect.

This also replaces the call to `default_target.isnetworknode` with an explicit check on the hostname. This check is very specific to Météo-France at the moment (configuration files were as well, anyway) but should not impact the behaviour at ECMWF, since there is no distinction between compute and transfer nodes.

The helper function `get_cluster_name` is moved from `vortex-iga` to `the vortex.tools.services` module.

