### PR TITLE
Enforce `importlib_metadata>=3.6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "taylorism",
     "tomli",
     "arpifs_listings",
-    "importlib_metadata; python_version < '3.8'",
+    # Selectable entrypoints from importlib_metadata 3.6
+    "importlib_metadata>=3.6; python_version < '3.8'",
     "pyyaml",
 ]
 

--- a/src/vortex/__init__.py
+++ b/src/vortex/__init__.py
@@ -24,6 +24,7 @@ import atexit
 import copy
 from pathlib import Path
 import sys
+from typing import Set  # Python 3.7 compat
 
 # importlib.metadata included in stdlib from 3.8 onwards.
 # For older versions, import third-party importlib_metadata
@@ -135,7 +136,7 @@ for plugin in importlib.metadata.entry_points(group="vtx"):
     _LOADED_PLUGINS.add(plugin.name)
 
 
-def loaded_plugins() -> set[str]:
+def loaded_plugins() -> Set[str]:
     """Return the set of names for loaded plugins
 
     **Example:**


### PR DESCRIPTION
See https://github.com/UMR-CNRM/vortex/issues/58#issuecomment-4260488652

Plugin detection relies on calling `importlib.metadata.entry_points(group="vtx")`, i.e. selecting entry points  based on the their group. Selectable entry points where added in version 3.6.0 of the `importlib_metadata` backport.