### PR TITLE
Add function to merge configuration

### DIFF
--- a/src/vortex/config.py
+++ b/src/vortex/config.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 VORTEX_CONFIG = {}
-_PATH = None
+_PATH = []
 
 logger = loggers.getLogger(__name__)
 
@@ -31,8 +31,9 @@ class ConfigurationError(Exception):
 def load_config(configpath=Path("vortex.toml")):
     """Load configuration from a TOML configuration file
 
-    Existing configuration values are overriden. The configuration
-    is expected to have valid TOML syntax, e.g.
+    Existing configuration values are overriden. Current configuration
+    keys not present in the loaded configuration are discarded. The
+    configuration is expected to have valid TOML syntax, e.g.
 
     .. code:: toml
 
@@ -50,7 +51,27 @@ def load_config(configpath=Path("vortex.toml")):
     try:
         with configpath.open(mode="rb") as f:
             VORTEX_CONFIG = tomli.load(f)
-            _PATH = configpath.absolute()
+            _PATH.append(configpath.absolute())
+    except FileNotFoundError:
+        print(
+            f"Could not read configuration file {configpath.absolute()} (not found)."
+        )
+        print("Use load_config(/path/to/config) to update the configuration")
+
+
+def merge_config(configpath=Path("vortex.toml")):
+    """Merge TOML configuration file with current configuration
+
+    Similar to `load_config` except existing configuration keys are
+    not discarded. Existing configuration values are overriden.
+    """
+    global VORTEX_CONFIG
+    global _PATH
+    configpath = Path(configpath)
+    try:
+        with configpath.open(mode="rb") as f:
+            VORTEX_CONFIG |= tomli.load(f)
+            _PATH.append(configpath.absolute())
     except FileNotFoundError:
         print(
             f"Could not read configuration file {configpath.absolute()} (not found)."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ def clean_config():
     saved_cfg = config.VORTEX_CONFIG.copy()
     saved_path = config._PATH
     config.VORTEX_CONFIG = {}
-    config._PATH = None
+    config._PATH = []
     yield
     config.VORTEX_CONFIG = saved_cfg
     config._PATH = saved_path
@@ -90,7 +90,7 @@ def test_load_config_populates_config(clean_config, toml_config_file):
 def test_load_config_sets_file_property(clean_config, toml_config_file):
     config.load_config(toml_config_file)
 
-    assert config.file == toml_config_file.absolute()
+    assert config.file == [toml_config_file.absolute()]
 
 
 def test_load_config_overrides_existing(clean_config, tmp_path):
@@ -112,3 +112,22 @@ def test_load_config_file_not_found(clean_config, tmp_path, capsys):
     captured = capsys.readouterr()
     assert "not found" in captured.out
     assert config.VORTEX_CONFIG == {}
+
+
+def test_merge_config(clean_config, tmp_path):
+    first = tmp_path / "first.toml"
+    first.write_text("""[section-a]
+key = \"value-a\"
+otherkey = \"value-b\"
+""")
+    second = tmp_path / "second.toml"
+    second.write_text('[section-b]\nkey = "value-b"\n')
+
+    config.load_config(first)
+    config.merge_config(second)
+
+    assert "section-a" in config.VORTEX_CONFIG
+    assert config.VORTEX_CONFIG == {
+        "section-a": {"key": "value-a", "otherkey": "value-b"},
+        "section-b": {"key": "value-b"},
+    }


### PR DESCRIPTION
Adds `config.merge_config`. 

This allows to have a default config in `.vortex.d` and load additional configuration keys or override from another file.