### PR TITLE
Make vortex quieter

### DIFF
--- a/sphinx/user-guide/plugins.rst
+++ b/sphinx/user-guide/plugins.rst
@@ -20,6 +20,9 @@ or :py:func:`vortex.task`, the corresponding Python modules must be
 installed as part of a package that declares the ``vtx`` entry point
 in its metadata.
 
+The :py:func:`vortex.loaded_plugins` can be used to list currently
+loaded plugin packages.
+
 Example
 -------
 

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -21,6 +21,7 @@ strongly advised.
 """
 
 import atexit
+import copy
 from pathlib import Path
 import sys
 
@@ -127,9 +128,15 @@ else:
 # will typically depend on objects defined in 'vortex'
 # and 'vortex.nwp', these must be imported /before/
 # loading plugins.
+_LOADED_PLUGINS = set()
 for plugin in importlib.metadata.entry_points(group="vtx"):
     plugin.load()
-    print(f"Loaded plugin {plugin.name}")
+    _LOADED_PLUGINS.add(plugin.name)
+
+
+def loaded_plugins() -> set[str]:
+    """Return the set of names for loaded plugins"""
+    return copy.copy(_LOADED_PLUGINS)
 
 
 # Register proper vortex exit before the end of interpreter session

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -35,7 +35,6 @@ else:
     import importlib.metadata
 
 from bronx.fancies import loggers as bloggers
-import bronx.stdtypes.date
 
 import footprints
 
@@ -141,26 +140,9 @@ def complete():
     for kid in multiprocessing.active_children():
         logger.warning("Terminate active kid %s", str(kid))
         kid.terminate()
-    print(
-        "Vortex",
-        __version__,
-        "completed",
-        "(",
-        bronx.stdtypes.date.at_second().reallynice(),
-        ")",
-    )
 
 
 atexit.register(complete)
 del atexit, complete
-
-print(
-    "Vortex",
-    __version__,
-    "loaded",
-    "(",
-    bronx.stdtypes.date.at_second().reallynice(),
-    ")",
-)
 
 del footprints

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -67,6 +67,7 @@ __all__ = [
     "task",
     "promise",
     "diff",
+    "loaded_plugins",
 ]
 
 # Set vortex specific priorities for footprints usage
@@ -135,7 +136,16 @@ for plugin in importlib.metadata.entry_points(group="vtx"):
 
 
 def loaded_plugins() -> set[str]:
-    """Return the set of names for loaded plugins"""
+    """Return the set of names for loaded plugins
+
+    **Example:**
+
+    .. code:: python
+
+        >>> import vortex
+        >>> vortex.loaded_plugins()
+            {"gco", "cen"}
+    """
     return copy.copy(_LOADED_PLUGINS)
 
 


### PR DESCRIPTION
- Remove messages on stdout when importing vortex or quitting interpreter
- Remove message on stdout listing loaded plugins

For plugins, introduce function `vortex.loaded_plugins` that returns the set of loaded plugins.