### PR TITLE
Replace `rawftshell` section by `ftserv.shell`

### DIFF
--- a/src/vortex/tools/addons.py
+++ b/src/vortex/tools/addons.py
@@ -8,7 +8,11 @@ from bronx.fancies import loggers
 from bronx.syntax.decorators import nicedeco
 import footprints
 
-from vortex.config import get_from_config_w_default
+from vortex.config import (
+    get_from_config_w_default,
+    from_config,
+    ConfigurationError,
+)
 from vortex.layout import contexts
 from vortex.tools.env import Environment
 from vortex.tools.systems import OSExtended
@@ -206,11 +210,11 @@ class FtrawEnableAddon(Addon):
         super().__init__(*args, **kw)
         # If needed, look in the config file for the rawftshell
         if self.rawftshell is None:
-            self.rawftshell = get_from_config_w_default(
-                section="rawftshell",
-                key=self.kind,
-                default=None,
-            )
+            try:
+                shell = from_config(section="ftserv", key="shell")
+                self.rawftshell = f"/usr/local/bin/ft_regroupement_concat_{shell[self.kind]}.sh"
+            except (ConfigurationError, KeyError):
+                self.rawftshell = None
 
 
 class AddonGroup(footprints.FootprintBase):


### PR DESCRIPTION
Make ftserv configuration easier to read/write and obviously related to ftserv.

```toml
[ftserv.shell]
lfi = "falfi"
grib = "basic"
odb = "tar"
ddhpack = "tar"
obslocationpack = "tar"
obsfirepack = "tar"
rawfiles = "tar"
filespack = "tar"
```
instead of

```toml
[rawftshell]
lfi = "/usr/local/bin/ft_regroupement_concat_falfi.sh"
grib = "/usr/local/bin/ft_regroupement_concat_basic.sh"
odb = "/usr/local/bin/ft_regroupement_concat_tar.sh"
ddhpack = "/usr/local/bin/ft_regroupement_concat_tar.sh"
obslocationpack = "/usr/local/bin/ft_regroupement_concat_tar.sh"
obsfirepack = "/usr/local/bin/ft_regroupement_concat_tar.sh"
rawfiles = "/usr/local/bin/ft_regroupement_concat_tar.sh"
filespack = "/usr/local/bin/ft_regroupement_concat_tar.sh"
```