### PR TITLE
Remove 'source' from the FTP put condition

### DIFF
--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -3394,7 +3394,7 @@ class OSExtended(System):
         hostname = self.fix_fthostname(hostname, fatal=False)
         logname = self.fix_ftuser(hostname, logname)
         for method in self.ftp_methods:
-            if method.put_condition(source=source, cpipeline=cpipeline):
+            if method.put_condition(cpipeline=cpipeline):
                 return method.put(
                     source,
                     destination,


### PR DESCRIPTION
It should be possible to register an external "put" method regardless of the source file being transferred.

According to the current logic, the default "put" method must be used when:

- `cpipeline` is not None
- `cpipeline.compress2rawftp(source)` returns None.

However, `compress2rawftp()` does not actually use its input argument.
https://github.com/UMR-CNRM/vortex/blob/d02877bb25beded7b194032207f37f2afd6a8fe8/src/vortex/tools/compression.py#L175-L180

As a consequence, `method.put_condition()` only need `cpipeline` (and `source` can be replaced by any str value in the "put_condition" function).