### PR TITLE
Add new names for arome-assistance geometries

### DIFF
--- a/src/vortex/data/geometries.ini
+++ b/src/vortex/data/geometries.ini
@@ -547,10 +547,24 @@ area       = assms1
 resolution = 2.50
 runit      = km
 
+[assm03sp]
+info       = AROME ASSM03 spectral geometry
+kind       = projected
+area       = assm03
+resolution = 2.50
+runit      = km
+
 [assms2sp]
 info       = AROME ASSMS2 spectral geometry
 kind       = projected
 area       = assms2
+resolution = 2.50
+runit      = km
+
+[assm04sp]
+info       = AROME ASSM04 spectral geometry
+kind       = projected
+area       = assm04
 resolution = 2.50
 runit      = km
 
@@ -561,10 +575,24 @@ area       = assmp1
 resolution = 2.50
 runit      = km
 
+[assm01sp]
+info       = AROME ASSM01 spectral geometry
+kind       = projected
+area       = assm01
+resolution = 2.50
+runit      = km
+
 [assmp2sp]
 info       = AROME ASSMP2 spectral geometry
 kind       = projected
 area       = assmp2
+resolution = 2.50
+runit      = km
+
+[assm02sp]
+info       = AROME ASSM02 spectral geometry
+kind       = projected
+area       = assm02
 resolution = 2.50
 runit      = km
 
@@ -1507,10 +1535,26 @@ resolution = 0.025
 nlat       = 0
 nlon       = 0
 
+[assm03]
+info       = Domaine Arome assm03
+kind       = lonlat
+area       = ASSM03
+resolution = 0.025
+nlat       = 0
+nlon       = 0
+
 [assms2]
 info       = Domaine Arome assms2
 kind       = lonlat
 area       = ASSMS2
+resolution = 0.025
+nlat       = 0
+nlon       = 0
+
+[assm04]
+info       = Domaine Arome assm04
+kind       = lonlat
+area       = ASSM04
 resolution = 0.025
 nlat       = 0
 nlon       = 0
@@ -1523,10 +1567,26 @@ resolution = 0.025
 nlat       = 0
 nlon       = 0
 
+[assm01]
+info       = Domaine Arome assm01
+kind       = lonlat
+area       = ASSM01
+resolution = 0.025
+nlat       = 0
+nlon       = 0
+
 [assmp2]
 info       = Domaine Arome assmp2
 kind       = lonlat
 area       = ASSMP2
+resolution = 0.025
+nlat       = 0
+nlon       = 0
+
+[assm02]
+info       = Domaine Arome assm02
+kind       = lonlat
+area       = ASSM02
 resolution = 0.025
 nlat       = 0
 nlon       = 0


### PR DESCRIPTION
The arome-assistance configurations assmp1, assmp2, assms1 and assms2 have been renamed into assm01, assm02, assm03, and assm04, along with their geometries. The new generic geometry names need to be listed in the geometries.ini configuration file. 