### PR TITLE
Don't assume structure of namespace string for `VortexArchiveStore`

### DIFF
--- a/src/vortex/data/stores.py
+++ b/src/vortex/data/stores.py
@@ -908,16 +908,9 @@ class VortexArchiveStore(MultiStore):
 
     def alternates_netloc(self):
         """Return netlocs describing both base and stacked archives."""
-        netloc_m = re.match(
-            r"(?P<base>v.*)\.archive\.(?P<country>\w+)", self.netloc
-        )
         return [
-            "{base:s}.archive-legacy.{country:s}".format(
-                **netloc_m.groupdict()
-            ),
-            "{base:s}.stacked-archive-legacy.{country:s}".format(
-                **netloc_m.groupdict()
-            ),
+            f"{self.netloc.firstname}.archive-legacy.fr",
+            f"{self.netloc.firstname}.stacked-archive-legacy.fr",
         ]
 
     def alternates_fpextras(self):


### PR DESCRIPTION
This is the same as https://github.com/UMR-CNRM/vortex/pull/13 but for the vortex archive store instead of the cache store.

Currently the `VortexArchiveStore.alternate_netloc` method assumes that the archive store namespaces will match the following pattern

```
(?P<base>vortex.*)\.archive\.(?P<country>\w+)
```

This removes any constraint on the namespace value. This enables namespaces based on the `olive-exp` prefix. See
[vortex-olive!3](http://gitlab.meteo.fr/cnrm-gmap/vortex-olive/-/merge_requests/3).

In addition, the namespace suffix is always `.fr`.