### PR TITLE
Set username attr for promise store when clearing promises

### DIFF
--- a/src/vortex/toolbox.py
+++ b/src/vortex/toolbox.py
@@ -1113,7 +1113,7 @@ def rescue(*files, **opts):
         t.context.diff_history.show()
 
     # Force clearing of all promises
-    clear_promises(clear=True)
+    clear_promises(clear=True, storeoptions={"username": t.glove.user})
 
     sh.header("Rescuing current dir")
     sh.dir(output=False, fatal=False)


### PR DESCRIPTION
`toolbox.clear_promises` is called when a job crashes. the function eventually instantiates a promise store (by default the promise cache store). The `storeoptions` argument can be used to specify to pass the `username` footprint attribute when instantiating the promise store.