### PR TITLE
Remove reliance on old target configuration mechanics in for SMTP requests

### DIFF
--- a/src/vortex/tools/services.py
+++ b/src/vortex/tools/services.py
@@ -10,6 +10,7 @@ import contextlib
 import hashlib
 import pprint
 import re
+import socket
 from string import Template
 
 
@@ -248,10 +249,17 @@ class MailService(Service):
         my_smtpport = self.actual_value(
             "smtpport", as_var="VORTEX_SMTPPORT", default=smtplib.SMTP_PORT
         )
-        if not self.sh.default_target.isnetworknode:
-            sshobj = self.sh.ssh(
-                "network", virtualnode=True, mandatory_hostcheck=False
-            )
+
+        name = get_cluster_name(socket.gethostname())
+        #  If the current node is a compute node, it cannot reach the
+        #  smtp server.  In this case, the request is made through a
+        #  SSH tunnel on a login or transfer node
+        is_compute_node = re.match(
+            rf"{name}\d+\.{name}hpc\.meteo\.fr", socket.gethostname()
+        )
+
+        if is_compute_node:
+            sshobj = self.sh.ssh(hostname=f"{name}oper-int")
             with sshobj.tunnel(my_smtpserver, my_smtpport) as tun:
                 yield "localhost", tun.entranceport
         else:

--- a/src/vortex/tools/services.py
+++ b/src/vortex/tools/services.py
@@ -94,9 +94,7 @@ class Service(footprints.FootprintBase):
         if not value:
             value = self.env.get(as_var, None)
         if not value:
-            if as_conf is None:
-                as_conf = "services:" + key.lower()
-            value = self.sh.default_target.get(as_conf, default)
+            value = config.from_config(section="services", key=key)
         return value
 
     def __call__(self, *args):


### PR DESCRIPTION
The previous implicit configuration mechanics based on `Target` objects is still called when preparing SMTP requests in `tools/services.py`. This PR fixes:

- The call to `Target.get` when getting the value of the SMTP server address and port
- The call to `Target.isnetworknode` to decide whether or not to opening a SSH tunnel for the SMTP  request to go through