### PR TITLE
Use batch get functions via FtpMethod

### DIFF
--- a/src/vortex/tools/delayedactions.py
+++ b/src/vortex/tools/delayedactions.py
@@ -521,10 +521,10 @@ class AbstractFtpArchiveDelayedGetHandler(
         return hostname, port
 
 
-class RawFtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
+class FtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
     """
-    When FtServ is used, accumulate "GET" requests for several files and fetch
-    them during a unique ``ftget`` system call.
+    Accumulate "GET" requests for several files and fetch them using the batch
+    get function provided by the selected FTP method.
 
     :note: The *request* needs to be a two-elements tuple where the first element
            is the path to the file that shoudl be fetched and the second element
@@ -534,7 +534,7 @@ class RawFtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
     """
 
     _footprint = dict(
-        info="Fetch multiple files using FtServ.",
+        info="Fetch multiple files.",
         attr=dict(
             raw=dict(
                 optional=False,
@@ -553,7 +553,8 @@ class RawFtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
                 a_fmt = (
                     v.request[1]
                     if self.system.fmtspecific_mtd(
-                        "batchrawftget", v.request[1]
+                        self.system.ftp_methods[0].get_batch.__name__,
+                        v.request[1],
                     )
                     else None
                 )
@@ -571,7 +572,7 @@ class RawFtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
                     destinations.append(self._resultsmap[k].result)
                 try:
                     logger.info(
-                        "Running the ftserv command for format=%s.", str(a_fmt)
+                        "Running the batch command for format=%s.", str(a_fmt)
                     )
                     hostname, port = self._ftp_hostinfos
                     rc = self.system.ftp_methods[0].get_batch(

--- a/src/vortex/tools/delayedactions.py
+++ b/src/vortex/tools/delayedactions.py
@@ -574,7 +574,7 @@ class RawFtpDelayedGetHandler(AbstractFtpArchiveDelayedGetHandler):
                         "Running the ftserv command for format=%s.", str(a_fmt)
                     )
                     hostname, port = self._ftp_hostinfos
-                    rc = self.system.batchrawftget(
+                    rc = self.system.ftp_methods[0].get_batch(
                         sources,
                         destinations,
                         hostname=hostname,

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -761,8 +761,7 @@ class Archive(AbstractArchive):
 
     def _ftpearlyretrieve(self, item, local, **kwargs):
         """
-        If FtServ/ftraw is used, trigger a delayed action in order to fetch
-        several files at once.
+        Trigger a delayed action in order to fetch several files at once.
         """
         cpipeline = kwargs.get("compressionpipeline", None)
         if self.sh.ftp_methods[0].get_batch_condition(cpipeline):

--- a/src/vortex/tools/storage.py
+++ b/src/vortex/tools/storage.py
@@ -765,7 +765,7 @@ class Archive(AbstractArchive):
         several files at once.
         """
         cpipeline = kwargs.get("compressionpipeline", None)
-        if self.sh.rawftget_worthy(item, local, cpipeline):
+        if self.sh.ftp_methods[0].get_batch_condition(cpipeline):
             return self.context.delayedactions_hub.register(
                 (item, kwargs.get("fmt", "foo")),
                 kind="archive",

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -107,7 +107,7 @@ FTP_FLAVOUR = FtpFlavourTuple(STD=0, RETRIES=1, CONNECTION_POOLS=2)
 
 # Bundles the get, put callables and booleans that indicate whether each operation is usable.
 FtpMethod = namedtuple(
-    "FtpMethod", ["get", "put", "get_condition", "put_condition"]
+    "FtpMethod", ["get", "get_batch", "put", "get_condition", "get_batch_condition", "put_condition"]
 )
 
 
@@ -820,9 +820,11 @@ class OSExtended(System):
         self.ftp_methods = [
             FtpMethod(
                 get=self.ftget,
+                get_batch=lambda *args, **kwargs: None,
                 put=self.ftput,
-                put_condition=lambda *args, **kwargs: True,
                 get_condition=lambda *args, **kwargs: True,
+                get_batch_condition=lambda *args, **kwargs: False,
+                put_condition=lambda *args, **kwargs: True,
             )
         ]
         # Some internal variables used by particular methods
@@ -3351,7 +3353,7 @@ class OSExtended(System):
         ldir = self._appwide_lockdir_path(label)
         self._lockdir_destroy(ldir)
 
-    def register_ftp_method(self, getfunc, putfunc, getcond, putcond):
+    def register_ftp_method(self, getfunc, putfunc, getfunc_batch, getcond, putcond, getcond_batch):
         """Register a new FTP method.
 
         The method creates a :class:`~FtpMethod` instance from the supplied
@@ -3359,7 +3361,13 @@ class OSExtended(System):
         Because the list is traversed from left‑to‑right when looking up a
         FTP method, the newly‑registered method gets the highest priority."""
         self.ftp_methods.insert(
-            0, FtpMethod(getfunc, putfunc, getcond, putcond)
+            0, FtpMethod(get=getfunc,
+                         get_batch=getfunc_batch,
+                         put=putfunc,
+                         get_condition=getcond,
+                         put_condition=putcond,
+                         get_batch_condition=getcond_batch,
+                         )
         )
 
     def smartftput(

--- a/src/vortex/tools/systems.py
+++ b/src/vortex/tools/systems.py
@@ -107,7 +107,15 @@ FTP_FLAVOUR = FtpFlavourTuple(STD=0, RETRIES=1, CONNECTION_POOLS=2)
 
 # Bundles the get, put callables and booleans that indicate whether each operation is usable.
 FtpMethod = namedtuple(
-    "FtpMethod", ["get", "get_batch", "put", "get_condition", "get_batch_condition", "put_condition"]
+    "FtpMethod",
+    [
+        "get",
+        "get_batch",
+        "put",
+        "get_condition",
+        "get_batch_condition",
+        "put_condition",
+    ],
 )
 
 
@@ -3353,7 +3361,9 @@ class OSExtended(System):
         ldir = self._appwide_lockdir_path(label)
         self._lockdir_destroy(ldir)
 
-    def register_ftp_method(self, getfunc, putfunc, getfunc_batch, getcond, putcond, getcond_batch):
+    def register_ftp_method(
+        self, getfunc, putfunc, getfunc_batch, getcond, putcond, getcond_batch
+    ):
         """Register a new FTP method.
 
         The method creates a :class:`~FtpMethod` instance from the supplied
@@ -3361,13 +3371,15 @@ class OSExtended(System):
         Because the list is traversed from left‑to‑right when looking up a
         FTP method, the newly‑registered method gets the highest priority."""
         self.ftp_methods.insert(
-            0, FtpMethod(get=getfunc,
-                         get_batch=getfunc_batch,
-                         put=putfunc,
-                         get_condition=getcond,
-                         put_condition=putcond,
-                         get_batch_condition=getcond_batch,
-                         )
+            0,
+            FtpMethod(
+                get=getfunc,
+                get_batch=getfunc_batch,
+                put=putfunc,
+                get_condition=getcond,
+                put_condition=putcond,
+                get_batch_condition=getcond_batch,
+            ),
         )
 
     def smartftput(


### PR DESCRIPTION
`batchrawftget` has already been removed (7cbb8fac334a262b7b4c3c5902783b7b8112e29d)

To transfer several files at once, an external plugin can now provide this functionality through `register_ftp_method()`.

As no batch function is implemented by default, `get_batch_condition` is set to False.