### PR TITLE
Move FTServ out of the core module

### DIFF
--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -67,7 +67,8 @@ from vortex.tools.compression import CompressionPipeline
 from vortex.tools.env import Environment
 from vortex.tools.net import AssistedSsh, AutoRetriesFtp, DEFAULT_FTP_PORT
 from vortex.tools.net import FtpConnectionPool, LinuxNetstats, StdFtp
-from vortex import config
+from vortex import config, proxy
+
 
 #: No automatic export
 __all__ = []
@@ -1914,9 +1915,7 @@ class OSExtended(System):
         else:
             return False
 
-    def ftserv_allowed(self, source, destination):
-        """Given **source** and **destination**, is FtServ usable ?"""
-        return isinstance(source, str) and isinstance(destination, str)
+
 
     def ftserv_put(
         self,
@@ -2305,29 +2304,20 @@ class OSExtended(System):
             * **source** is a string (as opposed to a File like object)
             * **destination** is a string (as opposed to a File like object)
         """
-        if self.rawftget_worthy(source, destination, cpipeline):
-            # FtServ is uninteresting when dealing with compression
-            return self.rawftget(
-                source,
-                destination,
-                hostname=hostname,
-                logname=logname,
-                port=port,
-                cpipeline=cpipeline,
-                fmt=fmt,
+        
+        ftp = proxy.ftp_client(server = self.hostname)
+        #ftp = proxy.ftp_client(server = "toto") # test ftplib
+        
+        ftp.get(
+            source,
+            destination,
+            hostname=hostname,
+            logname=logname,
+            port=port,
+            cpipeline=cpipeline,
+            fmt=fmt,
             )
-        else:
-            if port is None:
-                port = DEFAULT_FTP_PORT
-            return self.ftget(
-                source,
-                destination,
-                hostname=hostname,
-                logname=logname,
-                port=port,
-                cpipeline=cpipeline,
-                fmt=fmt,
-            )
+        
 
     def smartbatchftget(
         self,
@@ -4015,3 +4005,134 @@ class Macosx34p(Macosx, Python34):
             info="Apple Mac computer under Macosx with a blazing Python version"
         ),
     ]
+
+
+
+
+class FtpClient(OSExtended):
+    """
+    Root class for any :class:`Ftp` subclasses.
+    """
+    _abstract  = True
+    _collector = ("ftp_client",)
+    _footprint = dict(
+        info = "FTP client handling",
+        attr = dict(
+            server = dict(),
+        ),
+    )
+
+class PythonFtp(FtpClient):
+    """
+    FTP client that relies on the standard library ``ftplib``.
+    """
+
+    _footprint = dict(
+        info = "FTP client that relies on the standard library ``ftplib``",
+        attr = dict(
+            server = dict(
+                values = []),
+        ),
+    )
+    def get(self,
+            source,
+            destination,
+            hostname=None,
+            logname=None,
+            port=None,
+            cpipeline=None,
+            fmt=None):
+        
+        if port is None:
+            port = DEFAULT_FTP_PORT
+            
+        return self.ftget(
+            source,
+            destination,
+            hostname=hostname,
+            logname=logname,
+            port=port,
+            cpipeline=cpipeline,
+            fmt=fmt,
+        )
+
+class MeteoFranceFtp(FtpClient):
+    """
+    Meteo-France FTP client ``FTServ``.
+    """
+
+    _footprint = dict(
+        info = "Meteo-France FTP client ``FTServ``",
+        attr = dict(
+            server = dict(
+                values = ["belenos", "taranis", "sxcoope1"]),
+        ),
+    )
+
+    @fmtshcmd
+    def get(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=None,
+        cpipeline=None,
+    ):
+        """Proceed with some external ftget command on the specified target.
+
+        :param str source: the remote path to get data
+        :param str destination: path to the filename where to put the data.
+        :param str hostname: the target hostname  (default: *None*).
+        :param str logname: the target logname  (default: *None*).
+        :param int port: the port number on the remote host.
+        :param CompressionPipeline cpipeline: unused (kept for compatibility)
+        """
+        if cpipeline is not None:
+            raise OSError("cpipeline is not supported by this method.")
+        return self.ftserv_get(
+            source, destination, hostname, logname, port=port
+        )
+
+
+    def ftserv_get(
+        self, source, destination, hostname=None, logname=None, port=None
+    ):
+        """Get a file using FtServ."""
+        if self.ftserv_allowed(source, destination):
+            if self.filecocoon(destination):
+                hostname = self.fix_fthostname(hostname, fatal=False)
+                logname = self.fix_ftuser(hostname, logname, fatal=False)
+                destination = self.path.expanduser(destination)
+                extras = list()
+                if hostname:
+                    if port is not None:
+                        hostname += ":{:s}".format(str(port))
+                    extras.extend(["-h", hostname])
+                if logname:
+                    extras.extend(["-u", logname])
+                ftcmd = self.ftgetcmd or "ftget"
+                try:
+                    rc = self.spawn(
+                        [
+                            ftcmd,
+                        ]
+                        + extras
+                        + [source, destination],
+                        output=False,
+                    )
+                except ExecutionError:
+                    rc = False
+            else:
+                raise OSError("Could not cocoon: {!s}".format(destination))
+        else:
+            raise OSError(
+                "Source or destination is not a plain file path: {!r}".format(
+                    source
+                )
+            )
+        return rc
+    
+    def ftserv_allowed(self, source, destination):
+        """Given **source** and **destination**, is FtServ usable ?"""
+        return isinstance(source, str) and isinstance(destination, str)

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -2304,7 +2304,7 @@ class OSExtended(System):
             source,
             destination,
             hostname=hostname,
-            logname=logname,
+            logname=self.fix_ftuser(hostname, logname),
             port=port,
             cpipeline=cpipeline,
             fmt=fmt,
@@ -3709,24 +3709,19 @@ class OSExtended(System):
         self._lockdir_destroy(ldir)
 
     def get_ftp_client(self):
-        """Returns an instance of a FTP client.
+        """Return a suitable FTP client instance.
         
-        The footprint mechanism collects all FTP clients inheriting from
-        ``FtpClient``.
-        
-        When requesting a client with ``name="ftp"``, several implementations may
-        match. If a plugin-defined implementation has a higher footprint 
-        priority than ``PythonFtp``, it is selected first.
-        
-        The selected client is used only if its ``_use_me(hostname)`` method returns
-        ``True``. Otherwise, the default ``PythonFtp`` implementation is returned by
-        requesting ``name="default"``.
+        The FTP client with the highest footprint priority is selected first.
+        If its ``_use_me()`` method returns ``False``, the default
+        ``PythonFtp`` implementation is returned instead.
         
         :return: An FTP client instance.
+        :rtype: FtpClient
         """
-        client = proxy.ftp_client(name="ftp")
+        client = proxy.ftp_client()
+        
         if client._use_me(self.hostname):
-            return client
+            return client 
 
         return proxy.ftp_client(name="default")
 
@@ -4032,26 +4027,25 @@ class PythonFtp(FtpClient):
     """
     FTP client that relies on the standard library ``ftplib``.
     """
-
+    _explicit = False
     _footprint = dict(
         info = "FTP client that relies on the standard library ``ftplib``",
         priority = dict(
             level = footprints.priorities.top.DEFAULT
             ),
         attr = dict(
-            name = dict(values=["default", "ftp"]),
-                ),
+            name = dict(default="default", optional=True),
+            ),
         )
-    
-    def _use_me(*args):
-        """
-        Determine whether this FTP client can be used.
-    
-        By default this client is always usable. Any supplied arguments are
-        ignored.
+
+    def _use_me(self, hostname=None):
+        """Check whether this FTP implementation can handle a hostname.
         
-        :param args: Positional arguments (ignored).
-        :return: ``True``.
+        This implementation is always considered usable. The hostname 
+        argument is ignored.
+        
+        :param str hostname: The hostname to test (unused).
+        :return: Always ``True``.
         :rtype: bool
         """
         return True
@@ -4064,6 +4058,7 @@ class PythonFtp(FtpClient):
             port=None,
             cpipeline=None,
             fmt=None):
+        """Wrapper for :meth:`~OSExtended.ftget`."""
         
         if port is None:
             port = DEFAULT_FTP_PORT
@@ -4077,49 +4072,3 @@ class PythonFtp(FtpClient):
             cpipeline=cpipeline,
             fmt=fmt,
         )
-
-    @fmtshcmd
-    def ftget(
-        self,
-        source,
-        destination,
-        hostname=None,
-        logname=None,
-        port=DEFAULT_FTP_PORT,
-        cpipeline=None,
-    ):
-        """Proceed to a direct ftp get on the specified target (using Vortex's FTP client).
-
-        :param str source: the remote path to get data
-        :param destination: The destination of data (either a path to file or a
-            File-like object)
-        :type destination: str or File-like object
-        :param str hostname: The target hostname (default: *None*, see the
-            :class:`~vortex.tools.net.StdFtp` class to get the effective default)
-        :param str logname: the target logname (default: *None*, see the
-            :class:`~vortex.tools.net.StdFtp` class to get the effective default)
-        :param int port: the port number on the remote host.
-        :param CompressionPipeline cpipeline: If not *None*, the object used to
-            uncompress the data during the file transfer (default: *None*).
-        """
-        if isinstance(destination, str):  # destination may be Virtual
-            self.rm(destination)
-        hostname = self.fix_fthostname(hostname)
-        ftp = self.ftp(hostname, logname, port=port)
-        if ftp:
-            try:
-                if cpipeline is None:
-                    rc = ftp.get(source, destination)
-                else:
-                    with cpipeline.stream2uncompress(
-                        destination
-                    ) as cdestination:
-                        rc = ftp.get(source, cdestination)
-            except ftplib.all_errors as e:
-                logger.warning("An FTP error occured: %s", str(e))
-                rc = False
-            finally:
-                ftp.close()
-            return rc
-        else:
-            return False

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -2282,7 +2282,7 @@ class OSExtended(System):
         cpipeline=None,
         fmt=None,
     ):
-        """Select the best alternative between ``ftget`` and ``rawftget``.
+        """“Retrieve a file from a remote FTP server.
 
         :param str source: the remote path to get data
         :param destination: The destination of data (either a path to file or a
@@ -2297,16 +2297,8 @@ class OSExtended(System):
             uncompress the data during the file transfer.
         :param str fmt: The format of data.
 
-        ``rawftget`` will be used if all of the following conditions are met:
-
-            * ``self.ftserv`` is *True*
-            * **cpipeline** is None
-            * **source** is a string (as opposed to a File like object)
-            * **destination** is a string (as opposed to a File like object)
         """
-        
-        ftp = proxy.ftp_client(server = self.hostname)
-        #ftp = proxy.ftp_client(server = "toto") # test ftplib
+        ftp = self.get_ftp_client()
         
         ftp.get(
             source,
@@ -2316,8 +2308,7 @@ class OSExtended(System):
             port=port,
             cpipeline=cpipeline,
             fmt=fmt,
-            )
-        
+            )        
 
     def smartbatchftget(
         self,
@@ -3717,6 +3708,34 @@ class OSExtended(System):
         ldir = self._appwide_lockdir_path(label)
         self._lockdir_destroy(ldir)
 
+    def get_ftp_client(self):
+        """Returns an instance of a FTP client.
+        
+        The footprint's mechanism collects all ftp clients that inherit from 
+        the ``FtpClient`` class.
+        
+        A specific FTP client defined in a plugin module will be selected 
+        if its footprint attribute ``name`` matches the value of
+        ``VORTEX_CONFIG["ftp_client"]["name"].``
+        
+        If the instantiation of the specified FTP client fails 
+        (for example, if the corresponding module is not available), 
+        a default client based on the ``ftplib`` library is returned.
+        
+
+        Returns
+        -------
+        An instantiated FTP client.
+        """
+        if config.is_defined("ftp_client"):
+            client_name = config.VORTEX_CONFIG["ftp_client"]["name"]
+            try:
+                return proxy.ftp_client(name = client_name)
+            except Exception as e:
+                logger.warning("Can't find FTP client %s: %s. \
+                           \nLoad default FTP client.", client_name, e)
+        return proxy.ftp_client(name="default")
+    
 
 class Python34:
     """Python features starting from version 3.4."""
@@ -4006,9 +4025,6 @@ class Macosx34p(Macosx, Python34):
         ),
     ]
 
-
-
-
 class FtpClient(OSExtended):
     """
     Root class for any :class:`Ftp` subclasses.
@@ -4018,9 +4034,9 @@ class FtpClient(OSExtended):
     _footprint = dict(
         info = "FTP client handling",
         attr = dict(
-            server = dict(),
-        ),
+            ),
     )
+    
 
 class PythonFtp(FtpClient):
     """
@@ -4030,10 +4046,10 @@ class PythonFtp(FtpClient):
     _footprint = dict(
         info = "FTP client that relies on the standard library ``ftplib``",
         attr = dict(
-            server = dict(
-                values = []),
+            name=dict(values=["default"])
         ),
     )
+    
     def get(self,
             source,
             destination,
@@ -4055,84 +4071,3 @@ class PythonFtp(FtpClient):
             cpipeline=cpipeline,
             fmt=fmt,
         )
-
-class MeteoFranceFtp(FtpClient):
-    """
-    Meteo-France FTP client ``FTServ``.
-    """
-
-    _footprint = dict(
-        info = "Meteo-France FTP client ``FTServ``",
-        attr = dict(
-            server = dict(
-                values = ["belenos", "taranis", "sxcoope1"]),
-        ),
-    )
-
-    @fmtshcmd
-    def get(
-        self,
-        source,
-        destination,
-        hostname=None,
-        logname=None,
-        port=None,
-        cpipeline=None,
-    ):
-        """Proceed with some external ftget command on the specified target.
-
-        :param str source: the remote path to get data
-        :param str destination: path to the filename where to put the data.
-        :param str hostname: the target hostname  (default: *None*).
-        :param str logname: the target logname  (default: *None*).
-        :param int port: the port number on the remote host.
-        :param CompressionPipeline cpipeline: unused (kept for compatibility)
-        """
-        if cpipeline is not None:
-            raise OSError("cpipeline is not supported by this method.")
-        return self.ftserv_get(
-            source, destination, hostname, logname, port=port
-        )
-
-
-    def ftserv_get(
-        self, source, destination, hostname=None, logname=None, port=None
-    ):
-        """Get a file using FtServ."""
-        if self.ftserv_allowed(source, destination):
-            if self.filecocoon(destination):
-                hostname = self.fix_fthostname(hostname, fatal=False)
-                logname = self.fix_ftuser(hostname, logname, fatal=False)
-                destination = self.path.expanduser(destination)
-                extras = list()
-                if hostname:
-                    if port is not None:
-                        hostname += ":{:s}".format(str(port))
-                    extras.extend(["-h", hostname])
-                if logname:
-                    extras.extend(["-u", logname])
-                ftcmd = self.ftgetcmd or "ftget"
-                try:
-                    rc = self.spawn(
-                        [
-                            ftcmd,
-                        ]
-                        + extras
-                        + [source, destination],
-                        output=False,
-                    )
-                except ExecutionError:
-                    rc = False
-            else:
-                raise OSError("Could not cocoon: {!s}".format(destination))
-        else:
-            raise OSError(
-                "Source or destination is not a plain file path: {!r}".format(
-                    source
-                )
-            )
-        return rc
-    
-    def ftserv_allowed(self, source, destination):
-        """Given **source** and **destination**, is FtServ usable ?"""
-        return isinstance(source, str) and isinstance(destination, str)

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -3711,31 +3711,24 @@ class OSExtended(System):
     def get_ftp_client(self):
         """Returns an instance of a FTP client.
         
-        The footprint's mechanism collects all ftp clients that inherit from 
-        the ``FtpClient`` class.
+        The footprint mechanism collects all FTP clients inheriting from
+        ``FtpClient``.
         
-        A specific FTP client defined in a plugin module will be selected 
-        if its footprint attribute ``name`` matches the value of
-        ``VORTEX_CONFIG["ftp_client"]["name"].``
+        When requesting a client with ``name="ftp"``, several implementations may
+        match. If a plugin-defined implementation has a higher footprint 
+        priority than ``PythonFtp``, it is selected first.
         
-        If the instantiation of the specified FTP client fails 
-        (for example, if the corresponding module is not available), 
-        a default client based on the ``ftplib`` library is returned.
+        The selected client is used only if its ``_use_me(hostname)`` method returns
+        ``True``. Otherwise, the default ``PythonFtp`` implementation is returned by
+        requesting ``name="default"``.
         
-
-        Returns
-        -------
-        An instantiated FTP client.
+        :return: An FTP client instance.
         """
-        if config.is_defined("ftp_client"):
-            client_name = config.VORTEX_CONFIG["ftp_client"]["name"]
-            try:
-                return proxy.ftp_client(name = client_name)
-            except Exception as e:
-                logger.warning("Can't find FTP client %s: %s. \
-                           \nLoad default FTP client.", client_name, e)
+        client = proxy.ftp_client(name="ftp")
+        if client._use_me(self.hostname):
+            return client
+
         return proxy.ftp_client(name="default")
-    
 
 class Python34:
     """Python features starting from version 3.4."""
@@ -4033,11 +4026,8 @@ class FtpClient(OSExtended):
     _collector = ("ftp_client",)
     _footprint = dict(
         info = "FTP client handling",
-        attr = dict(
-            ),
     )
     
-
 class PythonFtp(FtpClient):
     """
     FTP client that relies on the standard library ``ftplib``.
@@ -4045,11 +4035,27 @@ class PythonFtp(FtpClient):
 
     _footprint = dict(
         info = "FTP client that relies on the standard library ``ftplib``",
+        priority = dict(
+            level = footprints.priorities.top.DEFAULT
+            ),
         attr = dict(
-            name=dict(values=["default"])
-        ),
-    )
+            name = dict(values=["default", "ftp"]),
+                ),
+        )
     
+    def _use_me(*args):
+        """
+        Determine whether this FTP client can be used.
+    
+        By default this client is always usable. Any supplied arguments are
+        ignored.
+        
+        :param args: Positional arguments (ignored).
+        :return: ``True``.
+        :rtype: bool
+        """
+        return True
+        
     def get(self,
             source,
             destination,
@@ -4071,3 +4077,49 @@ class PythonFtp(FtpClient):
             cpipeline=cpipeline,
             fmt=fmt,
         )
+
+    @fmtshcmd
+    def ftget(
+        self,
+        source,
+        destination,
+        hostname=None,
+        logname=None,
+        port=DEFAULT_FTP_PORT,
+        cpipeline=None,
+    ):
+        """Proceed to a direct ftp get on the specified target (using Vortex's FTP client).
+
+        :param str source: the remote path to get data
+        :param destination: The destination of data (either a path to file or a
+            File-like object)
+        :type destination: str or File-like object
+        :param str hostname: The target hostname (default: *None*, see the
+            :class:`~vortex.tools.net.StdFtp` class to get the effective default)
+        :param str logname: the target logname (default: *None*, see the
+            :class:`~vortex.tools.net.StdFtp` class to get the effective default)
+        :param int port: the port number on the remote host.
+        :param CompressionPipeline cpipeline: If not *None*, the object used to
+            uncompress the data during the file transfer (default: *None*).
+        """
+        if isinstance(destination, str):  # destination may be Virtual
+            self.rm(destination)
+        hostname = self.fix_fthostname(hostname)
+        ftp = self.ftp(hostname, logname, port=port)
+        if ftp:
+            try:
+                if cpipeline is None:
+                    rc = ftp.get(source, destination)
+                else:
+                    with cpipeline.stream2uncompress(
+                        destination
+                    ) as cdestination:
+                        rc = ftp.get(source, cdestination)
+            except ftplib.all_errors as e:
+                logger.warning("An FTP error occured: %s", str(e))
+                rc = False
+            finally:
+                ftp.close()
+            return rc
+        else:
+            return False


### PR DESCRIPTION
* Each FTP client (e.g. ftplib, FTServ) is now wrapped in its own class.
* The footprint package automatically selects the appropriate client based on the target hostname.