### PR TITLE
Remove '_std_rawftput' for FA files 

### DIFF
--- a/src/vortex/tools/lfi.py
+++ b/src/vortex/tools/lfi.py
@@ -366,57 +366,7 @@ class LFI_Tool_Raw(addons.FtrawEnableAddon):
                 sync=sync,
             )
 
-    def _std_rawftput(
-        self,
-        source,
-        destination,
-        hostname=None,
-        logname=None,
-        port=None,
-        cpipeline=None,
-        sync=False,
-    ):
-        """Use ftserv as much as possible."""
-        if self.is_xlfi(source):
-            if cpipeline is not None:
-                raise OSError("It's not allowed to compress xlfi files.")
-            if self.sh.ftraw and self.rawftshell is not None:
-                newsource = self.sh.copy2ftspool(source, fmt="lfi")
-                rc = self.sh.ftserv_put(
-                    newsource,
-                    destination,
-                    hostname=hostname,
-                    logname=logname,
-                    port=port,
-                    specialshell=self.rawftshell,
-                    sync=sync,
-                )
-                self.sh.rm(newsource)  # Delete the request file
-                return rc
-            else:
-                if port is None:
-                    port = DEFAULT_FTP_PORT
-                return self._std_ftput(
-                    source,
-                    destination,
-                    hostname,
-                    logname,
-                    port=port,
-                    sync=sync,
-                )
-        else:
-            return self.sh.rawftput(
-                source,
-                destination,
-                hostname=hostname,
-                logname=logname,
-                port=port,
-                cpipeline=cpipeline,
-                sync=sync,
-            )
-
     fa_ftput = lfi_ftput = _std_ftput
-    fa_rawftput = lfi_rawftput = _std_rawftput
 
     def _std_prepare(self, source, destination, intent="in"):
         """Check for the source and prepare the destination."""
@@ -951,3 +901,4 @@ class IO_Poll(addons.Addon):
     def polled(self):
         """List of files already polled."""
         return sorted(self._polled)
+

--- a/src/vortex/tools/lfi.py
+++ b/src/vortex/tools/lfi.py
@@ -901,4 +901,3 @@ class IO_Poll(addons.Addon):
     def polled(self):
         """List of files already polled."""
         return sorted(self._polled)
-

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -3394,7 +3394,7 @@ class OSExtended(System):
         hostname = self.fix_fthostname(hostname, fatal=False)
         logname = self.fix_ftuser(hostname, logname)
         for method in self.ftp_methods:
-            if method.put_condition(cpipeline=cpipeline):
+            if method.put_condition(source=source, cpipeline=cpipeline):
                 return method.put(
                     source,
                     destination,

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -6,6 +6,9 @@ from vortex.tools.net import DEFAULT_FTP_PORT
 import vortex
 from vortex.tools.lfi import use_in_shell
 
+import pytest
+
+
 SOURCE = "/path/to/data"
 DESTINATION = "/path/to/destination"
 HOSTNAME = "hendrix.meteo.fr"
@@ -198,10 +201,10 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
         sync=False,
     )
 
-# fa_ftput is called when fmt='fa'
+
+# With fmt="fa", @fmtshcmd dispatches the ftput call to fa_ftput.
 @patch("vortex.tools.lfi.LFI_Tool_Raw.fa_ftput")
-def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
-    
+def test_smartftput_fa(mocked_fa_ftput):
     ticket = vortex.ticket()
 
     # Extend the shell with the LFI interface.
@@ -213,9 +216,9 @@ def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
         hostname=HOSTNAME,
         logname=LOGNAME,
         port=DEFAULT_FTP_PORT,
-        fmt='fa',
+        fmt="fa",  # triggers the call to fa_ftput
     )
-    
+
     mocked_fa_ftput.assert_called_once_with(
         SOURCE,
         DESTINATION,
@@ -225,3 +228,32 @@ def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
         cpipeline=None,
         sync=False,
     )
+
+
+# Check that XLFI files are detected by fa_ftput.
+def test_smartftput_fa_xlfi(tmp_path):
+    source = tmp_path / "source.fa"
+    source.write_bytes(b"LFI_ALTM")
+    source = str(source)
+
+    ticket = vortex.ticket()
+
+    use_in_shell(sh=ticket.sh, kind="lfi")
+
+    assert ticket.sh.is_xlfi(source)
+
+    cpipeline = object()  # not None, to stop before the FTP transfer.
+
+    with pytest.raises(
+        OSError,
+        match="It's not allowed to compress xlfi files.",
+    ):
+        ticket.sh.smartftput(
+            source,
+            DESTINATION,
+            hostname=HOSTNAME,
+            logname=LOGNAME,
+            port=DEFAULT_FTP_PORT,
+            fmt="fa",
+            cpipeline=cpipeline,
+        )

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -3,15 +3,16 @@ from unittest.mock import Mock, patch
 from vortex.tools.systems import Linux34p
 from vortex.tools.net import DEFAULT_FTP_PORT
 
+
 SOURCE = "/path/to/data"
 DESTINATION = "/path/to/destination"
 HOSTNAME = "hendrix.meteo.fr"
 LOGNAME = "username"
 
+
 # smartftget -> default method.
 @patch("vortex.tools.systems.OSExtended.ftget")
 def test_smartftget(mocked_ftget):
-    
     system = Linux34p()
 
     system.smartftget(
@@ -35,7 +36,6 @@ def test_smartftget(mocked_ftget):
 # smartftput -> default method.
 @patch("vortex.tools.systems.OSExtended.ftput")
 def test_smartftput(mocked_ftput):
-    
     system = Linux34p()
 
     system.smartftput(
@@ -65,11 +65,12 @@ def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
     mocked_rawftput = Mock()
 
     system = Linux34p()
-    system.register_ftp_method(mocked_rawftget,
-                               mocked_rawftput, 
-                               lambda cpipeline=None: True,
-                               lambda cpipeline=None: True,
-                               )
+    system.register_ftp_method(
+        mocked_rawftget,
+        mocked_rawftput,
+        lambda cpipeline=None: True,
+        lambda cpipeline=None, source=SOURCE: True,
+    )
     system.smartftget(
         SOURCE,
         DESTINATION,
@@ -95,13 +96,14 @@ def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
 def test_smartftput_uses_new_method_when_putcond_is_true(mocked_ftput):
     mocked_rawftget = Mock()
     mocked_rawftput = Mock()
-    
+
     system = Linux34p()
-    system.register_ftp_method(mocked_rawftget,
-                               mocked_rawftput,
-                               lambda cpipeline=None: True,
-                               lambda cpipeline=None: True,
-                               )
+    system.register_ftp_method(
+        mocked_rawftget,
+        mocked_rawftput,
+        lambda cpipeline=None: True,
+        lambda cpipeline=None, source=SOURCE: True,
+    )
 
     system.smartftput(
         SOURCE,
@@ -132,11 +134,12 @@ def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
     mocked_rawftput = Mock()
 
     system = Linux34p()
-    system.register_ftp_method(mocked_rawftget,
-                               mocked_rawftput,
-                               lambda cpipeline=None: False,
-                               lambda cpipeline=None: False,
-                               )
+    system.register_ftp_method(
+        mocked_rawftget,
+        mocked_rawftput,
+        lambda cpipeline=None: False,
+        lambda cpipeline=None, source=SOURCE: False,
+    )
 
     system.smartftget(
         SOURCE,
@@ -163,13 +166,14 @@ def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
 def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
     mocked_rawftget = Mock()
     mocked_rawftput = Mock()
-    
+
     system = Linux34p()
-    system.register_ftp_method(mocked_rawftget,
-                               mocked_rawftput,
-                               lambda cpipeline=None: False,
-                               lambda cpipeline=None: False,
-                               )
+    system.register_ftp_method(
+        mocked_rawftget,
+        mocked_rawftput,
+        lambda cpipeline=None: False,
+        lambda cpipeline=None, source=SOURCE: False,
+    )
 
     system.smartftput(
         SOURCE,

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -68,10 +68,10 @@ def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
 
     system = Linux34p()
     system.register_ftp_method(
-        mocked_rawftget,
-        mocked_rawftput,
-        lambda cpipeline=None: True,
-        lambda cpipeline=None, source=SOURCE: True,
+        getfunc=mocked_rawftget,
+        putfunc=mocked_rawftput,
+        getcond=lambda cpipeline=None: True,
+        putcond=lambda cpipeline=None, source=SOURCE: True,
     )
     system.smartftget(
         SOURCE,
@@ -101,10 +101,10 @@ def test_smartftput_uses_new_method_when_putcond_is_true(mocked_ftput):
 
     system = Linux34p()
     system.register_ftp_method(
-        mocked_rawftget,
-        mocked_rawftput,
-        lambda cpipeline=None: True,
-        lambda cpipeline=None, source=SOURCE: True,
+        getfunc=mocked_rawftget,
+        putfunc=mocked_rawftput,
+        getcond=lambda cpipeline=None: True,
+        putcond=lambda cpipeline=None, source=SOURCE: True,
     )
 
     system.smartftput(
@@ -137,10 +137,10 @@ def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
 
     system = Linux34p()
     system.register_ftp_method(
-        mocked_rawftget,
-        mocked_rawftput,
-        lambda cpipeline=None: False,
-        lambda cpipeline=None, source=SOURCE: False,
+        getfunc=mocked_rawftget,
+        putfunc=mocked_rawftput,
+        getcond=lambda cpipeline=None: False,
+        putcond=lambda cpipeline=None, source=SOURCE: False,
     )
 
     system.smartftget(
@@ -171,10 +171,10 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
 
     system = Linux34p()
     system.register_ftp_method(
-        mocked_rawftget,
-        mocked_rawftput,
-        lambda cpipeline=None: False,
-        lambda cpipeline=None, source=SOURCE: False,
+        getfunc=mocked_rawftget,
+        putfunc=mocked_rawftput,
+        getcond=lambda cpipeline=None: False,
+        putcond=lambda cpipeline=None, source=SOURCE: False,
     )
 
     system.smartftput(
@@ -198,10 +198,10 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
         sync=False,
     )
 
+
 # fa_ftput is called when fmt='fa'
 @patch("vortex.tools.lfi.LFI_Tool_Raw.fa_ftput")
 def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
-    
     ticket = vortex.ticket()
 
     # Extend the shell with the LFI interface.
@@ -213,9 +213,9 @@ def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
         hostname=HOSTNAME,
         logname=LOGNAME,
         port=DEFAULT_FTP_PORT,
-        fmt='fa',
+        fmt="fa", # triggers the call to fa_ftput
     )
-    
+
     mocked_fa_ftput.assert_called_once_with(
         SOURCE,
         DESTINATION,

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -63,13 +63,13 @@ def test_smartftput(mocked_ftput):
 # smartftget -> new method if getcond=True.
 @patch("vortex.tools.systems.OSExtended.ftget")
 def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
-    mocked_rawftget = Mock()
-    mocked_rawftput = Mock()
+    mocked_other_ftget = Mock()
+    mocked_other_ftput = Mock()
 
     system = Linux34p()
     system.register_ftp_method(
-        getfunc=mocked_rawftget,
-        putfunc=mocked_rawftput,
+        getfunc=mocked_other_ftget,
+        putfunc=mocked_other_ftput,
         getcond=lambda cpipeline=None: True,
         putcond=lambda cpipeline=None, source=SOURCE: True,
     )
@@ -83,7 +83,7 @@ def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
 
     mocked_ftget.assert_not_called()
 
-    mocked_rawftget.assert_called_once_with(
+    mocked_other_ftget.assert_called_once_with(
         SOURCE,
         DESTINATION,
         hostname=HOSTNAME,
@@ -96,13 +96,13 @@ def test_smartftget_uses_new_method_when_getcond_is_true(mocked_ftget):
 # smartftput -> new method if putcond=True.
 @patch("vortex.tools.systems.OSExtended.ftput")
 def test_smartftput_uses_new_method_when_putcond_is_true(mocked_ftput):
-    mocked_rawftget = Mock()
-    mocked_rawftput = Mock()
+    mocked_other_ftget = Mock()
+    mocked_other_ftput = Mock()
 
     system = Linux34p()
     system.register_ftp_method(
-        getfunc=mocked_rawftget,
-        putfunc=mocked_rawftput,
+        getfunc=mocked_other_ftget,
+        putfunc=mocked_other_ftput,
         getcond=lambda cpipeline=None: True,
         putcond=lambda cpipeline=None, source=SOURCE: True,
     )
@@ -117,7 +117,7 @@ def test_smartftput_uses_new_method_when_putcond_is_true(mocked_ftput):
 
     mocked_ftput.assert_not_called()
 
-    mocked_rawftput.assert_called_once_with(
+    mocked_other_ftput.assert_called_once_with(
         SOURCE,
         DESTINATION,
         hostname=HOSTNAME,
@@ -132,13 +132,13 @@ def test_smartftput_uses_new_method_when_putcond_is_true(mocked_ftput):
 # smartftget -> fallback to the default method if getcond=False.
 @patch("vortex.tools.systems.OSExtended.ftget")
 def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
-    mocked_rawftget = Mock()
-    mocked_rawftput = Mock()
+    mocked_other_ftget = Mock()
+    mocked_other_ftput = Mock()
 
     system = Linux34p()
     system.register_ftp_method(
-        getfunc=mocked_rawftget,
-        putfunc=mocked_rawftput,
+        getfunc=mocked_other_ftget,
+        putfunc=mocked_other_ftput,
         getcond=lambda cpipeline=None: False,
         putcond=lambda cpipeline=None, source=SOURCE: False,
     )
@@ -151,7 +151,7 @@ def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
         port=DEFAULT_FTP_PORT,
     )
 
-    mocked_rawftget.assert_not_called()
+    mocked_other_ftget.assert_not_called()
 
     mocked_ftget.assert_called_once_with(
         SOURCE,
@@ -166,13 +166,13 @@ def test_smartftget_uses_default_method_when_getcond_is_false(mocked_ftget):
 # smartftput -> fallback to the default method if putcond=False.
 @patch("vortex.tools.systems.OSExtended.ftput")
 def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
-    mocked_rawftget = Mock()
-    mocked_rawftput = Mock()
+    mocked_other_ftget = Mock()
+    mocked_other_ftput = Mock()
 
     system = Linux34p()
     system.register_ftp_method(
-        getfunc=mocked_rawftget,
-        putfunc=mocked_rawftput,
+        getfunc=mocked_other_ftget,
+        putfunc=mocked_other_ftput,
         getcond=lambda cpipeline=None: False,
         putcond=lambda cpipeline=None, source=SOURCE: False,
     )
@@ -185,7 +185,7 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
         port=DEFAULT_FTP_PORT,
     )
 
-    mocked_rawftput.assert_not_called()
+    mocked_other_ftput.assert_not_called()
 
     mocked_ftput.assert_called_once_with(
         SOURCE,

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock, patch
 from vortex.tools.systems import Linux34p
 from vortex.tools.net import DEFAULT_FTP_PORT
 
+import vortex
+from vortex.tools.lfi import use_in_shell
 
 SOURCE = "/path/to/data"
 DESTINATION = "/path/to/destination"
@@ -192,6 +194,34 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
         logname=LOGNAME,
         port=DEFAULT_FTP_PORT,
         fmt=None,
+        cpipeline=None,
+        sync=False,
+    )
+
+# fa_ftput is called when fmt='fa'
+@patch("vortex.tools.lfi.LFI_Tool_Raw.fa_ftput")
+def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
+    
+    ticket = vortex.ticket()
+
+    # Extend the shell with the LFI interface.
+    use_in_shell(sh=ticket.sh, kind="lfi")
+
+    ticket.sh.smartftput(
+        SOURCE,
+        DESTINATION,
+        hostname=HOSTNAME,
+        logname=LOGNAME,
+        port=DEFAULT_FTP_PORT,
+        fmt='fa',
+    )
+    
+    mocked_fa_ftput.assert_called_once_with(
+        SOURCE,
+        DESTINATION,
+        hostname=HOSTNAME,
+        logname=LOGNAME,
+        port=DEFAULT_FTP_PORT,
         cpipeline=None,
         sync=False,
     )

--- a/tests/test_smartftget_smartftput.py
+++ b/tests/test_smartftget_smartftput.py
@@ -6,9 +6,6 @@ from vortex.tools.net import DEFAULT_FTP_PORT
 import vortex
 from vortex.tools.lfi import use_in_shell
 
-import pytest
-
-
 SOURCE = "/path/to/data"
 DESTINATION = "/path/to/destination"
 HOSTNAME = "hendrix.meteo.fr"
@@ -201,10 +198,10 @@ def test_smartftput_uses_default_method_when_putcond_is_false(mocked_ftput):
         sync=False,
     )
 
-
-# With fmt="fa", @fmtshcmd dispatches the ftput call to fa_ftput.
+# fa_ftput is called when fmt='fa'
 @patch("vortex.tools.lfi.LFI_Tool_Raw.fa_ftput")
-def test_smartftput_fa(mocked_fa_ftput):
+def test_smartftput_uses_fa_ftput(mocked_fa_ftput):
+    
     ticket = vortex.ticket()
 
     # Extend the shell with the LFI interface.
@@ -216,9 +213,9 @@ def test_smartftput_fa(mocked_fa_ftput):
         hostname=HOSTNAME,
         logname=LOGNAME,
         port=DEFAULT_FTP_PORT,
-        fmt="fa",  # triggers the call to fa_ftput
+        fmt='fa',
     )
-
+    
     mocked_fa_ftput.assert_called_once_with(
         SOURCE,
         DESTINATION,
@@ -228,32 +225,3 @@ def test_smartftput_fa(mocked_fa_ftput):
         cpipeline=None,
         sync=False,
     )
-
-
-# Check that XLFI files are detected by fa_ftput.
-def test_smartftput_fa_xlfi(tmp_path):
-    source = tmp_path / "source.fa"
-    source.write_bytes(b"LFI_ALTM")
-    source = str(source)
-
-    ticket = vortex.ticket()
-
-    use_in_shell(sh=ticket.sh, kind="lfi")
-
-    assert ticket.sh.is_xlfi(source)
-
-    cpipeline = object()  # not None, to stop before the FTP transfer.
-
-    with pytest.raises(
-        OSError,
-        match="It's not allowed to compress xlfi files.",
-    ):
-        ticket.sh.smartftput(
-            source,
-            DESTINATION,
-            hostname=HOSTNAME,
-            logname=LOGNAME,
-            port=DEFAULT_FTP_PORT,
-            fmt="fa",
-            cpipeline=cpipeline,
-        )


### PR DESCRIPTION
Remove `_std_rawftput` (this function has been moved to the FTSERV plugin).

Add the `source` argument to `method.put_condition`. This is required by the plugin to check wether the source is a split (XLFI) file.